### PR TITLE
Rename rfc7230 to http to more clearly indicate its purpose.

### DIFF
--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -7,7 +7,7 @@ use method;
 use header::Headers;
 use header::common::Host;
 use net::{NetworkStream, HttpStream};
-use rfc7230::LINE_ENDING;
+use http::LINE_ENDING;
 use version;
 use {HttpResult, HttpUriError};
 use super::{Response};

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -5,7 +5,7 @@ use header;
 use header::common::{ContentLength, TransferEncoding};
 use header::common::transfer_encoding::Chunked;
 use net::{NetworkStream, HttpStream};
-use rfc7230::{read_status_line, HttpReader, SizedReader, ChunkedReader, EofReader};
+use http::{read_status_line, HttpReader, SizedReader, ChunkedReader, EofReader};
 use status;
 use version;
 use {HttpResult};

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -15,7 +15,7 @@ use std::collections::hashmap::{HashMap, Entries};
 
 use uany::UncheckedAnyDowncast;
 
-use rfc7230::read_header;
+use http::read_header;
 use {HttpResult};
 
 /// Common Headers

--- a/src/http.rs
+++ b/src/http.rs
@@ -429,7 +429,7 @@ pub type RawHeaderLine = (Vec<u8>, Vec<u8>);
 
 /// Read a RawHeaderLine from a Reader.
 ///
-/// From [spec](https://tools.ietf.org/html/rfc7230#section-3.2):
+/// From [spec](https://tools.ietf.org/html/http#section-3.2):
 ///
 /// > Each header field consists of a case-insensitive field name followed
 /// > by a colon (":"), optional leading whitespace, the field value, and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub mod status;
 pub mod uri;
 pub mod version;
 
-mod rfc7230;
+mod http;
 
 mod mimewrapper {
     /// Re-exporting the mime crate, for convenience.

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -10,8 +10,8 @@ use version::{HttpVersion};
 use method;
 use header::Headers;
 use header::common::ContentLength;
-use rfc7230::{read_request_line};
-use rfc7230::{HttpReader, SizedReader, ChunkedReader};
+use http::{read_request_line};
+use http::{HttpReader, SizedReader, ChunkedReader};
 use net::NetworkStream;
 use uri::RequestUri;
 

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -8,7 +8,7 @@ use time::now_utc;
 
 use header;
 use header::common;
-use rfc7230::{CR, LF, LINE_ENDING};
+use http::{CR, LF, LINE_ENDING};
 use status;
 use net::NetworkStream;
 use version;
@@ -30,7 +30,7 @@ pub struct Response<W: WriteStatus> {
     /// The HTTP version of this response.
     pub version: version::HttpVersion,
     // Stream the Response is writing to, not accessible through UnwrittenResponse
-    body: BufferedWriter<Box<NetworkStream + Send>>, // TODO: use a HttpWriter from rfc7230
+    body: BufferedWriter<Box<NetworkStream + Send>>, // TODO: use a HttpWriter from http
     // The status code for the request.
     status: status::StatusCode,
     // The outgoing headers on this response.


### PR DESCRIPTION
The current name, IMO, is unnecessarily cryptic.
