### PR TITLE
wip: ssl-verify

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -190,6 +190,31 @@ impl<W: Writer> HttpWriter<W> {
         }
     }
 
+    /// Access the inner Writer.
+    #[inline]
+    pub fn get_ref<'a>(&'a self) -> &'a W {
+        match *self {
+            ThroughWriter(ref w) => w,
+            ChunkedWriter(ref w) => w,
+            SizedWriter(ref w, _) => w,
+            EmptyWriter(ref w) => w,
+        }
+    }
+
+    /// Access the inner Writer mutably.
+    ///
+    /// Warning: You should not write to this directly, as you can corrupt
+    /// the state.
+    #[inline]
+    pub fn get_mut<'a>(&'a mut self) -> &'a mut W {
+        match *self {
+            ThroughWriter(ref mut w) => w,
+            ChunkedWriter(ref mut w) => w,
+            SizedWriter(ref mut w, _) => w,
+            EmptyWriter(ref mut w) => w,
+        }
+    }
+
     /// Ends the HttpWriter, and returns the underlying Writer.
     ///
     /// A final `write()` is called with an empty message, and then flushed.

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -61,14 +61,15 @@ impl Writer for MockStream {
 }
 
 impl NetworkStream for MockStream {
-
     fn peer_name(&mut self) -> IoResult<SocketAddr> {
         Ok(from_str("127.0.0.1:1337").unwrap())
     }
 }
 
-impl NetworkConnector for MockStream {
-    fn connect<To: ToSocketAddr>(_addr: To, _scheme: &str) -> IoResult<MockStream> {
+pub struct MockConnector;
+
+impl NetworkConnector<MockStream> for MockConnector {
+    fn connect<To: ToSocketAddr>(&mut self, _addr: To, _scheme: &str) -> IoResult<MockStream> {
         Ok(MockStream::new())
     }
 }


### PR DESCRIPTION
Instead, you can use an instance of a NetworkConnector with
`Request::with_connector`. This allows overloading of the NetworkStream
constructors, so that it is easy to modify how an `HttpStream` is
created, while still relying on the rest of the stream implementation.
