### PR TITLE
refactor(headers): add header macros and add two example uses (obsolete)

### DIFF
--- a/src/header/common/accept_encoding.rs
+++ b/src/header/common/accept_encoding.rs
@@ -1,7 +1,4 @@
-use std::fmt;
-
-use header;
-use header::shared;
+use header::{self, shared};
 
 /// The `Accept-Encoding` header
 ///

--- a/src/header/common/accept_encoding.rs
+++ b/src/header/common/accept_encoding.rs
@@ -3,12 +3,6 @@ use std::fmt;
 use header;
 use header::shared;
 
-
-//#[derive(Clone, PartialEq, Show)]
-//pub struct AcceptEncoding(pub Vec<shared::QualityItem<shared::Encoding>>);
-//deref!(AcceptEncoding => Vec<shared::QualityItem<shared::Encoding>>);
-
-
 /// The `Accept-Encoding` header
 ///
 /// The `Accept-Encoding` header can be used by clients to indicate what

--- a/src/header/common/accept_encoding.rs
+++ b/src/header/common/accept_encoding.rs
@@ -3,6 +3,12 @@ use std::fmt;
 use header;
 use header::shared;
 
+
+//#[derive(Clone, PartialEq, Show)]
+//pub struct AcceptEncoding(pub Vec<shared::QualityItem<shared::Encoding>>);
+//deref!(AcceptEncoding => Vec<shared::QualityItem<shared::Encoding>>);
+
+
 /// The `Accept-Encoding` header
 ///
 /// The `Accept-Encoding` header can be used by clients to indicate what
@@ -10,23 +16,9 @@ use header::shared;
 #[derive(Clone, PartialEq, Show)]
 pub struct AcceptEncoding(pub Vec<shared::QualityItem<shared::Encoding>>);
 
-deref!(AcceptEncoding => Vec<shared::QualityItem<shared::Encoding>>);
-
-impl header::Header for AcceptEncoding {
-    fn header_name(_: Option<AcceptEncoding>) -> &'static str {
-        "AcceptEncoding"
-    }
-
-    fn parse_header(raw: &[Vec<u8>]) -> Option<AcceptEncoding> {
-        shared::from_comma_delimited(raw).map(AcceptEncoding)
-    }
-}
-
-impl header::HeaderFormat for AcceptEncoding {
-    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        shared::fmt_comma_delimited(fmt, &self[])
-    }
-}
+impl_list_header!(AcceptEncoding,
+                  "Accept-Encoding",
+                  Vec<shared::QualityItem<shared::Encoding>>);
 
 #[test]
 fn test_parse_header() {

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -95,6 +95,13 @@ macro_rules! impl_list_header(
                 $crate::header::shared::fmt_comma_delimited(fmt, &self[])
             }
         }
+
+        impl ::std::fmt::String for $from {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                use header::HeaderFormat;
+                self.fmt_header(f)
+            }
+        }
     }
 );
 

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -76,6 +76,51 @@ macro_rules! deref(
     }
 );
 
+macro_rules! impl_list_header(
+    ($from:ident, $name:expr, $item:ty) => {
+        deref!($from => $item);
+
+        impl header::Header for $from {
+            fn header_name(_: Option<$from>) -> &'static str {
+                $name
+            }
+
+            fn parse_header(raw: &[Vec<u8>]) -> Option<$from> {
+                shared::from_comma_delimited(raw).map($from)
+            }
+        }
+
+        impl header::HeaderFormat for $from {
+            fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                shared::fmt_comma_delimited(fmt, &self[])
+            }
+        }
+    }
+);
+
+macro_rules! impl_header(
+    ($from:ident, $name:expr, $item:ty) => {
+        deref!($from => $item);
+
+        impl header::Header for $from {
+            fn header_name(_: Option<$from>) -> &'static str {
+                $name
+            }
+
+            fn parse_header(raw: &[Vec<u8>]) -> Option<$from> {
+                from_one_raw_str(raw).map($from)
+            }
+        }
+
+        impl header::HeaderFormat for $from {
+            fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+                let value = &(self[]);
+                value.fmt(fmt)
+            }
+        }
+    }
+);
+
 /// Exposes the AccessControl* family of headers.
 pub mod access_control;
 

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -114,8 +114,14 @@ macro_rules! impl_header(
 
         impl header::HeaderFormat for $from {
             fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                let value = &(self[]);
-                value.fmt(fmt)
+                let value = &*self;
+                fmt::String::fmt(&value, fmt)
+            }
+        }
+
+        impl fmt::String for $from {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                fmt::String::fmt(&**self, f)
             }
         }
     }

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -86,13 +86,13 @@ macro_rules! impl_list_header(
             }
 
             fn parse_header(raw: &[Vec<u8>]) -> Option<$from> {
-                shared::from_comma_delimited(raw).map($from)
+                $crate::header::shared::from_comma_delimited(raw).map($from)
             }
         }
 
         impl header::HeaderFormat for $from {
-            fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                shared::fmt_comma_delimited(fmt, &self[])
+            fn fmt_header(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                $crate::header::shared::fmt_comma_delimited(fmt, &self[])
             }
         }
     }
@@ -108,20 +108,20 @@ macro_rules! impl_header(
             }
 
             fn parse_header(raw: &[Vec<u8>]) -> Option<$from> {
-                from_one_raw_str(raw).map($from)
+                $crate::header::shared::from_one_raw_str(raw).map($from)
             }
         }
 
         impl header::HeaderFormat for $from {
-            fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                let value = &*self;
-                fmt::String::fmt(&value, fmt)
+            fn fmt_header(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                ::std::fmt::String::fmt(&**self, f)
             }
         }
 
-        impl fmt::String for $from {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                fmt::String::fmt(&**self, f)
+        impl ::std::fmt::String for $from {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                use header::HeaderFormat;
+                self.fmt_header(f)
             }
         }
     }

--- a/src/header/common/server.rs
+++ b/src/header/common/server.rs
@@ -1,5 +1,5 @@
 use header;
-use std::fmt::{self, Show};
+use std::fmt;
 use header::shared::util::from_one_raw_str;
 
 /// The `Server` header field.

--- a/src/header/common/server.rs
+++ b/src/header/common/server.rs
@@ -1,6 +1,4 @@
 use header;
-use std::fmt;
-use header::shared::util::from_one_raw_str;
 
 /// The `Server` header field.
 ///

--- a/src/header/common/server.rs
+++ b/src/header/common/server.rs
@@ -1,4 +1,4 @@
-use header::{Header, HeaderFormat};
+use header;
 use std::fmt::{self, Show};
 use header::shared::util::from_one_raw_str;
 
@@ -8,23 +8,8 @@ use header::shared::util::from_one_raw_str;
 #[derive(Clone, PartialEq, Show)]
 pub struct Server(pub String);
 
-deref!(Server => String);
-
-impl Header for Server {
-    fn header_name(_: Option<Server>) -> &'static str {
-        "Server"
-    }
-
-    fn parse_header(raw: &[Vec<u8>]) -> Option<Server> {
-        from_one_raw_str(raw).map(|s| Server(s))
-    }
-}
-
-impl HeaderFormat for Server {
-    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let Server(ref value) = *self;
-        value.fmt(fmt)
-    }
-}
+impl_header!(Server,
+             "Server",
+             String);
 
 bench_header!(bench, Server, { vec![b"Some String".to_vec()] });


### PR DESCRIPTION
Add `impl_header!` and `impl_list_header!` macros. Rewrite `Accept-Encoding`
and `Server` header to use the new macros.

~~Work in progress.~~ How do you like the macros? These macros will allow to remove really much duplicate code in src/header/common/