### PR TITLE
Add a get_raw method, which allows users to access the raw value of a header

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -127,6 +127,27 @@ impl Headers {
         self.get_ref().map(|v: &H| v.clone())
     }
 
+    /// Access the raw value of a header, if it exists and has not
+    /// been already parsed.
+    ///
+    /// If the header field has already been parsed into a typed header,
+    /// then you *must* access it through that representation.
+    ///
+    /// Example:
+    /// ```
+    /// # use hyper::header::{Headers, ContentType};
+    /// # let mut headers = Headers::new();
+    /// let raw_content_type = unsafe { headers.get_raw("content-type") };
+    /// ```
+    pub unsafe fn get_raw(&self, name: &'static str) -> Option<&[Vec<u8>]> {
+        self.data.find(&name).and_then(|item| {
+            match *item {
+                Raw(ref raw) => Some(raw.as_slice()),
+                _ => None
+            }
+        })
+    }
+
     /// Get a reference to the header field's value, if it exists.
     pub fn get_ref<H: Header>(&mut self) -> Option<&H> {
         self.data.find_mut(&header_name::<H>()).and_then(|item| {


### PR DESCRIPTION
This method is marked unsafe, as it should not be used in normal code
because it can easily invalidate header representations.

Fixes #10

We might want to _not_ mark this method unsafe, but that's mostly a matter
of convention. What are your thoughts on this?
