### PR TITLE
Update hash_map and fmt usages

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -9,7 +9,8 @@ use std::fmt::{mod, Show};
 use std::intrinsics::TypeId;
 use std::raw::TraitObject;
 use std::str::{SendStr, Slice, Owned};
-use std::collections::hashmap::{HashMap, Entries, Occupied, Vacant};
+use std::collections::HashMap;
+use std::collections::hash_map::{Entries, Occupied, Vacant};
 use std::sync::RWLock;
 use std::{hash, mem};
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -1571,7 +1571,7 @@ impl StatusCode {
 
 impl fmt::Unsigned for StatusCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::secret_unsigned(&(*self as u16), f)
+        fmt::Unsigned::fmt(&(*self as u16), f)
     }
 }
 


### PR DESCRIPTION
Fixes compilation on latest nightly (ec28b4a6c)

Depends on https://github.com/carllerche/curl-rust/pull/24 and https://github.com/chris-morgan/rust-http/pull/167
