### PR TITLE
Drop the unnecessary dependency on `typeable`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ git = "https://github.com/hyperium/mime.rs"
 [dependencies.unsafe-any]
 git = "https://github.com/reem/rust-unsafe-any"
 
-[dependencies.typeable]
-git = "https://github.com/reem/rust-typeable"
-
 [dev-dependencies.curl]
 git = "https://github.com/carllerche/curl-rust"
 

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -4,6 +4,7 @@
 //! why we're using Rust in the first place. To set or get any header, an object
 //! must implement the `Header` trait from this module. Several common headers
 //! are already provided, such as `Host`, `ContentType`, `UserAgent`, and others.
+use std::any::Any;
 use std::ascii::{AsciiExt, ASCII_LOWER_MAP};
 use std::fmt::{mod, Show};
 use std::intrinsics::TypeId;
@@ -15,7 +16,6 @@ use std::sync::RWLock;
 use std::{hash, mem};
 
 use uany::{UncheckedAnyDowncast, UncheckedAnyMutDowncast};
-use typeable::Typeable;
 
 use http::{mod, LineEnding};
 use {HttpResult};
@@ -27,7 +27,7 @@ pub mod common;
 ///
 /// This trait represents the construction and identification of headers,
 /// and contains trait-object unsafe methods.
-pub trait Header: Typeable + Send + Sync {
+pub trait Header: Any + Send + Sync {
     /// Returns the name of the header field this belongs to.
     ///
     /// The market `Option` is to hint to the type system which implementation
@@ -47,7 +47,7 @@ pub trait Header: Typeable + Send + Sync {
 /// A trait for any object that will represent a header field and value.
 ///
 /// This trait represents the formatting of a Header for output to a TcpStream.
-pub trait HeaderFormat: Clone + Typeable + Send + Sync {
+pub trait HeaderFormat: Clone + Any + Send + Sync {
     /// Format a header to be output into a TcpStream.
     ///
     /// This method is not allowed to introduce an Err not produced
@@ -66,7 +66,7 @@ trait Is {
 
 impl<'a> Is for &'a HeaderFormat {
     fn is<T: 'static>(self) -> bool {
-        self.get_type() == TypeId::of::<T>()
+        self.get_type_id() == TypeId::of::<T>()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,6 @@ extern crate openssl;
 #[phase(plugin,link)] extern crate log;
 #[cfg(test)] extern crate test;
 extern crate "unsafe-any" as uany;
-extern crate typeable;
 extern crate cookie;
 
 pub use std::io::net::ip::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr, Port};

--- a/src/net.rs
+++ b/src/net.rs
@@ -12,7 +12,6 @@ use std::raw::{mod, TraitObject};
 use std::sync::{Arc, Mutex};
 
 use uany::UncheckedBoxAnyDowncast;
-use typeable::Typeable;
 use openssl::ssl::{SslStream, SslContext, Sslv23};
 use openssl::ssl::error::{SslError, StreamError, OpenSslErrors, SslSessionClosed};
 
@@ -25,7 +24,7 @@ pub struct Fresh;
 pub struct Streaming;
 
 /// An abstraction to listen for connections on a certain port.
-pub trait NetworkListener<S: NetworkStream, A: NetworkAcceptor<S>>: Listener<S, A> + Typeable {
+pub trait NetworkListener<S: NetworkStream, A: NetworkAcceptor<S>>: Listener<S, A> {
     /// Bind to a socket.
     ///
     /// Note: This does not start listening for connections. You must call


### PR DESCRIPTION
See also https://github.com/reem/rust-typeable/issues/3.
