### PR TITLE
Removed now-deprecated Equiv implementation

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -466,12 +466,6 @@ impl PartialEq for CaseInsensitive {
 
 impl Eq for CaseInsensitive {}
 
-impl Equiv<CaseInsensitive> for CaseInsensitive {
-    fn equiv(&self, other: &CaseInsensitive) -> bool {
-        self == other
-    }
-}
-
 impl<H: hash::Writer> hash::Hash<H> for CaseInsensitive {
     #[inline]
     fn hash(&self, hasher: &mut H) {


### PR DESCRIPTION
`Equiv` has been deprecated as per [this pull request to Rust](https://github.com/rust-lang/rust/pull/19167).  This pull request removes the use, which was unused within `hyper`.
