### PR TITLE
feat(client): add a new Client struct with super powers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,18 +42,18 @@ Client:
 
 ```rust
 fn main() {
+    // Create a client.
+    let mut client = Client::new();
+
     // Creating an outgoing request.
-    let mut req = Request::get(Url::parse("http://www.gooogle.com/").unwrap()).unwrap();
+    let mut res = client.get("http://www.gooogle.com/")
+        // set a header
+        .header(Connection(vec![Close]))
+        // let 'er go!
+        .send();
 
-    // Setting a header.
-    req.headers_mut().set(Connection(vec![Close]));
-
-    // Start the Request, writing headers and starting streaming.
-    let res = req.start().unwrap()
-        // Send the Request.
-        .send().unwrap()
-        // Read the Response.
-        .read_to_string().unwrap();
+    // Read the Response.
+    let body = res.read_to_string().unwrap();
 
     println!("Response: {}", res);
 }
@@ -64,22 +64,20 @@ fn main() {
 [Client Bench:](./benches/client.rs)
 
 ```
-
 running 3 tests
-test bench_curl  ... bench:    298416 ns/iter (+/- 132455)
-test bench_http  ... bench:    292725 ns/iter (+/- 167575)
-test bench_hyper ... bench:    222819 ns/iter (+/- 86615)
+test bench_curl  ... bench:    400253 ns/iter (+/- 143539)
+test bench_hyper ... bench:    181703 ns/iter (+/- 46529)
 
-test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured
+test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured
 ```
 
 [Mock Client Bench:](./benches/client_mock_tcp.rs)
 
 ```
 running 3 tests
-test bench_mock_curl  ... bench:     25254 ns/iter (+/- 2113)
-test bench_mock_http  ... bench:     43585 ns/iter (+/- 1206)
-test bench_mock_hyper ... bench:     27153 ns/iter (+/- 2227)
+test bench_mock_curl  ... bench:     53987 ns/iter (+/- 1735)
+test bench_mock_http  ... bench:     43569 ns/iter (+/- 1409)
+test bench_mock_hyper ... bench:     20996 ns/iter (+/- 1742)
 
 test result: ok. 0 passed; 0 failed; 0 ignored; 3 measured
 ```

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -9,12 +9,13 @@ use test::Bencher;
 use std::io::net::ip::{SocketAddr, Ipv4Addr};
 
 use http::server::Server;
+use hyper::method::Method::Get;
 use hyper::server::{Request, Response};
 
 static PHRASE: &'static [u8] = b"Benchmarking hyper vs others!";
 
 fn request(url: hyper::Url) {
-    let req = hyper::client::Request::get(url).unwrap();
+    let req = hyper::client::Request::new(Get, url).unwrap();
     req.start().unwrap().send().unwrap().read_to_string().unwrap();
 }
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -4,8 +4,7 @@ use std::os;
 use std::io::stdout;
 use std::io::util::copy;
 
-use hyper::Url;
-use hyper::client::Request;
+use hyper::Client;
 
 fn main() {
     let args = os::args();
@@ -17,26 +16,17 @@ fn main() {
         }
     };
 
-    let url = match Url::parse(args[1].as_slice()) {
-        Ok(url) => {
-            println!("GET {}...", url)
-            url
-        },
-        Err(e) => panic!("Invalid URL: {}", e)
-    };
+    let url = &*args[1];
 
+    let mut client = Client::new();
 
-    let req = match Request::get(url) {
-        Ok(req) => req,
+    let mut res = match client.get(url).send() {
+        Ok(res) => res,
         Err(err) => panic!("Failed to connect: {}", err)
     };
 
-    let mut res = req
-        .start().unwrap() // failure: Error writing Headers
-        .send().unwrap(); // failure: Error reading Response head.
-
     println!("Response: {}", res.status);
-    println!("{}", res.headers);
+    println!("Headers:\n{}", res.headers);
     match copy(&mut res, &mut stdout()) {
         Ok(..) => (),
         Err(e) => panic!("Stream failure: {}", e)

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,7 +1,399 @@
 //! HTTP Client
+//!
+//! # Usage
+//!
+//! The `Client` API is designed for most people to make HTTP requests.
+//! It utilizes the lower level `Request` API.
+//!
+//! ```no_run
+//! use hyper::Client;
+//!
+//! let mut client = Client::new();
+//!
+//! let mut res = client.get("http://example.domain").send().unwrap();
+//! assert_eq!(res.status, hyper::Ok);
+//! ```
+//!
+//! The returned value from is a `Response`, which provides easy access
+//! to the `status`, the `headers`, and the response body via the `Writer`
+//! trait.
+use std::default::Default;
+use std::io::IoResult;
+use std::io::util::copy;
+use std::iter::Extend;
+
+use url::UrlParser;
+use url::ParseError as UrlError;
+
+use openssl::ssl::VerifyCallback;
+
+use header::{Headers, Header, HeaderFormat};
+use header::common::{ContentLength, Location};
+use method::Method;
+use net::{NetworkConnector, NetworkStream, HttpConnector};
+use status::StatusClass::Redirection;
+use {Url, Port, HttpResult};
+use HttpError::HttpUriError;
+
 pub use self::request::Request;
 pub use self::response::Response;
 
 pub mod request;
 pub mod response;
 
+/// A Client to use additional features with Requests.
+///
+/// Clients can handle things such as: redirect policy.
+pub struct Client<C> {
+    connector: C,
+    redirect_policy: RedirectPolicy,
+}
+
+impl Client<HttpConnector> {
+
+    /// Create a new Client.
+    pub fn new() -> Client<HttpConnector> {
+        Client::with_connector(HttpConnector(None))
+    }
+
+    /// Set the SSL verifier callback for use with OpenSSL.
+    pub fn set_ssl_verifier(&mut self, verifier: VerifyCallback) {
+        self.connector = HttpConnector(Some(verifier));
+    }
+
+}
+
+impl<C: NetworkConnector<S>, S: NetworkStream> Client<C> {
+
+    /// Create a new client with a specific connector.
+    pub fn with_connector(connector: C) -> Client<C> {
+        Client {
+            connector: connector,
+            redirect_policy: Default::default()
+        }
+    }
+
+    /// Set the RedirectPolicy.
+    pub fn set_redirect_policy(&mut self, policy: RedirectPolicy) {
+        self.redirect_policy = policy;
+    }
+
+    /// Execute a Get request.
+    pub fn get<U: IntoUrl>(&mut self, url: U) -> RequestBuilder<U, C, S> {
+        self.request(Method::Get, url)
+    }
+
+    /// Execute a Head request.
+    pub fn head<U: IntoUrl>(&mut self, url: U) -> RequestBuilder<U, C, S> {
+        self.request(Method::Head, url)
+    }
+
+    /// Execute a Post request.
+    pub fn post<U: IntoUrl>(&mut self, url: U) -> RequestBuilder<U, C, S> {
+        self.request(Method::Post, url)
+    }
+
+    /// Execute a Put request.
+    pub fn put<U: IntoUrl>(&mut self, url: U) -> RequestBuilder<U, C, S> {
+        self.request(Method::Put, url)
+    }
+
+    /// Execute a Delete request.
+    pub fn delete<U: IntoUrl>(&mut self, url: U) -> RequestBuilder<U, C, S> {
+        self.request(Method::Delete, url)
+    }
+
+
+    /// Build a new request using this Client.
+    pub fn request<U: IntoUrl>(&mut self, method: Method, url: U) -> RequestBuilder<U, C, S> {
+        RequestBuilder {
+            client: self,
+            method: method,
+            url: url,
+            body: None,
+            headers: None,
+        }
+    }
+}
+
+/// Options for an individual Request.
+///
+/// One of these will be built for you if you use one of the convenience
+/// methods, such as `get()`, `post()`, etc.
+pub struct RequestBuilder<'a, U: IntoUrl, C: NetworkConnector<S> + 'a, S: NetworkStream> {
+    client: &'a mut Client<C>,
+    url: U,
+    headers: Option<Headers>,
+    method: Method,
+    body: Option<Body<'a>>,
+}
+
+impl<'a, U: IntoUrl, C: NetworkConnector<S>, S: NetworkStream> RequestBuilder<'a, U, C, S> {
+
+    /// Set a request body to be sent.
+    pub fn body<B: IntoBody<'a>>(mut self, body: B) -> RequestBuilder<'a, U, C, S> {
+        self.body = Some(body.into_body());
+        self
+    }
+
+    /// Add additional headers to the request.
+    pub fn headers(mut self, headers: Headers) -> RequestBuilder<'a, U, C, S> {
+        self.headers = Some(headers);
+        self
+    }
+
+    /// Add an individual new header to the request.
+    pub fn header<H: Header + HeaderFormat>(mut self, header: H) -> RequestBuilder<'a, U, C, S> {
+        {
+            let mut headers = match self.headers {
+                Some(ref mut h) => h,
+                None => {
+                    self.headers = Some(Headers::new());
+                    self.headers.as_mut().unwrap()
+                }
+            };
+
+            headers.set(header);
+        }
+        self
+    }
+
+    /// Execute this request and receive a Response back.
+    pub fn send(self) -> HttpResult<Response> {
+        let RequestBuilder { client, method, url, headers, body } = self;
+        let mut url = try!(url.into_url());
+        debug!("client.request {} {}", method, url);
+
+        let can_have_body = match &method {
+            &Method::Get | &Method::Head => false,
+            _ => true
+        };
+
+        let mut body = if can_have_body {
+            body.map(|b| b.into_body())
+        } else {
+             None
+        };
+
+        loop {
+            let mut req = try!(Request::with_connector(method.clone(), url.clone(), &mut client.connector));
+            headers.as_ref().map(|headers| req.headers_mut().extend(headers.iter()));
+
+            match (can_have_body, body.as_ref()) {
+                (true, Some(ref body)) => match body.size() {
+                    Some(size) => req.headers_mut().set(ContentLength(size)),
+                    None => (), // chunked, Request will add it automatically
+                },
+                (true, None) => req.headers_mut().set(ContentLength(0)),
+                _ => () // neither
+            }
+            let mut streaming = try!(req.start());
+            body.take().map(|mut rdr| copy(&mut rdr, &mut streaming));
+            let res = try!(streaming.send());
+            if res.status.class() != Redirection {
+                return Ok(res)
+            }
+            debug!("redirect code {} for {}", res.status, url);
+
+            let loc = {
+                // punching borrowck here
+                let loc = match res.headers.get::<Location>() {
+                    Some(&Location(ref loc)) => {
+                        Some(UrlParser::new().base_url(&url).parse(loc[]))
+                    }
+                    None => {
+                        debug!("no Location header");
+                        // could be 304 Not Modified?
+                        None
+                    }
+                };
+                match loc {
+                    Some(r) => r,
+                    None => return Ok(res)
+                }
+            };
+            url = match loc {
+                Ok(u) => {
+                    inspect!("Location", u)
+                },
+                Err(e) => {
+                    debug!("Location header had invalid URI: {}", e);
+                    return Ok(res);
+                }
+            };
+            match client.redirect_policy {
+                // separate branches because they cant be one
+                RedirectPolicy::FollowAll => (), //continue
+                RedirectPolicy::FollowIf(cond) if cond(&url) => (), //continue
+                _ => return Ok(res),
+            }
+        }
+    }
+}
+
+/// A helper trait to allow overloading of the body parameter.
+pub trait IntoBody<'a> {
+    /// Consumes self into an instance of `Body`.
+    fn into_body(self) -> Body<'a>;
+}
+
+/// The target enum for the IntoBody trait.
+pub enum Body<'a> {
+    /// A Reader does not necessarily know it's size, so it is chunked.
+    ChunkedBody(&'a mut (Reader + 'a)),
+    /// For Readers that can know their size, like a `File`.
+    SizedBody(&'a mut (Reader + 'a), uint),
+    /// A String has a size, and uses Content-Length.
+    BufBody(&'a [u8] , uint),
+}
+
+impl<'a> Body<'a> {
+    fn size(&self) -> Option<uint> {
+        match *self {
+            Body::SizedBody(_, len) | Body::BufBody(_, len) => Some(len),
+            _ => None
+        }
+    }
+}
+
+impl<'a> Reader for Body<'a> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<uint> {
+        match *self {
+            Body::ChunkedBody(ref mut r) => r.read(buf),
+            Body::SizedBody(ref mut r, _) => r.read(buf),
+            Body::BufBody(ref mut r, _) => r.read(buf),
+        }
+    }
+}
+
+// To allow someone to pass a `Body::SizedBody()` themselves.
+impl<'a> IntoBody<'a> for Body<'a> {
+    #[inline]
+    fn into_body(self) -> Body<'a> {
+        self
+    }
+}
+
+impl<'a> IntoBody<'a> for &'a [u8] {
+    #[inline]
+    fn into_body(self) -> Body<'a> {
+        Body::BufBody(self, self.len())
+    }
+}
+
+impl<'a> IntoBody<'a> for &'a str {
+    #[inline]
+    fn into_body(self) -> Body<'a> {
+        self.as_bytes().into_body()
+    }
+}
+
+impl<'a, R: Reader> IntoBody<'a> for &'a mut R {
+    #[inline]
+    fn into_body(self) -> Body<'a> {
+        Body::ChunkedBody(self)
+    }
+}
+
+/// A helper trait to convert common objects into a Url.
+pub trait IntoUrl {
+    /// Consumes the object, trying to return a Url.
+    fn into_url(self) -> Result<Url, UrlError>;
+}
+
+impl IntoUrl for Url {
+    fn into_url(self) -> Result<Url, UrlError> {
+        Ok(self)
+    }
+}
+
+impl<'a> IntoUrl for &'a str {
+    fn into_url(self) -> Result<Url, UrlError> {
+        Url::parse(self)
+    }
+}
+
+/// Behavior regarding how to handle redirects within a Client.
+#[deriving(Copy, Clone)]
+pub enum RedirectPolicy {
+    /// Don't follow any redirects.
+    FollowNone,
+    /// Follow all redirects.
+    FollowAll,
+    /// Follow a redirect if the contained function returns true.
+    FollowIf(fn(&Url) -> bool),
+}
+
+impl Default for RedirectPolicy {
+    fn default() -> RedirectPolicy {
+        RedirectPolicy::FollowAll
+    }
+}
+
+fn get_host_and_port(url: &Url) -> HttpResult<(String, Port)> {
+    let host = match url.serialize_host() {
+        Some(host) => host,
+        None => return Err(HttpUriError(UrlError::EmptyHost))
+    };
+    debug!("host={}", host);
+    let port = match url.port_or_default() {
+        Some(port) => port,
+        None => return Err(HttpUriError(UrlError::InvalidPort))
+    };
+    debug!("port={}", port);
+    Ok((host, port))
+}
+
+#[cfg(test)]
+mod tests {
+    use header::common::Server;
+    use super::{Client, RedirectPolicy};
+    use url::Url;
+
+    mock_connector!(MockRedirectPolicy {
+        "http://127.0.0.1" =>       "HTTP/1.1 301 Redirect\r\n\
+                                     Location: http://127.0.0.2\r\n\
+                                     Server: mock1\r\n\
+                                     \r\n\
+                                    "
+        "http://127.0.0.2" =>       "HTTP/1.1 302 Found\r\n\
+                                     Location: https://127.0.0.3\r\n\
+                                     Server: mock2\r\n\
+                                     \r\n\
+                                    "
+        "https://127.0.0.3" =>      "HTTP/1.1 200 OK\r\n\
+                                     Server: mock3\r\n\
+                                     \r\n\
+                                    "
+    })
+
+    #[test]
+    fn test_redirect_followall() {
+        let mut client = Client::with_connector(MockRedirectPolicy);
+        client.set_redirect_policy(RedirectPolicy::FollowAll);
+
+        let res = client.get("http://127.0.0.1").send().unwrap();
+        assert_eq!(res.headers.get(), Some(&Server("mock3".into_string())));
+    }
+
+    #[test]
+    fn test_redirect_dontfollow() {
+        let mut client = Client::with_connector(MockRedirectPolicy);
+        client.set_redirect_policy(RedirectPolicy::FollowNone);
+        let res = client.get("http://127.0.0.1").send().unwrap();
+        assert_eq!(res.headers.get(), Some(&Server("mock1".into_string())));
+    }
+
+    #[test]
+    fn test_redirect_followif() {
+        fn follow_if(url: &Url) -> bool {
+            !url.serialize()[].contains("127.0.0.3")
+        }
+        let mut client = Client::with_connector(MockRedirectPolicy);
+        client.set_redirect_policy(RedirectPolicy::FollowIf(follow_if));
+        let res = client.get("http://127.0.0.1").send().unwrap();
+        assert_eq!(res.headers.get(), Some(&Server("mock2".into_string())));
+    }
+
+}

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -8,12 +8,11 @@ use method::Method::{Get, Post, Delete, Put, Patch, Head, Options};
 use header::Headers;
 use header::common::{mod, Host};
 use net::{NetworkStream, NetworkConnector, HttpConnector, Fresh, Streaming};
-use HttpError::HttpUriError;
 use http::{HttpWriter, LINE_ENDING};
 use http::HttpWriter::{ThroughWriter, ChunkedWriter, SizedWriter, EmptyWriter};
 use version;
 use HttpResult;
-use client::Response;
+use client::{Response, get_host_and_port};
 
 
 /// A client request to a remote server.
@@ -42,23 +41,14 @@ impl<W> Request<W> {
 impl Request<Fresh> {
     /// Create a new client request.
     pub fn new(method: method::Method, url: Url) -> HttpResult<Request<Fresh>> {
-        let mut conn = HttpConnector;
+        let mut conn = HttpConnector(None);
         Request::with_connector(method, url, &mut conn)
     }
 
     /// Create a new client request with a specific underlying NetworkStream.
     pub fn with_connector<C: NetworkConnector<S>, S: NetworkStream>(method: method::Method, url: Url, connector: &mut C) -> HttpResult<Request<Fresh>> {
         debug!("{} {}", method, url);
-        let host = match url.serialize_host() {
-            Some(host) => host,
-            None => return Err(HttpUriError)
-        };
-        debug!("host={}", host);
-        let port = match url.port_or_default() {
-            Some(port) => port,
-            None => return Err(HttpUriError)
-        };
-        debug!("port={}", port);
+        let (host, port) = try!(get_host_and_port(&url));
 
         let stream: S = try!(connector.connect(host[], port, &*url.scheme));
         let stream = ThroughWriter(BufferedWriter::new(box stream as Box<NetworkStream + Send>));
@@ -80,30 +70,37 @@ impl Request<Fresh> {
 
     /// Create a new GET request.
     #[inline]
+    #[deprecated = "use hyper::Client"]
     pub fn get(url: Url) -> HttpResult<Request<Fresh>> { Request::new(Get, url) }
 
     /// Create a new POST request.
     #[inline]
+    #[deprecated = "use hyper::Client"]
     pub fn post(url: Url) -> HttpResult<Request<Fresh>> { Request::new(Post, url) }
 
     /// Create a new DELETE request.
     #[inline]
+    #[deprecated = "use hyper::Client"]
     pub fn delete(url: Url) -> HttpResult<Request<Fresh>> { Request::new(Delete, url) }
 
     /// Create a new PUT request.
     #[inline]
+    #[deprecated = "use hyper::Client"]
     pub fn put(url: Url) -> HttpResult<Request<Fresh>> { Request::new(Put, url) }
 
     /// Create a new PATCH request.
     #[inline]
+    #[deprecated = "use hyper::Client"]
     pub fn patch(url: Url) -> HttpResult<Request<Fresh>> { Request::new(Patch, url) }
 
     /// Create a new HEAD request.
     #[inline]
+    #[deprecated = "use hyper::Client"]
     pub fn head(url: Url) -> HttpResult<Request<Fresh>> { Request::new(Head, url) }
 
     /// Create a new OPTIONS request.
     #[inline]
+    #[deprecated = "use hyper::Client"]
     pub fn options(url: Url) -> HttpResult<Request<Fresh>> { Request::new(Options, url) }
 
     /// Consume a Fresh Request, writing the headers and method,

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -38,7 +38,7 @@ impl Response {
         debug!("{} {}", version, status);
 
         let headers = try!(header::Headers::from_raw(&mut stream));
-        debug!("{}", headers);
+        debug!("Headers: [\n{}]", headers);
 
         let body = if headers.has::<TransferEncoding>() {
             match headers.get::<TransferEncoding>() {

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -30,7 +30,7 @@ pub mod common;
 ///
 /// This trait represents the construction and identification of headers,
 /// and contains trait-object unsafe methods.
-pub trait Header: Any + Send + Sync {
+pub trait Header: Clone + Any + Send + Sync {
     /// Returns the name of the header field this belongs to.
     ///
     /// The market `Option` is to hint to the type system which implementation

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -105,8 +105,8 @@ impl<L: NetworkListener<S, A>, S: NetworkStream, A: NetworkAcceptor<S>> Server<L
                                 };
 
                                 keep_alive = match (req.version, req.headers.get::<Connection>()) {
-                                    (Http10, Some(conn)) if !conn.0.contains(&KeepAlive) => false,
-                                    (Http11, Some(conn)) if conn.0.contains(&Close)  => false,
+                                    (Http10, Some(conn)) if !conn.contains(&KeepAlive) => false,
+                                    (Http11, Some(conn)) if conn.contains(&Close)  => false,
                                     _ => true
                                 };
                                 res.version = req.version;


### PR DESCRIPTION
- Includes ergonomic traits like IntoUrl and IntoBody, allowing easy
  usage.
- Client can have a RedirectPolicy.
- Client can have a SslVerifier.

Updated benchmarks for client. (Disabled rust-http client bench since it
hangs.)

Closes #62 
