### PR TITLE
Provide Response::<Fresh>::deconstruct to deconstruct a Response.

### DIFF
--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -44,6 +44,19 @@ impl<W: WriteStatus> Response<W> {
 
     /// The headers of this response.
     pub fn headers(&self) -> &header::Headers { &self.headers }
+
+    /// Construct a Response from its constituent parts.
+    pub fn construct(version: version::HttpVersion,
+                     body: BufferedWriter<TcpStream>,
+                     status: status::StatusCode,
+                     headers: header::Headers) -> Response<Fresh> {
+        Response {
+            status: status,
+            version: version,
+            body: body,
+            headers: headers
+        }
+    }
 }
 
 impl Response<Fresh> {
@@ -89,6 +102,11 @@ impl Response<Fresh> {
 
     /// Get a mutable reference to the Headers.
     pub fn headers_mut(&mut self) -> &mut header::Headers { &mut self.headers }
+
+    /// Deconstruct this Response into its constituent parts.
+    pub fn deconstruct(self) -> (version::HttpVersion, BufferedWriter<TcpStream>, status::StatusCode, header::Headers) {
+        (self.version, self.body, self.status, self.headers)
+    }
 }
 
 impl Response<Streaming> {


### PR DESCRIPTION
This allows downstream frameworks by-value access to these fields, letting
them create their own Response abstractions out of hyper's Response.

This is, for instance, needed in Iron to create Iron's Response object, as it
will have to move the Headers out, later putting them back and writing to the
Response.

Requires #19 and will be rebased when/if it is merged.
