### PR TITLE
Server programs no longer exit immediately.

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -52,6 +52,7 @@ fn echo(mut req: Request, mut res: Response) {
 
 fn main() {
     let server = Server::http(Ipv4Addr(127, 0, 0, 1), 1337);
-    server.listen(echo).unwrap();
+    let mut listening = server.listen(echo).unwrap();
     println!("Listening on http://127.0.0.1:1337");
+    listening.await();
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,7 +3,7 @@ use std::io::{Listener, EndOfFile, BufferedReader, BufferedWriter};
 use std::io::net::ip::{IpAddr, Port, SocketAddr};
 use std::os;
 use std::sync::{Arc, TaskPool};
-use std::thread::Builder;
+use std::thread::{Builder, JoinGuard};
 
 
 pub use self::request::Request;
@@ -68,7 +68,7 @@ impl<L: NetworkListener<S, A>, S: NetworkStream, A: NetworkAcceptor<S>> Server<L
         let acceptor = try!(listener.listen());
 
         let mut captured = acceptor.clone();
-        Builder::new().name("hyper acceptor".into_string()).spawn(move || {
+        let guard = Builder::new().name("hyper acceptor".into_string()).spawn(move || {
             let handler = Arc::new(handler);
             debug!("threads = {}", threads);
             let pool = TaskPool::new(threads);
@@ -126,10 +126,11 @@ impl<L: NetworkListener<S, A>, S: NetworkStream, A: NetworkAcceptor<S>> Server<L
                     }
                 }
             }
-        }).detach();
+        });
 
         Ok(Listening {
             acceptor: acceptor,
+            guard: Some(guard),
             socket: socket,
         })
     }
@@ -149,11 +150,19 @@ impl<L: NetworkListener<S, A>, S: NetworkStream, A: NetworkAcceptor<S>> Server<L
 /// A listening server, which can later be closed.
 pub struct Listening<A = HttpAcceptor> {
     acceptor: A,
+    guard: Option<JoinGuard<()>>,
     /// The socket addresses that the server is bound to.
     pub socket: SocketAddr,
 }
 
 impl<A: NetworkAcceptor<S>, S: NetworkStream> Listening<A> {
+    /// Causes the current thread to wait for this listening to complete.
+    pub fn await(&mut self) {
+        if let Some(guard) = self.guard.take() {
+            let _ = guard.join();
+        }
+    }
+
     /// Stop the server from listening to its socket address.
     pub fn close(&mut self) -> HttpResult<()> {
         debug!("closing server");


### PR DESCRIPTION
This change works by holding the JoinGuard inside of the Listening object produced by Server::listen(...). It's interesting to note the following behaviors:

The following prints the listening line and explicitly waits while the server is open.

``` rust
fn main() {
    let server = Server::http(Ipv4Addr(127, 0, 0, 1), 1337);
    let mut listening = server.listen(echo).unwrap();
    println!("Listening on http://127.0.0.1:1337");
    listening.await();
    // nothing here will execute until after the server is closed.
}
```

The following prints the listening line and implicitly waits while the server is open.

``` rust
fn main() {
    let server = Server::http(Ipv4Addr(127, 0, 0, 1), 1337);
    let listening = server.listen(echo).unwrap();
    println!("Listening on http://127.0.0.1:1337");
    // note, await is omitted, but the result of listen is named, thus staying in scope.
    // any additional lines of code will execute.
}
```

Both of the following ~~exit immediately~~ join before printing (for the same reason).

``` rust
fn main() {
    let server = Server::http(Ipv4Addr(127, 0, 0, 1), 1337);
    let _ = server.listen(echo).unwrap();
    println!("Listening on http://127.0.0.1:1337");
}
```

``` rust
fn main() {
    let server = Server::http(Ipv4Addr(127, 0, 0, 1), 1337);
    server.listen(echo).unwrap();
    println!("Listening on http://127.0.0.1:1337");
}
```
