### PR TITLE
Fix unwrap() => into_inner()

### DIFF
--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -187,7 +187,7 @@ impl Request<Streaming> {
     ///
     /// Consumes the Request.
     pub fn send(self) -> HttpResult<Response> {
-        let raw = try!(self.body.end()).unwrap();
+        let raw = try!(self.body.end()).into_inner();
         Response::new(raw)
     }
 }
@@ -219,8 +219,8 @@ mod tests {
             Get, Url::parse("http://example.dom").unwrap()
         ).unwrap();
         let req = req.start().unwrap();
-        let stream = *req.body.end().unwrap().unwrap().downcast::<MockStream>().unwrap();
-        let bytes = stream.write.unwrap();
+        let stream = *req.body.end().unwrap().into_inner().downcast::<MockStream>().unwrap();
+        let bytes = stream.write.into_inner();
         let s = from_utf8(bytes[]).unwrap();
         assert!(!s.contains("Content-Length:"));
         assert!(!s.contains("Transfer-Encoding:"));
@@ -232,8 +232,8 @@ mod tests {
             Head, Url::parse("http://example.dom").unwrap()
         ).unwrap();
         let req = req.start().unwrap();
-        let stream = *req.body.end().unwrap().unwrap().downcast::<MockStream>().unwrap();
-        let bytes = stream.write.unwrap();
+        let stream = *req.body.end().unwrap().into_inner().downcast::<MockStream>().unwrap();
+        let bytes = stream.write.into_inner();
         let s = from_utf8(bytes[]).unwrap();
         assert!(!s.contains("Content-Length:"));
         assert!(!s.contains("Transfer-Encoding:"));

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -80,9 +80,9 @@ impl Response {
         &self.status_raw
     }
 
-    /// Unwraps the Request to return the NetworkStream underneath.
-    pub fn unwrap(self) -> Box<NetworkStream + Send> {
-        self.body.unwrap().unwrap()
+    /// Consumes the Request to return the NetworkStream underneath.
+    pub fn into_inner(self) -> Box<NetworkStream + Send> {
+        self.body.unwrap().into_inner()
     }
 }
 
@@ -120,7 +120,7 @@ mod tests {
             status_raw: RawStatus(200, Slice("OK"))
         };
 
-        let b = res.unwrap().downcast::<MockStream>().unwrap();
+        let b = res.into_inner().downcast::<MockStream>().unwrap();
         assert_eq!(b, box MockStream::new());
 
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -748,7 +748,7 @@ mod tests {
         let mut w = super::HttpWriter::ChunkedWriter(MemWriter::new());
         w.write(b"foo bar").unwrap();
         w.write(b"baz quux herp").unwrap();
-        let buf = w.end().unwrap().unwrap();
+        let buf = w.end().unwrap().into_inner();
         let s = from_utf8(buf.as_slice()).unwrap();
         assert_eq!(s, "7\r\nfoo bar\r\nD\r\nbaz quux herp\r\n0\r\n\r\n");
     }
@@ -760,7 +760,7 @@ mod tests {
         w.write(b"foo bar").unwrap();
         assert_eq!(w.write(b"baz"), Err(io::standard_error(io::ShortWrite(1))));
 
-        let buf = w.end().unwrap().unwrap();
+        let buf = w.end().unwrap().into_inner();
         let s = from_utf8(buf.as_slice()).unwrap();
         assert_eq!(s, "foo barb");
     }


### PR DESCRIPTION
This pr also renames Response.unwrap() into Response.into_inner() to match new conventions.
