### PR TITLE
Remove debug crate from examples

### DIFF
--- a/examples/concurrent-server.rs
+++ b/examples/concurrent-server.rs
@@ -1,7 +1,6 @@
 #![feature(macro_rules, default_type_params)]
 
 extern crate hyper;
-extern crate debug;
 
 use std::io::util::copy;
 use std::io::net::ip::Ipv4Addr;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,7 +1,6 @@
 #![feature(macro_rules)]
 
 extern crate hyper;
-extern crate debug;
 
 use std::io::util::copy;
 use std::io::net::ip::Ipv4Addr;


### PR DESCRIPTION
This fixes errors with latest 0.13.0-nightly as the debug crate has been removed:

```
error: can't find crate for `debug`
```
