### PR TITLE
Changed deprecated trim_chars to trim_matches

### DIFF
--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -109,7 +109,7 @@ impl FromStr for CacheDirective {
             "proxy-revalidate" => Some(ProxyRevalidate),
             "" => None,
             _ => match s.find('=') {
-                Some(idx) if idx+1 < s.len() => match (s[..idx], s[idx+1..].trim_chars('"')) {
+                Some(idx) if idx+1 < s.len() => match (s[..idx], s[idx+1..].trim_matches('"')) {
                     ("max-age" , secs) => secs.parse().map(MaxAge),
                     ("max-stale", secs) => secs.parse().map(MaxStale),
                     ("min-fresh", secs) => secs.parse().map(MinFresh),


### PR DESCRIPTION
trim_chars is deprecated and won't build with default settings. Changed to trim_matches which is a non-deprecated version of trim_chars.
I'm using `rustc 0.13.0-dev (71123902e 2014-12-29 20:19:53 +0000)`
