### PR TITLE
fix(imports): Update TypeId import location to "any" module

### DIFF
--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -4,10 +4,9 @@
 //! why we're using Rust in the first place. To set or get any header, an object
 //! must implement the `Header` trait from this module. Several common headers
 //! are already provided, such as `Host`, `ContentType`, `UserAgent`, and others.
-use std::any::Any;
+use std::any::{Any, TypeId};
 use std::borrow::Cow::{Borrowed, Owned};
 use std::fmt;
-use std::intrinsics::TypeId;
 use std::raw::TraitObject;
 use std::str::from_utf8;
 use std::string::CowString;

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,7 +1,6 @@
 //! A collection of traits abstracting over Listeners and Streams.
-use std::any::Any;
+use std::any::{Any, TypeId};
 use std::fmt;
-use std::intrinsics::TypeId;
 use std::io::{IoResult, IoError, ConnectionAborted, InvalidInput, OtherIoError,
               Stream, Listener, Acceptor};
 use std::io::net::ip::{SocketAddr, ToSocketAddr, Port};


### PR DESCRIPTION
TypeId has moved from std::intrinsics to std::any