### PR TITLE
Parse Transfer Encodings that we don't handle

### DIFF
--- a/src/header/common/transfer_encoding.rs
+++ b/src/header/common/transfer_encoding.rs
@@ -48,7 +48,10 @@ impl FromStr for Encoding {
     fn from_str(s: &str) -> Option<Encoding> {
         match s {
             "chunked" => Some(Chunked),
-            _ => None
+            "deflate" => Some(Deflate),
+            "gzip" => Some(Gzip),
+            "compress" => Some(Compress),
+            _ => Some(EncodingExt(s.to_string()))
         }
     }
 }


### PR DESCRIPTION
We should not throw away information here, as downstream users
may want to handle alternative encodings.
