### PR TITLE
Move len/clear from trait implementations to inherent methods

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -534,6 +534,9 @@ mod tests {
         assert_eq!(headers.len(), 1);
         headers.set(ContentType(Mime(Text, Plain, vec![])));
         assert_eq!(headers.len(), 2);
+        // Redundant, should not increase count.
+        headers.set(ContentLength(20));
+        assert_eq!(headers.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Rust has removed them due to collections reform RFC:

RFC: https://github.com/rust-lang/rfcs/pull/235/files
Commit:
https://github.com/rust-lang/rust/commit/21ac985af44f4e2470ef6f4c0eb4d72daf5a6497
