### PR TITLE
Fixed compilation for Rust master.

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -315,7 +315,7 @@ impl<'a> IntoUrl for &'a str {
 }
 
 /// Behavior regarding how to handle redirects within a Client.
-#[deriving(Copy, Clone)]
+#[deriving(Copy)]
 pub enum RedirectPolicy {
     /// Don't follow any redirects.
     FollowNone,
@@ -323,6 +323,13 @@ pub enum RedirectPolicy {
     FollowAll,
     /// Follow a redirect if the contained function returns true.
     FollowIf(fn(&Url) -> bool),
+}
+
+// This is a hack because of upstream typesystem issues. 
+impl Clone for RedirectPolicy {
+    fn clone(&self) -> RedirectPolicy {
+        *self 
+    }
 }
 
 impl Default for RedirectPolicy {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,7 +3,7 @@ use std::io::{Listener, EndOfFile, BufferedReader, BufferedWriter};
 use std::io::net::ip::{IpAddr, Port, SocketAddr};
 use std::os;
 use std::sync::{Arc, TaskPool};
-use std::task::TaskBuilder;
+use std::thread::Builder;
 
 
 pub use self::request::Request;
@@ -68,7 +68,7 @@ impl<L: NetworkListener<S, A>, S: NetworkStream, A: NetworkAcceptor<S>> Server<L
         let acceptor = try!(listener.listen());
 
         let mut captured = acceptor.clone();
-        TaskBuilder::new().named("hyper acceptor").spawn(move || {
+        Builder::new().name("hyper acceptor".into_string()).spawn(move || {
             let handler = Arc::new(handler);
             debug!("threads = {}", threads);
             let pool = TaskPool::new(threads);
@@ -126,7 +126,7 @@ impl<L: NetworkListener<S, A>, S: NetworkStream, A: NetworkAcceptor<S>> Server<L
                     }
                 }
             }
-        });
+        }).detach();
 
         Ok(Listening {
             acceptor: acceptor,


### PR DESCRIPTION
This fixes compilation for the latest Rust nightly. Changes include an explicit implementation of Clone for RedirectPolicy because of an upstream bug preventing a generic implementation of Clone for all function types, and a switch from TaskBuilder to Builder, as the former is now deprecated.
