### PR TITLE
fix(client): GET and HEAD shouldn't add Transfer-Encoding

### DIFF
--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -100,11 +100,11 @@ mod tests {
             status: status::Ok,
             headers: Headers::new(),
             version: version::Http11,
-            body: EofReader(BufferedReader::new(box MockStream as Box<NetworkStream + Send>))
+            body: EofReader(BufferedReader::new(box MockStream::new() as Box<NetworkStream + Send>))
         };
 
         let b = res.unwrap().downcast::<MockStream>().unwrap();
-        assert_eq!(b, box MockStream);
+        assert_eq!(b, box MockStream::new());
 
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -274,19 +274,19 @@ mod tests {
 
     #[test]
     fn test_downcast_box_stream() {
-        let stream = box MockStream as Box<NetworkStream + Send>;
+        let stream = box MockStream::new() as Box<NetworkStream + Send>;
 
         let mock = stream.downcast::<MockStream>().unwrap();
-        assert_eq!(mock, box MockStream);
+        assert_eq!(mock, box MockStream::new());
 
     }
 
     #[test]
     fn test_downcast_unchecked_box_stream() {
-        let stream = box MockStream as Box<NetworkStream + Send>;
+        let stream = box MockStream::new() as Box<NetworkStream + Send>;
 
         let mock = unsafe { stream.downcast_unchecked::<MockStream>() };
-        assert_eq!(mock, box MockStream);
+        assert_eq!(mock, box MockStream::new());
 
     }
 


### PR DESCRIPTION
Also adds an EmptyWriter, used for GET and HEAD requests,
which will return an io::ShortWrite error if the user ever tries
to write to a GET or HEAD request.

Closes #77
