### PR TITLE
fix(fmt): Unsigned formatting trait has been removed

### DIFF
--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -144,7 +144,7 @@ impl Response<Streaming> {
 
 impl Writer for Response<Streaming> {
     fn write(&mut self, msg: &[u8]) -> IoResult<()> {
-        debug!("write {:u} bytes", msg.len());
+        debug!("write {} bytes", msg.len());
         self.body.write(msg)
     }
 
@@ -152,4 +152,3 @@ impl Writer for Response<Streaming> {
         self.body.flush()
     }
 }
-

--- a/src/status.rs
+++ b/src/status.rs
@@ -1569,12 +1569,6 @@ impl StatusCode {
     }
 }
 
-impl fmt::Unsigned for StatusCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Unsigned::fmt(&(*self as u16), f)
-    }
-}
-
 /// Formats the status code, *including* the canonical reason.
 ///
 /// ```rust
@@ -1584,8 +1578,6 @@ impl fmt::Unsigned for StatusCode {
 /// assert_eq!(format!("{}", Code123).as_slice(),
 ///            "123 <unknown status code>");
 /// ```
-///
-/// If you wish to just include the number, use `Unsigned` instead (`{:u}`).
 impl fmt::Show for StatusCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {}", *self as u16,


### PR DESCRIPTION
Yay, my first compiler panic. Just want to get it confirmed by Travis for now, you probably don't want to merge this.
