### PR TITLE
Members of enums are imported

### DIFF
--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -3,13 +3,16 @@ use std::io::{BufferedWriter, IoResult};
 
 use url::Url;
 
-use method::{mod, Get, Post, Delete, Put, Patch, Head, Options};
+use method;
+use method::Method::{Get, Post, Delete, Put, Patch, Head, Options};
 use header::Headers;
 use header::common::{mod, Host};
 use net::{NetworkStream, NetworkConnector, HttpStream, Fresh, Streaming};
-use http::{HttpWriter, ThroughWriter, ChunkedWriter, SizedWriter, EmptyWriter, LINE_ENDING};
+use HttpError::HttpUriError;
+use http::{HttpWriter, LINE_ENDING};
+use http::HttpWriter::{ThroughWriter, ChunkedWriter, SizedWriter, EmptyWriter};
 use version;
-use {HttpResult, HttpUriError};
+use HttpResult;
 use client::Response;
 
 
@@ -69,7 +72,7 @@ impl Request<Fresh> {
             method: method,
             headers: headers,
             url: url,
-            version: version::Http11,
+            version: version::HttpVersion::Http11,
             body: stream
         })
     }
@@ -141,7 +144,7 @@ impl Request<Fresh> {
                     let encodings = match self.headers.get_mut::<common::TransferEncoding>() {
                         Some(&common::TransferEncoding(ref mut encodings)) => {
                             //TODO: check if chunked is already in encodings. use HashSet?
-                            encodings.push(common::transfer_encoding::Chunked);
+                            encodings.push(common::transfer_encoding::Encoding::Chunked);
                             false
                         },
                         None => true
@@ -149,7 +152,7 @@ impl Request<Fresh> {
 
                     if encodings {
                         self.headers.set::<common::TransferEncoding>(
-                            common::TransferEncoding(vec![common::transfer_encoding::Chunked]))
+                            common::TransferEncoding(vec![common::transfer_encoding::Encoding::Chunked]))
                     }
                 }
 
@@ -206,7 +209,7 @@ mod tests {
     use std::boxed::BoxAny;
     use std::str::from_utf8;
     use url::Url;
-    use method::{Get, Head};
+    use method::Method::{Get, Head};
     use mock::MockStream;
     use super::Request;
 

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -3,12 +3,13 @@ use std::io::{BufferedReader, IoResult};
 
 use header;
 use header::common::{ContentLength, TransferEncoding};
-use header::common::transfer_encoding::Chunked;
+use header::common::transfer_encoding::Encoding::Chunked;
 use net::{NetworkStream, HttpStream};
-use http::{read_status_line, HttpReader, SizedReader, ChunkedReader, EofReader};
+use http::{read_status_line, HttpReader};
+use http::HttpReader::{SizedReader, ChunkedReader, EofReader};
 use status;
 use version;
-use {HttpResult};
+use HttpResult;
 
 /// A response for a client request to a remote server.
 pub struct Response<S = HttpStream> {
@@ -85,7 +86,7 @@ mod tests {
     use std::io::BufferedReader;
 
     use header::Headers;
-    use http::EofReader;
+    use http::HttpReader::EofReader;
     use mock::MockStream;
     use net::NetworkStream;
     use status;
@@ -97,9 +98,9 @@ mod tests {
     #[test]
     fn test_unwrap() {
         let res = Response {
-            status: status::Ok,
+            status: status::StatusCode::Ok,
             headers: Headers::new(),
-            version: version::Http11,
+            version: version::HttpVersion::Http11,
             body: EofReader(BufferedReader::new(box MockStream::new() as Box<NetworkStream + Send>))
         };
 

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -3,6 +3,8 @@ use std::fmt::{mod, Show};
 use super::{from_comma_delimited, fmt_comma_delimited};
 use std::str::FromStr;
 
+use self::ConnectionOption::{KeepAlive, Close, ConnectionHeader};
+
 /// The `Connection` header.
 #[deriving(Clone, PartialEq, Show)]
 pub struct Connection(pub Vec<ConnectionOption>);

--- a/src/header/common/transfer_encoding.rs
+++ b/src/header/common/transfer_encoding.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use std::str::FromStr;
 use super::{from_comma_delimited, fmt_comma_delimited};
 
+use self::Encoding::{Chunked, Gzip, Deflate, Compress, EncodingExt};
+
 /// The `Transfer-Encoding` header.
 ///
 /// This header describes the encoding of the message body. It can be
@@ -32,7 +34,6 @@ pub struct TransferEncoding(pub Vec<Encoding>);
 pub enum Encoding {
     /// The `chunked` encoding.
     Chunked,
-
     /// The `gzip` encoding.
     Gzip,
     /// The `deflate` encoding.

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -3,6 +3,8 @@ use std::fmt::{mod, Show};
 use super::{from_comma_delimited, fmt_comma_delimited};
 use std::str::FromStr;
 
+use self::Protocol::{WebSocket, ProtocolExt};
+
 /// The `Upgrade` header.
 #[deriving(Clone, PartialEq, Show)]
 pub struct Upgrade(Vec<Protocol>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(macro_rules, phase, default_type_params, if_let, slicing_syntax,
-           tuple_indexing)]
+           tuple_indexing, globs)]
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![experimental]
@@ -140,8 +140,8 @@ extern crate cookie;
 pub use std::io::net::ip::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr, Port};
 pub use mimewrapper::mime;
 pub use url::Url;
-pub use method::{Get, Head, Post, Delete};
-pub use status::{Ok, BadRequest, NotFound};
+pub use method::Method::{Get, Head, Post, Delete};
+pub use status::StatusCode::{Ok, BadRequest, NotFound};
 pub use server::Server;
 
 use std::fmt;
@@ -150,6 +150,8 @@ use std::io::IoError;
 
 use std::rt::backtrace;
 
+use self::HttpError::{HttpMethodError, HttpUriError, HttpVersionError,
+                      HttpHeaderError, HttpStatusError, HttpIoError};
 
 macro_rules! todo(
     ($($arg:tt)*) => (if cfg!(not(ndebug)) {

--- a/src/method.rs
+++ b/src/method.rs
@@ -2,6 +2,9 @@
 use std::fmt;
 use std::str::FromStr;
 
+use self::Method::{Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch,
+                   Extension};
+
 /// The Request Method (VERB)
 ///
 /// Currently includes 8 variants representing the 8 methods defined in

--- a/src/net.rs
+++ b/src/net.rs
@@ -16,6 +16,8 @@ use typeable::Typeable;
 use openssl::ssl::{SslStream, SslContext, Sslv23};
 use openssl::ssl::error::{SslError, StreamError, OpenSslErrors, SslSessionClosed};
 
+use self::HttpStream::{Http, Https};
+
 /// The write-status indicating headers have not been written.
 pub struct Fresh;
 

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -11,7 +11,8 @@ use method;
 use header::Headers;
 use header::common::ContentLength;
 use http::{read_request_line};
-use http::{HttpReader, SizedReader, ChunkedReader};
+use http::HttpReader;
+use http::HttpReader::{SizedReader, ChunkedReader};
 use net::NetworkStream;
 use uri::RequestUri;
 

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -8,7 +8,8 @@ use time::now_utc;
 
 use header;
 use header::common;
-use http::{CR, LF, LINE_ENDING, HttpWriter, ThroughWriter, ChunkedWriter, SizedWriter};
+use http::{CR, LF, LINE_ENDING, HttpWriter};
+use http::HttpWriter::{ThroughWriter, ChunkedWriter, SizedWriter};
 use status;
 use net::{NetworkStream, Fresh, Streaming};
 use version;
@@ -52,8 +53,8 @@ impl Response<Fresh> {
     /// Creates a new Response that can be used to write to a network stream.
     pub fn new<S: NetworkStream>(stream: S) -> Response<Fresh> {
         Response {
-            status: status::Ok,
-            version: version::Http11,
+            status: status::StatusCode::Ok,
+            version: version::HttpVersion::Http11,
             headers: header::Headers::new(),
             body: ThroughWriter(BufferedWriter::new(box stream as Box<NetworkStream + Send>))
         }
@@ -85,7 +86,7 @@ impl Response<Fresh> {
             let encodings = match self.headers.get_mut::<common::TransferEncoding>() {
                 Some(&common::TransferEncoding(ref mut encodings)) => {
                     //TODO: check if chunked is already in encodings. use HashSet?
-                    encodings.push(common::transfer_encoding::Chunked);
+                    encodings.push(common::transfer_encoding::Encoding::Chunked);
                     false
                 },
                 None => true
@@ -93,7 +94,7 @@ impl Response<Fresh> {
 
             if encodings {
                 self.headers.set::<common::TransferEncoding>(
-                    common::TransferEncoding(vec![common::transfer_encoding::Chunked]))
+                    common::TransferEncoding(vec![common::transfer_encoding::Encoding::Chunked]))
             }
         }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -2,6 +2,11 @@
 use std::fmt;
 use std::mem::transmute;
 
+use self::StatusClass::{Informational, Success, Redirection, ClientError,
+                        ServerError};
+
+use self::StatusCode::*;
+
 // shamelessly lifted from Teepee. I tried a few schemes, this really
 // does seem like the best.
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -4,6 +4,8 @@
 //! the `HttpVersion` enum.
 use std::fmt;
 
+use self::HttpVersion::{Http09, Http10, Http11, Http20};
+
 /// Represents a version of the HTTP spec.
 #[deriving(PartialEq, PartialOrd)]
 pub enum HttpVersion {


### PR DESCRIPTION
[This push](https://github.com/rust-lang/rust/pull/18973) breaks `master`.  This pull request makes everything (including tests) compile again.
