### PR TITLE
lints!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: rust
 
 script:
-    - cargo build
-    - cargo test
+    - cargo build --features hyperlint
+    - cargo test --features hyperlint
     - cargo bench --no-run
 
 after_success: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ git = "https://github.com/rust-lang/time"
 
 [dependencies.mucell]
 git = "https://github.com/chris-morgan/mucell"
+
+[dependencies.hyperlint]
+path = "./hyperlint"
+optional = true

--- a/hyperlint/Cargo.toml
+++ b/hyperlint/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+
+name = "hyperlint"
+version = "0.0.1"
+authors = ["Sean McArthur <sean.monstar@gmail.com>"]
+
+[[lib]]
+name = "hyperlint"
+crate-type = ["dylib"]

--- a/hyperlint/src/lib.rs
+++ b/hyperlint/src/lib.rs
@@ -1,0 +1,95 @@
+#![feature(phase, plugin_registrar)]
+
+#[phase(plugin, link)]
+extern crate rustc;
+#[phase(plugin, link)]
+extern crate syntax;
+
+use rustc::lint::{Context, LintPassObject, LintPass, LintArray};
+use rustc::middle::ty::{expr_ty, ty_str, ty_ptr, ty_rptr, Ty};
+use rustc::plugin::Registry;
+use syntax::ast;
+use syntax::attr::AttrMetaMethods;
+
+#[plugin_registrar]
+pub fn register(reg: &mut Registry) {
+    reg.register_lint_pass(box Glob as LintPassObject);
+    reg.register_lint_pass(box StrToString as LintPassObject);
+}
+
+declare_lint!(GLOB, Warn, "Warn if insane glob usage is not marked")
+
+struct Glob;
+
+impl LintPass for Glob {
+
+    fn get_lints(&self) -> LintArray {
+        lint_array!(GLOB)
+    }
+
+    fn check_view_item(&mut self, cx: &Context, view_item: &ast::ViewItem) {
+        match view_item.node {
+            ast::ViewItemUse(ref view_path) => {
+                match view_path.node {
+                    ast::ViewPathGlob(ast::Path { ref segments, .. }, _) => {
+                        let path = str_path(&**segments);
+                        if path == "std::prelude"
+                            || path.starts_with("self::")
+                            || has_glob_attr(view_item) {
+                            // all's well
+                        } else {
+                            let m = "Insane glob usage requires #[glob = \"explanation\"]";
+                            cx.span_lint(GLOB, view_item.span, m);
+                        }
+                    }
+                    _ => ()
+                }
+            },
+            _ => ()
+        }
+
+        fn str_path(segments: &[ast::PathSegment]) -> String {
+            segments.iter().map(|s| s.identifier.as_str()).collect::<Vec<&str>>().connect("::")
+        }
+
+        fn has_glob_attr(view_item: &ast::ViewItem) -> bool {
+            view_item.attrs.iter().any(|a|  a.check_name("glob") && a.value_str().is_some())
+        }
+
+    }
+}
+
+declare_lint!(STR_TO_STRING, Warn, "Warn when a String could use into_string() instead of to_string()")
+
+struct StrToString;
+
+impl LintPass for StrToString {
+    fn get_lints(&self) -> LintArray {
+        lint_array!(STR_TO_STRING)
+    }
+
+    fn check_expr(&mut self, cx: &Context, expr: &ast::Expr) {
+        match expr.node {
+            ast::ExprMethodCall(ref method, _, ref args)
+                if method.node.as_str() == "to_string"
+                && is_str(cx, &*args[0]) => {
+                cx.span_lint(STR_TO_STRING, expr.span, "str.into_string() is faster");
+            },
+            _ => ()
+        }
+
+        fn is_str(cx: &Context, expr: &ast::Expr) -> bool {
+            fn walk_ty<'t>(ty: Ty<'t>) -> Ty<'t> {
+                //println!("{}: -> {}", depth, ty);
+                match ty.sty {
+                    ty_ptr(ref tm) | ty_rptr(_, ref tm) => walk_ty(tm.ty),
+                    _ => ty
+                }
+            }
+            match walk_ty(expr_ty(cx.tcx, expr)).sty {
+                ty_str => true,
+                _ => false
+            }
+        }
+    }
+}

--- a/src/header/common/allow.rs
+++ b/src/header/common/allow.rs
@@ -38,7 +38,7 @@ mod tests {
         let mut allow: Option<Allow>;
 
         allow = Header::parse_header([b"OPTIONS,GET,PUT,POST,DELETE,HEAD,TRACE,CONNECT,PATCH,fOObAr".to_vec()].as_slice());
-        assert_eq!(allow, Some(Allow(vec![Options, Get, Put, Post, Delete, Head, Trace, Connect, Patch, Extension("fOObAr".to_string())])));
+        assert_eq!(allow, Some(Allow(vec![Options, Get, Put, Post, Delete, Head, Trace, Connect, Patch, Extension("fOObAr".into_string())])));
 
         allow = Header::parse_header([b"".to_vec()].as_slice());
         assert_eq!(allow, Some(Allow(Vec::<Method>::new())));

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -149,7 +149,7 @@ mod tests {
     fn test_raw_auth() {
         let mut headers = Headers::new();
         headers.set(Authorization("foo bar baz".into_string()));
-        assert_eq!(headers.to_string(), "Authorization: foo bar baz\r\n".to_string());
+        assert_eq!(headers.to_string(), "Authorization: foo bar baz\r\n".into_string());
     }
 
     #[test]
@@ -168,8 +168,8 @@ mod tests {
     #[test]
     fn test_basic_auth_no_password() {
         let mut headers = Headers::new();
-        headers.set(Authorization(Basic { username: "Aladdin".to_string(), password: None }));
-        assert_eq!(headers.to_string(), "Authorization: Basic QWxhZGRpbjo=\r\n".to_string());
+        headers.set(Authorization(Basic { username: "Aladdin".into_string(), password: None }));
+        assert_eq!(headers.to_string(), "Authorization: Basic QWxhZGRpbjo=\r\n".into_string());
     }
 
     #[test]
@@ -177,7 +177,7 @@ mod tests {
         let headers = Headers::from_raw(&mut mem("Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==\r\n\r\n")).unwrap();
         let auth = headers.get::<Authorization<Basic>>().unwrap();
         assert_eq!(auth.0.username[], "Aladdin");
-        assert_eq!(auth.0.password, Some("open sesame".to_string()));
+        assert_eq!(auth.0.password, Some("open sesame".into_string()));
     }
 
     #[test]
@@ -185,7 +185,7 @@ mod tests {
         let headers = Headers::from_raw(&mut mem("Authorization: Basic QWxhZGRpbjo=\r\n\r\n")).unwrap();
         let auth = headers.get::<Authorization<Basic>>().unwrap();
         assert_eq!(auth.0.username.as_slice(), "Aladdin");
-        assert_eq!(auth.0.password, Some("".to_string()));
+        assert_eq!(auth.0.password, Some("".into_string()));
     }
 
 }

--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -126,6 +126,7 @@ impl FromStr for CacheDirective {
 #[cfg(test)]
 mod tests {
     use header::Header;
+    #[cfg_attr(feature = "hyperlint", glob = "tests")]
     use super::*;
 
     #[test]
@@ -151,8 +152,8 @@ mod tests {
     #[test]
     fn test_parse_extension() {
         let cache = Header::parse_header(&[b"foo, bar=baz".to_vec()]);
-        assert_eq!(cache, Some(CacheControl(vec![CacheDirective::Extension("foo".to_string(), None),
-                                                 CacheDirective::Extension("bar".to_string(), Some("baz".to_string()))])))
+        assert_eq!(cache, Some(CacheControl(vec![CacheDirective::Extension("foo".into_string(), None),
+                                                 CacheDirective::Extension("bar".into_string(), Some("baz".into_string()))])))
     }
 
     #[test]

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -34,7 +34,7 @@ impl FromStr for ConnectionOption {
         match s {
             "keep-alive" => Some(KeepAlive),
             "close" => Some(Close),
-            s => Some(ConnectionHeader(s.to_string()))
+            s => Some(ConnectionHeader(s.into_string()))
         }
     }
 }

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -83,8 +83,8 @@ impl Cookies {
 #[test]
 fn test_parse() {
     let h = Header::parse_header([b"foo=bar; baz=quux".to_vec()][]);
-    let c1 = Cookie::new("foo".to_string(), "bar".to_string());
-    let c2 = Cookie::new("baz".to_string(), "quux".to_string());
+    let c1 = Cookie::new("foo".into_string(), "bar".into_string());
+    let c2 = Cookie::new("baz".into_string(), "quux".into_string());
     assert_eq!(h, Some(Cookies(vec![c1, c2])));
 }
 
@@ -92,10 +92,10 @@ fn test_parse() {
 fn test_fmt() {
     use header::Headers;
 
-    let mut cookie = Cookie::new("foo".to_string(), "bar".to_string());
+    let mut cookie = Cookie::new("foo".into_string(), "bar".into_string());
     cookie.httponly = true;
-    cookie.path = Some("/p".to_string());
-    let cookies = Cookies(vec![cookie, Cookie::new("baz".to_string(), "quux".to_string())]);
+    cookie.path = Some("/p".into_string());
+    let cookies = Cookies(vec![cookie, Cookie::new("baz".into_string(), "quux".into_string())]);
     let mut headers = Headers::new();
     headers.set(cookies);
 
@@ -104,7 +104,7 @@ fn test_fmt() {
 
 #[test]
 fn cookie_jar() {
-    let cookie = Cookie::new("foo".to_string(), "bar".to_string());
+    let cookie = Cookie::new("foo".into_string(), "bar".into_string());
     let cookies = Cookies(vec![cookie]);
     let jar = cookies.to_cookie_jar(&[]);
     let new_cookies = Cookies::from_cookie_jar(&jar);

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -32,6 +32,7 @@ macro_rules! bench_header(
         #[cfg(test)]
         mod $name {
             use test::Bencher;
+            #[cfg_attr(feature = "hyperlint", glob = "benchmarks")]
             use super::*;
 
             use header::{Header, HeaderFormatter};

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -77,7 +77,7 @@ impl SetCookie {
 #[test]
 fn test_parse() {
     let h = Header::parse_header([b"foo=bar; HttpOnly".to_vec()][]);
-    let mut c1 = Cookie::new("foo".to_string(), "bar".to_string());
+    let mut c1 = Cookie::new("foo".into_string(), "bar".into_string());
     c1.httponly = true;
 
     assert_eq!(h, Some(SetCookie(vec![c1])));
@@ -87,10 +87,10 @@ fn test_parse() {
 fn test_fmt() {
     use header::Headers;
 
-    let mut cookie = Cookie::new("foo".to_string(), "bar".to_string());
+    let mut cookie = Cookie::new("foo".into_string(), "bar".into_string());
     cookie.httponly = true;
-    cookie.path = Some("/p".to_string());
-    let cookies = SetCookie(vec![cookie, Cookie::new("baz".to_string(), "quux".to_string())]);
+    cookie.path = Some("/p".into_string());
+    let cookies = SetCookie(vec![cookie, Cookie::new("baz".into_string(), "quux".into_string())]);
     let mut headers = Headers::new();
     headers.set(cookies);
 
@@ -100,7 +100,7 @@ fn test_fmt() {
 #[test]
 fn cookie_jar() {
     let jar = CookieJar::new("secret".as_bytes());
-    let cookie = Cookie::new("foo".to_string(), "bar".to_string());
+    let cookie = Cookie::new("foo".into_string(), "bar".into_string());
     jar.encrypted().add(cookie);
 
     let cookies = SetCookie::from_cookie_jar(&jar);

--- a/src/header/common/transfer_encoding.rs
+++ b/src/header/common/transfer_encoding.rs
@@ -66,7 +66,7 @@ impl FromStr for Encoding {
             "deflate" => Some(Deflate),
             "gzip" => Some(Gzip),
             "compress" => Some(Compress),
-            _ => Some(EncodingExt(s.to_string()))
+            _ => Some(EncodingExt(s.into_string()))
         }
     }
 }

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -24,7 +24,7 @@ impl FromStr for Protocol {
     fn from_str(s: &str) -> Option<Protocol> {
         match s {
             "websocket" => Some(WebSocket),
-            s => Some(ProtocolExt(s.to_string()))
+            s => Some(ProtocolExt(s.into_string()))
         }
     }
 }

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -662,7 +662,7 @@ mod tests {
             assert!(header.is::<ContentLength>());
             assert_eq!(header.name(), Header::header_name(None::<ContentLength>));
             assert_eq!(header.value(), Some(&ContentLength(11)));
-            assert_eq!(header.value_string(), "11".to_string());
+            assert_eq!(header.value_string(), "11".into_string());
         }
     }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -437,7 +437,7 @@ pub fn read_uri<R: Reader>(stream: &mut R) -> HttpResult<uri::RequestUri> {
             }
         }
     } else {
-        let mut temp = "http://".to_string();
+        let mut temp = "http://".into_string();
         temp.push_str(s.as_slice());
         match Url::parse(temp.as_slice()) {
             Ok(_u) => {
@@ -729,8 +729,8 @@ mod tests {
         read("CONNECT /", Ok(method::Method::Connect));
         read("TRACE /", Ok(method::Method::Trace));
         read("PATCH /", Ok(method::Method::Patch));
-        read("FOO /", Ok(method::Method::Extension("FOO".to_string())));
-        read("akemi!~#HOMURA /", Ok(method::Method::Extension("akemi!~#HOMURA".to_string())));
+        read("FOO /", Ok(method::Method::Extension("FOO".into_string())));
+        read("akemi!~#HOMURA /", Ok(method::Method::Extension("akemi!~#HOMURA".into_string())));
         read(" ", Err(HttpMethodError));
     }
 
@@ -742,8 +742,8 @@ mod tests {
 
         read("* ", Ok(Star));
         read("http://hyper.rs/ ", Ok(AbsoluteUri(Url::parse("http://hyper.rs/").unwrap())));
-        read("hyper.rs ", Ok(Authority("hyper.rs".to_string())));
-        read("/ ", Ok(AbsolutePath("/".to_string())));
+        read("hyper.rs ", Ok(Authority("hyper.rs".into_string())));
+        read("/ ", Ok(AbsolutePath("/".into_string())));
     }
 
     #[test]
@@ -778,11 +778,11 @@ mod tests {
 
         read("200 OK\r\n", Ok(RawStatus(200, Borrowed("OK"))));
         read("404 Not Found\r\n", Ok(RawStatus(404, Borrowed("Not Found"))));
-        read("200 crazy pants\r\n", Ok(RawStatus(200, Owned("crazy pants".to_string()))));
-        read("301 Moved Permanently\r\n", Ok(RawStatus(301, Owned("Moved Permanently".to_string()))));
+        read("200 crazy pants\r\n", Ok(RawStatus(200, Owned("crazy pants".into_string()))));
+        read("301 Moved Permanently\r\n", Ok(RawStatus(301, Owned("Moved Permanently".into_string()))));
         read_ignore_string("301 Unreasonably long header that should not happen, \
                            but some men just want to watch the world burn\r\n",
-             Ok(RawStatus(301, Owned("Ignored".to_string()))));
+             Ok(RawStatus(301, Owned("Ignored".into_string()))));
     }
 
     #[test]
@@ -791,7 +791,7 @@ mod tests {
             assert_eq!(read_header(&mut mem(s)), result);
         }
 
-        read("Host: rust-lang.org\r\n", Ok(Some(("Host".to_string(),
+        read("Host: rust-lang.org\r\n", Ok(Some(("Host".into_string(),
                                                 "rust-lang.org".as_bytes().to_vec()))));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,8 @@ extern crate "unsafe-any" as uany;
 extern crate cookie;
 extern crate mucell;
 
+#[cfg(feature = "hyperlint")] #[phase(plugin)] extern crate hyperlint;
+
 pub use std::io::net::ip::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr, Port};
 pub use mimewrapper::mime;
 pub use url::Url;

--- a/src/method.rs
+++ b/src/method.rs
@@ -82,7 +82,7 @@ impl FromStr for Method {
                 "TRACE" => Trace,
                 "CONNECT" => Connect,
                 "PATCH" => Patch,
-                _ => Extension(s.to_string())
+                _ => Extension(s.into_string())
             })
         }
     }
@@ -128,15 +128,15 @@ mod tests {
     #[test]
     fn test_from_str() {
         assert_eq!(Some(Get), FromStr::from_str("GET"));
-        assert_eq!(Some(Extension("MOVE".to_string())),
+        assert_eq!(Some(Extension("MOVE".into_string())),
                    FromStr::from_str("MOVE"));
     }
 
     #[test]
     fn test_fmt() {
-        assert_eq!("GET".to_string(), format!("{}", Get));
-        assert_eq!("MOVE".to_string(),
-                   format!("{}", Extension("MOVE".to_string())));
+        assert_eq!("GET".into_string(), format!("{}", Get));
+        assert_eq!("MOVE".into_string(),
+                   format!("{}", Extension("MOVE".into_string())));
     }
 
     #[test]


### PR DESCRIPTION
Specifically, this will prevent 2 code smells:
1. glob: `use foo::*` is by default denied. `use self::sub::*` is fine, as way to uplift sub modules. For uses of bad globs, they must be covered with a `#[glob = "explanation"]` attribute.
2. str_to_string: Micro benchmarks show it's 5x slower than `&str.into_string()`. So this lint denies such usage.
