### PR TITLE
add bits to deal with Upgrade requests

### DIFF
--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -65,11 +65,46 @@ impl Response {
             body: body,
         })
     }
+
+    /// Unwraps the Request to return the NetworkStream underneath.
+    pub fn unwrap(self) -> Box<NetworkStream + Send> {
+        self.body.unwrap().unwrap()
+    }
 }
 
 impl Reader for Response {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
         self.body.read(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::boxed::BoxAny;
+    use std::io::BufferedReader;
+
+    use header::Headers;
+    use http::EofReader;
+    use mock::MockStream;
+    use net::NetworkStream;
+    use status;
+    use version;
+
+    use super::Response;
+
+
+    #[test]
+    fn test_unwrap() {
+        let res = Response {
+            status: status::Ok,
+            headers: Headers::new(),
+            version: version::Http11,
+            body: EofReader(BufferedReader::new(box MockStream as Box<NetworkStream + Send>))
+        };
+
+        let b = res.unwrap().downcast::<MockStream>().unwrap();
+        assert_eq!(b, box MockStream);
+
     }
 }

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -1,28 +1,47 @@
 use header::Header;
 use std::fmt::{mod, Show};
-use super::util::from_one_raw_str;
+use super::{from_comma_delimited, fmt_comma_delimited};
 use std::from_str::FromStr;
 
 /// The `Connection` header.
-///
-/// Describes whether the socket connection should be closed or reused after
-/// this request/response is completed.
 #[deriving(Clone, PartialEq, Show)]
-pub enum Connection {
+pub struct Connection(Vec<ConnectionOption>);
+
+/// Values that can be in the `Connection` header.
+#[deriving(Clone, PartialEq)]
+pub enum ConnectionOption {
     /// The `keep-alive` connection value.
     KeepAlive,
     /// The `close` connection value.
-    Close
+    Close,
+    /// Values in the Connection header that are supposed to be names of other Headers.
+    ///
+    /// > When a header field aside from Connection is used to supply control
+    /// > information for or about the current connection, the sender MUST list
+    /// > the corresponding field-name within the Connection header field.
+    // TODO: it would be nice if these "Strings" could be stronger types, since
+    // they are supposed to relate to other Header fields (which we have strong
+    // types for).
+    ConnectionHeader(String),
 }
 
-impl FromStr for Connection {
-    fn from_str(s: &str) -> Option<Connection> {
-        debug!("Connection::from_str =? {}", s);
+impl FromStr for ConnectionOption {
+    fn from_str(s: &str) -> Option<ConnectionOption> {
         match s {
             "keep-alive" => Some(KeepAlive),
             "close" => Some(Close),
-            _ => None
+            s => Some(ConnectionHeader(s.to_string()))
         }
+    }
+}
+
+impl fmt::Show for ConnectionOption {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            KeepAlive => "keep-alive",
+            Close => "close",
+            ConnectionHeader(ref s) => s.as_slice()
+        }.fmt(fmt)
     }
 }
 
@@ -32,14 +51,12 @@ impl Header for Connection {
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> Option<Connection> {
-        from_one_raw_str(raw)
+        from_comma_delimited(raw).map(|vec| Connection(vec))
     }
 
     fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            KeepAlive => "keep-alive",
-            Close => "close",
-        }.fmt(fmt)
+        let Connection(ref parts) = *self;
+        fmt_comma_delimited(fmt, parts[])
     }
 }
 

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -6,25 +6,21 @@
 //! strongly-typed theme, the [mime](http://seanmonstar.github.io/mime.rs) crate
 //! is used, such as `ContentType(pub Mime)`.
 
-pub use self::host::Host;
-pub use self::content_length::ContentLength;
-pub use self::content_type::ContentType;
 pub use self::accept::Accept;
 pub use self::connection::Connection;
+pub use self::content_length::ContentLength;
+pub use self::content_type::ContentType;
+pub use self::date::Date;
+pub use self::host::Host;
+pub use self::location::Location;
 pub use self::transfer_encoding::TransferEncoding;
+pub use self::upgrade::Upgrade;
 pub use self::user_agent::UserAgent;
 pub use self::server::Server;
-pub use self::date::Date;
-pub use self::location::Location;
 
-/// Exposes the Host header.
-pub mod host;
-
-/// Exposes the ContentLength header.
-pub mod content_length;
-
-/// Exposes the ContentType header.
-pub mod content_type;
+use std::fmt::{mod, Show};
+use std::from_str::FromStr;
+use std::str::from_utf8;
 
 /// Exposes the Accept header.
 pub mod accept;
@@ -32,17 +28,30 @@ pub mod accept;
 /// Exposes the Connection header.
 pub mod connection;
 
-/// Exposes the TransferEncoding header.
-pub mod transfer_encoding;
+/// Exposes the ContentLength header.
+pub mod content_length;
 
-/// Exposes the UserAgent header.
-pub mod user_agent;
+/// Exposes the ContentType header.
+pub mod content_type;
+
+/// Exposes the Date header.
+pub mod date;
+
+/// Exposes the Host header.
+pub mod host;
 
 /// Exposes the Server header.
 pub mod server;
 
-/// Exposes the Date header.
-pub mod date;
+/// Exposes the TransferEncoding header.
+pub mod transfer_encoding;
+
+/// Exposes the Upgrade header.
+pub mod upgrade;
+
+/// Exposes the UserAgent header.
+pub mod user_agent;
+
 
 /// Exposes the Location header.
 pub mod location;
@@ -50,3 +59,29 @@ pub mod location;
 pub mod util;
 
 
+fn from_comma_delimited<T: FromStr>(raw: &[Vec<u8>]) -> Option<Vec<T>> {
+    if raw.len() != 1 {
+        return None;
+    }
+    // we JUST checked that raw.len() == 1, so raw[0] WILL exist.
+    match from_utf8(unsafe { raw.as_slice().unsafe_get(0).as_slice() }) {
+        Some(s) => {
+            Some(s.as_slice()
+                 .split([',', ' '].as_slice())
+                 .filter_map(from_str)
+                 .collect())
+        }
+        None => None
+    }
+}
+
+fn fmt_comma_delimited<T: Show>(fmt: &mut fmt::Formatter, parts: &[T]) -> fmt::Result {
+    let last = parts.len() - 1;
+    for (i, part) in parts.iter().enumerate() {
+        try!(part.fmt(fmt));
+        if i < last {
+            try!(", ".fmt(fmt));
+        }
+    }
+    Ok(())
+}

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -1,0 +1,51 @@
+use header::Header;
+use std::fmt::{mod, Show};
+use super::{from_comma_delimited, fmt_comma_delimited};
+use std::from_str::FromStr;
+
+/// The `Upgrade` header.
+#[deriving(Clone, PartialEq, Show)]
+pub struct Upgrade(Vec<Protocol>);
+
+/// Protocol values that can appear in the Upgrade header.
+#[deriving(Clone, PartialEq)]
+pub enum Protocol {
+    /// The websocket protocol.
+    WebSocket,
+    /// Some other less common protocol.
+    ProtocolExt(String),
+}
+
+impl FromStr for Protocol {
+    fn from_str(s: &str) -> Option<Protocol> {
+        match s {
+            "websocket" => Some(WebSocket),
+            s => Some(ProtocolExt(s.to_string()))
+        }
+    }
+}
+
+impl fmt::Show for Protocol {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            WebSocket => "websocket",
+            ProtocolExt(ref s) => s.as_slice()
+        }.fmt(fmt)
+    }
+}
+
+impl Header for Upgrade {
+    fn header_name(_: Option<Upgrade>) -> &'static str {
+        "Upgrade"
+    }
+
+    fn parse_header(raw: &[Vec<u8>]) -> Option<Upgrade> {
+        from_comma_delimited(raw).map(|vec| Upgrade(vec))
+    }
+
+    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let Upgrade(ref parts) = *self;
+        fmt_comma_delimited(fmt, parts[])
+    }
+}
+

--- a/src/http.rs
+++ b/src/http.rs
@@ -38,6 +38,18 @@ pub enum HttpReader<R> {
     EofReader(R),
 }
 
+impl<R: Reader> HttpReader<R> {
+
+    /// Unwraps this HttpReader and returns the underlying Reader.
+    pub fn unwrap(self) -> R {
+        match self {
+            SizedReader(r, _) => r,
+            ChunkedReader(r, _) => r,
+            EofReader(r) => r,
+        }
+    }
+}
+
 impl<R: Reader> Reader for HttpReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,7 @@ pub mod status;
 pub mod uri;
 pub mod version;
 
+#[cfg(test)] mod mock;
 
 mod mimewrapper {
     /// Re-exporting the mime crate, for convenience.

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,0 +1,29 @@
+use std::io::IoResult;
+use std::io::net::ip::SocketAddr;
+
+use net::NetworkStream;
+
+#[deriving(Clone, PartialEq, Show)]
+pub struct MockStream;
+
+impl Reader for MockStream {
+    fn read(&mut self, _buf: &mut [u8]) -> IoResult<uint> {
+        unimplemented!()
+    }
+}
+
+impl Writer for MockStream {
+    fn write(&mut self, _msg: &[u8]) -> IoResult<()> {
+        unimplemented!()
+    }
+}
+
+impl NetworkStream for MockStream {
+    fn connect(_host: &str, _port: u16, _scheme: &str) -> IoResult<MockStream> {
+        Ok(MockStream)
+    }
+
+    fn peer_name(&mut self) -> IoResult<SocketAddr> {
+        Ok(from_str("127.0.0.1:1337").unwrap())
+    }
+}


### PR DESCRIPTION
You can access the `Box<NetworkStream>` from a `client::Response` by calling `unwrap()`.

fixes #51 
