### PR TITLE
Increase MAX_HEADER_FIELD_LENGTH to 4k

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -498,7 +498,7 @@ pub fn read_http_version<R: Reader>(stream: &mut R) -> HttpResult<HttpVersion> {
 }
 
 const MAX_HEADER_NAME_LENGTH: usize = 100;
-const MAX_HEADER_FIELD_LENGTH: usize = 1000;
+const MAX_HEADER_FIELD_LENGTH: usize = 4096;
 
 /// The raw bytes when parsing a header line.
 ///


### PR DESCRIPTION
In order to be able to handle larger headers than 1k, for example
header containing tracking cookies etc.

references:
- http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers
- http://stackoverflow.com/questions/686217/maximum-on-http-header-values