### PR TITLE
Use renamed unsafe_get and concat_vec methods.

### DIFF
--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -26,7 +26,7 @@ impl<S: Scheme> Header for Authorization<S> {
 
     fn parse_header(raw: &[Vec<u8>]) -> Option<Authorization<S>> {
         if raw.len() == 1 {
-            match (from_utf8(unsafe { raw[].unsafe_get(0)[] }), Scheme::scheme(None::<S>)) {
+            match (from_utf8(unsafe { raw[].get_unchecked(0)[] }), Scheme::scheme(None::<S>)) {
                 (Ok(header), Some(scheme))
                     if header.starts_with(scheme) && header.len() > scheme.len() + 1 => {
                     header[scheme.len() + 1..].parse::<S>().map(|s| Authorization(s))

--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -18,7 +18,7 @@ impl Header for CacheControl {
         let directives = raw.iter()
             .filter_map(|line| from_one_comma_delimited(line[]))
             .collect::<Vec<Vec<CacheDirective>>>()
-            .concat_vec();
+            .concat();
         if directives.len() > 0 {
             Some(CacheControl(directives))
         } else {

--- a/src/header/common/util.rs
+++ b/src/header/common/util.rs
@@ -10,7 +10,7 @@ pub fn from_one_raw_str<T: FromStr>(raw: &[Vec<u8>]) -> Option<T> {
         return None;
     }
     // we JUST checked that raw.len() == 1, so raw[0] WILL exist.
-    match from_utf8(unsafe { raw[].unsafe_get(0)[] }) {
+    match from_utf8(unsafe { raw[].get_unchecked(0)[] }) {
         Ok(s) => FromStr::from_str(s),
         Err(_) => None
     }
@@ -23,7 +23,7 @@ pub fn from_comma_delimited<T: FromStr>(raw: &[Vec<u8>]) -> Option<Vec<T>> {
         return None;
     }
     // we JUST checked that raw.len() == 1, so raw[0] WILL exist.
-    from_one_comma_delimited(unsafe { raw.as_slice().unsafe_get(0).as_slice() })
+    from_one_comma_delimited(unsafe { raw.as_slice().get_unchecked(0).as_slice() })
 }
 
 /// Reads a comma-delimited raw string into a Vec.


### PR DESCRIPTION
Changed calls to unsafe_get to use get_unchecked and calls to concat_vec
to use concat to avoid deprecation lints.

These methods were renamed by commits [4f863a3](https://github.com/rust-lang/rust/commit/4f863a338e0a7c33f81a8ac138103f1a0e8b33c5) and [e91d810](https://github.com/rust-lang/rust/commit/e91d810b9b36d6bb163970cd0e8bbf4692f704bb) in rust-lang/rust