### PR TITLE
`mark_dead` NetworkStream method to support client keep-alives.

### DIFF
--- a/benches/client_mock_tcp.rs
+++ b/benches/client_mock_tcp.rs
@@ -87,6 +87,8 @@ impl net::NetworkStream for MockStream {
     fn peer_name(&mut self) -> IoResult<SocketAddr> {
         Ok(from_str("127.0.0.1:1337").unwrap())
     }
+    fn mark_dead(&mut self) {
+    }
 }
 
 struct MockConnector;

--- a/benches/client_mock_tcp.rs
+++ b/benches/client_mock_tcp.rs
@@ -87,8 +87,7 @@ impl net::NetworkStream for MockStream {
     fn peer_name(&mut self) -> IoResult<SocketAddr> {
         Ok(from_str("127.0.0.1:1337").unwrap())
     }
-    fn mark_dead(&mut self) {
-    }
+    fn mark_dead(&mut self) {}
 }
 
 struct MockConnector;

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -43,8 +43,8 @@ impl Response {
 
         let keep_alive = match headers.get::<Connection>() {
             Some(&Connection(ref connection_options)) =>
-                connection_options.contains(&ConnectionOption::KeepAlive),
-            None => false,
+                !connection_options.contains(&ConnectionOption::Close),
+            None => true,
         };
         if !keep_alive {
             stream.get_mut().mark_dead()

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -3,7 +3,8 @@ use std::num::FromPrimitive;
 use std::io::{BufferedReader, IoResult};
 
 use header;
-use header::common::{ContentLength, TransferEncoding};
+use header::common::{Connection, ContentLength, TransferEncoding};
+use header::common::connection::{ConnectionOption};
 use header::common::transfer_encoding::Encoding::Chunked;
 use net::{NetworkStream, HttpStream};
 use http::{read_status_line, HttpReader, RawStatus};
@@ -39,6 +40,15 @@ impl Response {
 
         let headers = try!(header::Headers::from_raw(&mut stream));
         debug!("Headers: [\n{}]", headers);
+
+        let keep_alive = match headers.get::<Connection>() {
+            Some(&Connection(ref connection_options)) =>
+                connection_options.contains(&ConnectionOption::KeepAlive),
+            None => false,
+        };
+        if !keep_alive {
+            stream.get_mut().mark_dead()
+        }
 
         let body = if headers.has::<TransferEncoding>() {
             match headers.get::<TransferEncoding>() {

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -26,7 +26,7 @@ impl<S: Scheme> Header for Authorization<S> {
 
     fn parse_header(raw: &[Vec<u8>]) -> Option<Authorization<S>> {
         if raw.len() == 1 {
-            match (from_utf8(unsafe { raw[].unsafe_get(0)[] }), Scheme::scheme(None::<S>)) {
+            match (from_utf8(unsafe { raw[].get_unchecked(0)[] }), Scheme::scheme(None::<S>)) {
                 (Ok(header), Some(scheme))
                     if header.starts_with(scheme) && header.len() > scheme.len() + 1 => {
                     header[scheme.len() + 1..].parse::<S>().map(|s| Authorization(s))

--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -18,7 +18,7 @@ impl Header for CacheControl {
         let directives = raw.iter()
             .filter_map(|line| from_one_comma_delimited(line[]))
             .collect::<Vec<Vec<CacheDirective>>>()
-            .concat_vec();
+            .concat();
         if directives.len() > 0 {
             Some(CacheControl(directives))
         } else {

--- a/src/header/common/util.rs
+++ b/src/header/common/util.rs
@@ -10,7 +10,7 @@ pub fn from_one_raw_str<T: FromStr>(raw: &[Vec<u8>]) -> Option<T> {
         return None;
     }
     // we JUST checked that raw.len() == 1, so raw[0] WILL exist.
-    match from_utf8(unsafe { raw[].unsafe_get(0)[] }) {
+    match from_utf8(unsafe { raw[].get_unchecked(0)[] }) {
         Ok(s) => FromStr::from_str(s),
         Err(_) => None
     }
@@ -23,7 +23,7 @@ pub fn from_comma_delimited<T: FromStr>(raw: &[Vec<u8>]) -> Option<Vec<T>> {
         return None;
     }
     // we JUST checked that raw.len() == 1, so raw[0] WILL exist.
-    from_one_comma_delimited(unsafe { raw.as_slice().unsafe_get(0).as_slice() })
+    from_one_comma_delimited(unsafe { raw.as_slice().get_unchecked(0).as_slice() })
 }
 
 /// Reads a comma-delimited raw string into a Vec.

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -12,7 +12,7 @@ use std::intrinsics::TypeId;
 use std::raw::TraitObject;
 use std::str::{SendStr, FromStr};
 use std::collections::HashMap;
-use std::collections::hash_map::{Entries, Entry};
+use std::collections::hash_map::{Iter, Entry};
 use std::{hash, mem};
 
 use mucell::MuCell;
@@ -272,7 +272,7 @@ impl fmt::Show for Headers {
 
 /// An `Iterator` over the fields in a `Headers` map.
 pub struct HeadersItems<'a> {
-    inner: Entries<'a, CaseInsensitive, MuCell<Item>>
+    inner: Iter<'a, CaseInsensitive, MuCell<Item>>
 }
 
 impl<'a> Iterator<HeaderView<'a>> for HeadersItems<'a> {
@@ -573,7 +573,7 @@ mod tests {
                 return None;
             }
             // we JUST checked that raw.len() == 1, so raw[0] WILL exist.
-            match from_utf8(unsafe { raw.as_slice().unsafe_get(0).as_slice() }) {
+            match from_utf8(unsafe { raw.as_slice().get_unchecked(0).as_slice() }) {
                 Ok(s) => FromStr::from_str(s),
                 Err(_) => None
             }.map(|u| CrazyLength(Some(false), u))

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -65,8 +65,7 @@ impl NetworkStream for MockStream {
         Ok("127.0.0.1:1337".parse().unwrap())
     }
 
-    fn mark_dead(&mut self) {
-    }
+    fn mark_dead(&mut self) {}
 }
 
 pub struct MockConnector;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -64,6 +64,9 @@ impl NetworkStream for MockStream {
     fn peer_name(&mut self) -> IoResult<SocketAddr> {
         Ok("127.0.0.1:1337".parse().unwrap())
     }
+
+    fn mark_dead(&mut self) {
+    }
 }
 
 pub struct MockConnector;

--- a/src/net.rs
+++ b/src/net.rs
@@ -48,6 +48,10 @@ pub trait NetworkAcceptor<S: NetworkStream>: Acceptor<S> + Clone + Send {
 pub trait NetworkStream: Stream + Any + StreamClone + Send {
     /// Get the remote address of the underlying connection.
     fn peer_name(&mut self) -> IoResult<SocketAddr>;
+
+    /// During a client request/response, the remote server did not want to keep-alive
+    /// the connection, so the stream cannot be reused for subsequent requests.
+    fn mark_dead(&mut self);
 }
 
 #[doc(hidden)]
@@ -235,6 +239,9 @@ impl NetworkStream for HttpStream {
             Http(ref mut inner) => inner.peer_name(),
             Https(ref mut inner) => inner.get_mut().peer_name()
         }
+    }
+
+    fn mark_dead(&mut self) {
     }
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -241,8 +241,7 @@ impl NetworkStream for HttpStream {
         }
     }
 
-    fn mark_dead(&mut self) {
-    }
+    fn mark_dead(&mut self) {}
 }
 
 /// A connector that will produce HttpStreams.


### PR DESCRIPTION
When the `with_connector` client constructor is used, and those connections are being
retrieved from a pool, and re-used as keep-alive connections, the stream
needs some way to be notified that it is going to be closed by the
server because "Connection: close" was provided in the
response.

Then, the stream (which will be closed by the server and the next
request would fail) can be `drop()`-ped instead of being retained in the
pool.

(Also, brought current with some rust nightly changes.)