### PR TITLE
use Fresh and Streaming markers for client Requests

### DIFF
--- a/benches/client.rs
+++ b/benches/client.rs
@@ -68,9 +68,10 @@ fn bench_hyper(b: &mut test::Bencher) {
     let url = s.as_slice();
     b.iter(|| {
         let mut req = hyper::get(hyper::Url::parse(url).unwrap()).unwrap();
-        req.headers.set(Foo);
+        req.headers_mut().set(Foo);
 
         req
+            .start().unwrap()
             .send().unwrap()
             .read_to_string().unwrap()
     });

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -14,7 +14,7 @@ static phrase: &'static [u8] = b"Benchmarking hyper vs others!";
 
 fn request(url: hyper::Url) {
     let req = hyper::get(url).unwrap();
-    req.send().unwrap().read_to_string().unwrap();
+    req.start().unwrap().send().unwrap().read_to_string().unwrap();
 }
 
 fn hyper_handle(mut incoming: hyper::server::Incoming) {

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -29,7 +29,7 @@ fn main() {
         Ok(req) => req,
         Err(err) => fail!("Failed to connect: {}", err)
     };
-    let mut res = req.send().unwrap();
+    let mut res = req.start().unwrap().send().unwrap();
     
     println!("Response: {}", res.status);
     println!("{}", res.headers);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -5,34 +5,34 @@ use method::{Get, Head, Post, Delete, Method};
 
 pub use self::request::Request;
 pub use self::response::Response;
+pub use net::{Fresh, Streaming};
 use {HttpResult};
 
 pub mod request;
 pub mod response;
 
-
 /// Create a GET client request.
-pub fn get(url: Url) -> HttpResult<Request> {
+pub fn get(url: Url) -> HttpResult<Request<Fresh>> {
     request(Get, url)
 }
 
 /// Create a HEAD client request.
-pub fn head(url: Url) -> HttpResult<Request> {
+pub fn head(url: Url) -> HttpResult<Request<Fresh>> {
     request(Head, url)
 }
 
 /// Create a POST client request.
-pub fn post(url: Url) -> HttpResult<Request> {
+pub fn post(url: Url) -> HttpResult<Request<Fresh>> {
     // TODO: should this accept a Body parameter? or just let user `write` to the request?
     request(Post, url)
 }
 
 /// Create a DELETE client request.
-pub fn delete(url: Url) -> HttpResult<Request> {
+pub fn delete(url: Url) -> HttpResult<Request<Fresh>> {
     request(Delete, url)
 }
 
 /// Create a client request.
-pub fn request(method: Method, url: Url) -> HttpResult<Request> {
+pub fn request(method: Method, url: Url) -> HttpResult<Request<Fresh>> {
     Request::new(method, url)
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -41,6 +41,18 @@ pub trait NetworkStream: Stream + Clone + Send {
     fn clone_box(&self) -> Box<NetworkStream + Send> { self.clone().abstract() }
 }
 
+/// Phantom type indicating Headers and StatusCode have not been written.
+pub struct Fresh;
+
+/// Phantom type indicating Headers and StatusCode have been written.
+pub struct Streaming;
+
+/// The status of a Request/Response, indicating if the headers and status have been written.
+pub trait WriteStatus {}
+
+impl WriteStatus for Streaming {}
+impl WriteStatus for Fresh {}
+
 impl Clone for Box<NetworkStream + Send> {
     #[inline]
     fn clone(&self) -> Box<NetworkStream + Send> { self.clone_box() }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,8 +3,8 @@ use std::io::{Acceptor, Listener, IoResult, EndOfFile, IncomingConnections};
 use std::io::net::ip::{IpAddr, Port, SocketAddr};
 
 pub use self::request::Request;
-pub use self::response::{Response, Fresh, Streaming};
-
+pub use self::response::Response;
+pub use net::{Fresh, Streaming};
 use net::{NetworkListener, NetworkAcceptor, NetworkStream, HttpAcceptor, HttpListener};
 
 pub mod request;

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -10,20 +10,9 @@ use header;
 use header::common;
 use http::{CR, LF, LINE_ENDING};
 use status;
-use net::NetworkStream;
+use net::{NetworkStream, WriteStatus, Fresh, Streaming};
 use version;
 
-/// Phantom type indicating Headers and StatusCode have not been written.
-pub struct Fresh;
-
-/// Phantom type indicating Headers and StatusCode have been written.
-pub struct Streaming;
-
-/// The status of a Response, indicating if the headers and status have been written.
-pub trait WriteStatus {}
-
-impl WriteStatus for Streaming {}
-impl WriteStatus for Fresh {}
 
 /// The outgoing half for a Tcp connection, created by a `Server` and given to a `Handler`.
 pub struct Response<W: WriteStatus> {


### PR DESCRIPTION
Again, moves checks from being dynamic to being caught by the compiler. `hyper::request()` can use a `RequestBuilder` to make things ergonomic.
