### PR TITLE
feat(server): change Incoming to iterator over Connections

### DIFF
--- a/benches/client.rs
+++ b/benches/client.rs
@@ -23,7 +23,8 @@ macro_rules! try_continue(
     }})
 
 fn handle(mut incoming: Incoming) {
-    for (_, res) in incoming {
+    for conn in incoming {
+        let (_, res) = try_continue!(conn.open());
         let mut res = try_continue!(res.start());
         try_continue!(res.write(b"Benchmarking hyper vs others!"))
         try_continue!(res.end());

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -18,7 +18,8 @@ fn request(url: hyper::Url) {
 }
 
 fn hyper_handle(mut incoming: hyper::server::Incoming) {
-    for (_, mut res) in incoming {
+    for conn in incoming {
+        let (_, res) = conn.open().unwrap();
         let mut res = res.start().unwrap();
         res.write(PHRASE).unwrap();
         res.end().unwrap();

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -8,8 +8,9 @@ static PHRASE: &'static [u8] = b"Hello World!";
 fn hyper_handle(mut incoming: hyper::server::Incoming) {
     let mut pool = TaskPool::new(100, || { proc(_) { } });
 
-    for (_, mut res) in incoming {
+    for conn in incoming {
         pool.execute(proc(_) {
+            let (_, res) = conn.open().unwrap();
             let mut res = res.start().unwrap();
             res.write(PHRASE).unwrap();
             res.end().unwrap();

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -19,7 +19,8 @@ macro_rules! try_continue(
 )
 
 fn echo(mut incoming: Incoming) {
-    for (mut req, mut res) in incoming {
+    for conn in incoming {
+        let (mut req, mut res) = try_continue!(conn.open());
         match req.uri {
             hyper::uri::AbsolutePath(ref path) => match (&req.method, path.as_slice()) {
                 (&Get, "/") | (&Get, "/echo") => {


### PR DESCRIPTION
A connection is returned from Incoming.next(), and can be passed to a
separate thread before any parsing happens. Call conn.open() to get a
Result<(Request, Response)>.

BREAKING CHANGE

This should address #99 @reem
