### PR TITLE
Fixes from_one_comma_delimited, no more split at space

### DIFF
--- a/src/header/common/util.rs
+++ b/src/header/common/util.rs
@@ -31,7 +31,8 @@ pub fn from_one_comma_delimited<T: FromStr>(raw: &[u8]) -> Option<Vec<T>> {
     match from_utf8(raw) {
         Ok(s) => {
             Some(s.as_slice()
-                 .split([',', ' '].as_slice())
+                 .split(',')
+                 .map(|x| x.trim())
                  .filter_map(FromStr::from_str)
                  .collect())
         }


### PR DESCRIPTION
Before from_one_comma_delimited split at ",", and " " this made it unusable for the Accept-\* headers since their fields may contain whitespace.
