### PR TITLE
Implement the basic parsing for Accept header.

### DIFF
--- a/src/header/common/accept.rs
+++ b/src/header/common/accept.rs
@@ -26,9 +26,9 @@ impl Header for Accept {
         "Accept"
     }
 
-    fn parse_header(_raw: &[Vec<u8>]) -> Option<Accept> {
+    fn parse_header(raw: &[Vec<u8>]) -> Option<Accept> {
         let mut mimes: Vec<Mime> = vec![];
-        for mimes_raw in _raw.iter() {
+        for mimes_raw in raw.iter() {
             match from_utf8(mimes_raw.as_slice()) {
                 Some(mimes_str) => {
                     for mime_str in mimes_str.split(',') {

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -388,10 +388,10 @@ mod tests {
         let text_plain = Mime(Text, Plain, vec![]);
         let application_vendor = from_str("application/vnd.github.v3.full+json; q=0.5").unwrap();
 
-        let accept = Header::parse_header(["text/plain".as_bytes().to_vec()].as_slice());
+        let accept = Header::parse_header([b"text/plain".to_vec()].as_slice());
         assert_eq!(accept, Some(Accept(vec![text_plain.clone()])));
         
-        let accept = Header::parse_header(["application/vnd.github.v3.full+json; q=0.5, text/plain".as_bytes().to_vec()].as_slice());
+        let accept = Header::parse_header([b"application/vnd.github.v3.full+json; q=0.5, text/plain".to_vec()].as_slice());
         assert_eq!(accept, Some(Accept(vec![application_vendor, text_plain])));
     }
 


### PR DESCRIPTION
The first try to add missed Accept header parser. 

Current details:
- It is very pessimistic: `None` in case of any potential errors
- It returns `None` when header is empty (maybe we want */* as default)
