### PR TITLE
Use an out-of-tree unsafe-any trait instead of a home-grown version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,12 @@ git = "https://github.com/servo/rust-url"
 [dependencies.mime]
 git = "https://github.com/seanmonstar/mime.rs"
 
+[dependencies.unsafe-any]
+git = "https://github.com/reem/rust-unsafe-any"
+
 [dev-dependencies.curl]
 git = "https://github.com/carllerche/curl-rust"
 
 [dev-dependencies.http]
 git = "https://github.com/chris-morgan/rust-http"
+

--- a/src/header.rs
+++ b/src/header.rs
@@ -23,6 +23,7 @@ use std::collections::hashmap::{HashMap, Entries};
 
 use mime::Mime;
 use time::{Tm, strptime};
+use uany::UncheckedAnyDowncast;
 
 use rfc7230::read_header;
 use {HttpResult};
@@ -46,15 +47,7 @@ pub trait Header: Any + 'static {
     fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result;
 }
 
-/// A trait for downcasting owned TraitObjects to another type without checking
-/// `AnyRefExt::is::<T>(t)` first.
-trait UncheckedAnyRefExt<'a> {
-    /// This will downcast an object to another type without checking that it is
-    /// legal. Do not call this unless you are ABSOLUTE SURE of the types.
-    unsafe fn downcast_ref_unchecked<T: 'static>(self) -> &'a T;
-}
-
-impl<'a> UncheckedAnyRefExt<'a> for &'a Header + 'a {
+impl<'a> UncheckedAnyDowncast<'a> for &'a Header + 'a {
     #[inline]
     unsafe fn downcast_ref_unchecked<T: 'static>(self) -> &'a T {
         let to: TraitObject = transmute_copy(&self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate time;
 extern crate url;
 #[phase(plugin,link)] extern crate log;
 #[cfg(test)] extern crate test;
+extern crate "unsafe-any" as uany;
 
 pub use std::io::net::ip::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr, Port};
 pub use mimewrapper::mime;


### PR DESCRIPTION
This has the advantage of being separately checked, tested
and documented.
