### PR TITLE
feat(headers): header ergonomics

### DIFF
--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -134,7 +134,7 @@ impl Request<Fresh> {
                 match self.headers.get::<common::ContentLength>() {
                     Some(cl) => {
                         chunked = false;
-                        len = cl.len();
+                        len = **cl;
                     },
                     None => ()
                 };

--- a/src/header/common/accept.rs
+++ b/src/header/common/accept.rs
@@ -21,6 +21,8 @@ use mime::Mime;
 #[deriving(Clone, PartialEq, Show)]
 pub struct Accept(pub Vec<Mime>);
 
+deref!(Accept -> Vec<Mime>)
+
 impl Header for Accept {
     fn header_name(_: Option<Accept>) -> &'static str {
         "Accept"

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -7,6 +7,18 @@ use header::{Header, HeaderFormat};
 #[deriving(Clone, PartialEq, Show)]
 pub struct Authorization<S: Scheme>(pub S);
 
+impl<S: Scheme> Deref<S> for Authorization<S> {
+    fn deref<'a>(&'a self) -> &'a S {
+        &self.0
+    }
+}
+
+impl<S: Scheme> DerefMut<S> for Authorization<S> {
+    fn deref_mut<'a>(&'a mut self) -> &'a mut S {
+        &mut self.0
+    }
+}
+
 impl<S: Scheme> Header for Authorization<S> {
     fn header_name(_: Option<Authorization<S>>) -> &'static str {
         "Authorization"

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -9,6 +9,8 @@ pub use self::ConnectionOption::{KeepAlive, Close, ConnectionHeader};
 #[deriving(Clone, PartialEq, Show)]
 pub struct Connection(pub Vec<ConnectionOption>);
 
+deref!(Connection -> Vec<ConnectionOption>)
+
 /// Values that can be in the `Connection` header.
 #[deriving(Clone, PartialEq)]
 pub enum ConnectionOption {

--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -9,6 +9,8 @@ use super::util::from_one_raw_str;
 #[deriving(Clone, PartialEq, Show)]
 pub struct ContentLength(pub uint);
 
+deref!(ContentLength -> uint)
+
 impl Header for ContentLength {
     fn header_name(_: Option<ContentLength>) -> &'static str {
         "Content-Length"
@@ -28,10 +30,10 @@ impl HeaderFormat for ContentLength {
 
 impl ContentLength {
     /// Returns the wrapped length.
+    #[deprecated = "use Deref instead"]
     #[inline]
     pub fn len(&self) -> uint {
-        let ContentLength(len) = *self;
-        len
+        **self
     }
 }
 

--- a/src/header/common/content_type.rs
+++ b/src/header/common/content_type.rs
@@ -10,6 +10,8 @@ use mime::Mime;
 #[deriving(Clone, PartialEq, Show)]
 pub struct ContentType(pub Mime);
 
+deref!(ContentType -> Mime)
+
 impl Header for ContentType {
     fn header_name(_: Option<ContentType>) -> &'static str {
         "Content-Type"

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -16,6 +16,8 @@ use cookie::CookieJar;
 #[deriving(Clone, PartialEq, Show)]
 pub struct Cookies(pub Vec<Cookie>);
 
+deref!(Cookies -> Vec<Cookie>)
+
 impl Header for Cookies {
     fn header_name(_: Option<Cookies>) -> &'static str {
         "Cookie"

--- a/src/header/common/date.rs
+++ b/src/header/common/date.rs
@@ -9,6 +9,8 @@ use time::{Tm, strptime};
 #[deriving(PartialEq, Clone)]
 pub struct Date(pub Tm);
 
+deref!(Date -> Tm)
+
 impl Header for Date {
     fn header_name(_: Option<Date>) -> &'static str {
         "Date"

--- a/src/header/common/location.rs
+++ b/src/header/common/location.rs
@@ -16,6 +16,8 @@ use super::util::from_one_raw_str;
 #[deriving(Clone, PartialEq, Show)]
 pub struct Location(pub String);
 
+deref!(Location -> String)
+
 impl Header for Location {
     fn header_name(_: Option<Location>) -> &'static str {
         "Location"

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -59,6 +59,22 @@ macro_rules! bench_header(
     }
 )
 
+macro_rules! deref(
+    ($from:ty -> $to:ty) => {
+        impl Deref<$to> for $from {
+            fn deref<'a>(&'a self) -> &'a $to {
+                &self.0
+            }
+        }
+
+        impl DerefMut<$to> for $from {
+            fn deref_mut<'a>(&'a mut self) -> &'a mut $to {
+                &mut self.0
+            }
+        }
+    }
+)
+
 /// Exposes the Accept header.
 pub mod accept;
 

--- a/src/header/common/server.rs
+++ b/src/header/common/server.rs
@@ -8,6 +8,8 @@ use super::util::from_one_raw_str;
 #[deriving(Clone, PartialEq, Show)]
 pub struct Server(pub String);
 
+deref!(Server -> String)
+
 impl Header for Server {
     fn header_name(_: Option<Server>) -> &'static str {
         "Server"

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -13,6 +13,8 @@ use cookie::CookieJar;
 #[deriving(Clone, PartialEq, Show)]
 pub struct SetCookie(pub Vec<Cookie>);
 
+deref!(SetCookie -> Vec<Cookie>)
+
 impl Header for SetCookie {
     fn header_name(_: Option<SetCookie>) -> &'static str {
         "Set-Cookie"

--- a/src/header/common/transfer_encoding.rs
+++ b/src/header/common/transfer_encoding.rs
@@ -21,6 +21,8 @@ use self::Encoding::{Chunked, Gzip, Deflate, Compress, EncodingExt};
 #[deriving(Clone, PartialEq, Show)]
 pub struct TransferEncoding(pub Vec<Encoding>);
 
+deref!(TransferEncoding -> Vec<Encoding>)
+
 /// A value to be used with the `Transfer-Encoding` header.
 ///
 /// Example:

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -7,7 +7,9 @@ use self::Protocol::{WebSocket, ProtocolExt};
 
 /// The `Upgrade` header.
 #[deriving(Clone, PartialEq, Show)]
-pub struct Upgrade(Vec<Protocol>);
+pub struct Upgrade(pub Vec<Protocol>);
+
+deref!(Upgrade -> Vec<Protocol>)
 
 /// Protocol values that can appear in the Upgrade header.
 #[deriving(Clone, PartialEq)]

--- a/src/header/common/user_agent.rs
+++ b/src/header/common/user_agent.rs
@@ -8,6 +8,8 @@ use super::util::from_one_raw_str;
 #[deriving(Clone, PartialEq, Show)]
 pub struct UserAgent(pub String);
 
+deref!(UserAgent -> String)
+
 impl Header for UserAgent {
     fn header_name(_: Option<UserAgent>) -> &'static str {
         "User-Agent"

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -21,6 +21,8 @@ use uany::{UncheckedAnyDowncast, UncheckedAnyMutDowncast};
 use http::{mod, LineEnding};
 use {HttpResult};
 
+pub use self::common::*;
+
 /// Common Headers
 pub mod common;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(macro_rules, phase, default_type_params, if_let, slicing_syntax,
-           tuple_indexing)]
+           tuple_indexing, globs)]
 #![deny(missing_docs)]
 #![deny(warnings)]
 #![experimental]

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -83,7 +83,7 @@ impl<'a> Response<'a, Fresh> {
         match self.headers.get::<common::ContentLength>() {
             Some(cl) => {
                 chunked = false;
-                len = cl.len();
+                len = **cl;
             },
             None => ()
         };


### PR DESCRIPTION
- Reexports all common::\* as header::*
- Most headers implement Deref where it makes sense.

Closes #156
