### PR TITLE
Removes intertwining, since it is slow and showing up in profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ git = "https://github.com/hyperium/mime.rs"
 [dependencies.unsafe-any]
 git = "https://github.com/reem/rust-unsafe-any"
 
-[dependencies.intertwine]
-git = "https://github.com/reem/rust-intertwine"
-
 [dependencies.move-acceptor]
 git = "https://github.com/reem/rust-move-acceptor"
 

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -35,7 +35,7 @@ fn handle(mut incoming: Incoming) {
 #[bench]
 fn bench_curl(b: &mut test::Bencher) {
     let mut listening = listen();
-    let s = format!("http://{}/", listening.sockets[0]);
+    let s = format!("http://{}/", listening.socket);
     let url = s.as_slice();
     b.iter(|| {
         curl::http::handle()
@@ -67,7 +67,7 @@ impl hyper::header::HeaderFormat for Foo {
 #[bench]
 fn bench_hyper(b: &mut test::Bencher) {
     let mut listening = listen();
-    let s = format!("http://{}/", listening.sockets[0]);
+    let s = format!("http://{}/", listening.socket);
     let url = s.as_slice();
     b.iter(|| {
         let mut req = hyper::client::Request::get(hyper::Url::parse(url).unwrap()).unwrap();
@@ -83,7 +83,7 @@ fn bench_hyper(b: &mut test::Bencher) {
 #[bench]
 fn bench_http(b: &mut test::Bencher) {
     let mut listening = listen();
-    let s = format!("http://{}/", listening.sockets[0]);
+    let s = format!("http://{}/", listening.socket);
     let url = s.as_slice();
     b.iter(|| {
         let mut req: http::client::RequestWriter = http::client::RequestWriter::new(

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -31,7 +31,7 @@ fn bench_hyper(b: &mut Bencher) {
     let server = hyper::Server::http(Ipv4Addr(127, 0, 0, 1), 0);
     let mut listener = server.listen(hyper_handle).unwrap();
 
-    let url = hyper::Url::parse(format!("http://{}", listener.sockets[0]).as_slice()).unwrap();
+    let url = hyper::Url::parse(format!("http://{}", listener.socket).as_slice()).unwrap();
     b.iter(|| request(url.clone()));
     listener.close().unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,6 @@ extern crate openssl;
 #[cfg(test)] extern crate test;
 extern crate "unsafe-any" as uany;
 extern crate "move-acceptor" as macceptor;
-extern crate intertwine;
 extern crate typeable;
 extern crate cookie;
 


### PR DESCRIPTION
Intertwining was a nice feature, but it slows down hyper significantly,
so it is being removed.

There is some fallout from this, mainly that Incoming has had its type
parameter changed to `<A = HttpAcceptor>` and Handler receiving one
bounded with `A: NetworkAcceptor`.

[breaking-change]

Fixes #112
