### PR TITLE
Added TLS/SSL support serverside

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -46,6 +46,10 @@ impl Server<HttpListener> {
     pub fn http(ip: IpAddr, port: Port) -> Server {
         Server::with_listener(ip, port, HttpListener::Http)
     }
+    /// Creates a new server that will handler `HttpStreams`s using a TLS connection.
+    pub fn https(ip: IpAddr, port: Port, cert: Path, key: Path) -> Server {
+        Server::with_listener(ip, port, HttpListener::Https(cert, key))
+    }
 }
 
 impl<


### PR DESCRIPTION
Try three! Thoughts on whether more stuff should be configurable? Also, sorry for being too dense to figure out the refactoring you guys were talking about on the last PR

Tested with
```
extern crate hyper;

use std::io::net::ip::Ipv4Addr;
use std::path::posix::Path;
use hyper::server::{Request, Response};

static PHRASE: &'static [u8] = b"Hello World!";

fn hello(_: Request, res: Response) {
    let mut res = res.start().unwrap();
    res.write(PHRASE).unwrap();
    res.end().unwrap();
}

fn main() {
    hyper::Server::https(Ipv4Addr(127, 0, 0, 1), 3000,
            Path::new("./cert.pem"), Path::new("./key.pem"))
            .listen(hello).unwrap();
    println!("Listening on http://127.0.0.1:3000");
}
```