### PR TITLE
Allow hyper::method::Method to be put in HashMap

### DIFF
--- a/src/method.rs
+++ b/src/method.rs
@@ -100,3 +100,45 @@ impl fmt::Show for Method {
         }.fmt(fmt)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::str::FromStr;
+    use super::Method;
+    use super::Method::{Get, Post, Put, Extension};
+
+    #[test]
+    fn test_safe() {
+        assert_eq!(true, Get.safe());
+        assert_eq!(false, Post.safe());
+    }
+
+    #[test]
+    fn test_idempotent() {
+        assert_eq!(true, Get.idempotent());
+        assert_eq!(true, Put.idempotent());
+        assert_eq!(false, Post.idempotent());
+    }
+
+    #[test]
+    fn test_from_str() {
+        assert_eq!(Some(Get), FromStr::from_str("GET"));
+        assert_eq!(Some(Extension("MOVE".to_string())),
+                   FromStr::from_str("MOVE"));
+    }
+
+    #[test]
+    fn test_fmt() {
+        assert_eq!("GET".to_string(), format!("{}", Get));
+        assert_eq!("MOVE".to_string(),
+                   format!("{}", Extension("MOVE".to_string())));
+    }
+
+    #[test]
+    fn test_hashable() {
+        let mut counter: HashMap<Method,uint> = HashMap::new();
+        counter.insert(Get, 1);
+        assert_eq!(Some(&1), counter.get(&Get));
+    }
+}


### PR DESCRIPTION
This is needed for porting iron/router to hyper.

I'm happy to add some unit tests for this, if you'd like them.
