### PR TITLE
refactor(headers): remove marker from header_name method

### DIFF
--- a/benches/client.rs
+++ b/benches/client.rs
@@ -34,7 +34,7 @@ fn handle(_r: Request, res: Response) {
 struct Foo;
 
 impl hyper::header::Header for Foo {
-    fn header_name(_: Option<Foo>) -> &'static str {
+    fn header_name() -> &'static str {
         "x-foo"
     }
     fn parse_header(_: &[Vec<u8>]) -> Option<Foo> {

--- a/benches/client_mock_tcp.rs
+++ b/benches/client_mock_tcp.rs
@@ -50,7 +50,7 @@ impl Writer for MockStream {
 struct Foo;
 
 impl hyper::header::Header for Foo {
-    fn header_name(_: Option<Foo>) -> &'static str {
+    fn header_name() -> &'static str {
         "x-foo"
     }
     fn parse_header(_: &[Vec<u8>]) -> Option<Foo> {

--- a/src/header/common/accept.rs
+++ b/src/header/common/accept.rs
@@ -31,7 +31,7 @@ pub struct Accept(pub Vec<header::QualityItem<mime::Mime>>);
 deref!(Accept => Vec<header::QualityItem<mime::Mime>>);
 
 impl header::Header for Accept {
-    fn header_name(_: Option<Accept>) -> &'static str {
+    fn header_name() -> &'static str {
         "Accept"
     }
 

--- a/src/header/common/access_control/allow_headers.rs
+++ b/src/header/common/access_control/allow_headers.rs
@@ -15,7 +15,7 @@ pub struct AccessControlAllowHeaders(pub Vec<String>);
 
 impl header::Header for AccessControlAllowHeaders {
     #[inline]
-    fn header_name(_: Option<AccessControlAllowHeaders>) -> &'static str {
+    fn header_name() -> &'static str {
         "Access-Control-Allow-Headers"
     }
 

--- a/src/header/common/access_control/allow_methods.rs
+++ b/src/header/common/access_control/allow_methods.rs
@@ -16,7 +16,7 @@ pub struct AccessControlAllowMethods(pub Vec<method::Method>);
 
 impl header::Header for AccessControlAllowMethods {
     #[inline]
-    fn header_name(_: Option<AccessControlAllowMethods>) -> &'static str {
+    fn header_name() -> &'static str {
         "Access-Control-Allow-Methods"
     }
 

--- a/src/header/common/access_control/allow_origin.rs
+++ b/src/header/common/access_control/allow_origin.rs
@@ -23,7 +23,7 @@ pub enum AccessControlAllowOrigin {
 
 impl header::Header for AccessControlAllowOrigin {
     #[inline]
-    fn header_name(_: Option<AccessControlAllowOrigin>) -> &'static str {
+    fn header_name() -> &'static str {
         "Access-Control-Allow-Origin"
     }
 

--- a/src/header/common/access_control/max_age.rs
+++ b/src/header/common/access_control/max_age.rs
@@ -14,7 +14,7 @@ pub struct AccessControlMaxAge(pub u32);
 
 impl header::Header for AccessControlMaxAge {
     #[inline]
-    fn header_name(_: Option<AccessControlMaxAge>) -> &'static str {
+    fn header_name() -> &'static str {
         "Access-Control-Max-Age"
     }
 

--- a/src/header/common/access_control/request_headers.rs
+++ b/src/header/common/access_control/request_headers.rs
@@ -14,7 +14,7 @@ pub struct AccessControlRequestHeaders(pub Vec<String>);
 
 impl header::Header for AccessControlRequestHeaders {
     #[inline]
-    fn header_name(_: Option<AccessControlRequestHeaders>) -> &'static str {
+    fn header_name() -> &'static str {
         "Access-Control-Request-Headers"
     }
 

--- a/src/header/common/access_control/request_method.rs
+++ b/src/header/common/access_control/request_method.rs
@@ -15,7 +15,7 @@ pub struct AccessControlRequestMethod(pub Method);
 
 impl header::Header for AccessControlRequestMethod {
     #[inline]
-    fn header_name(_: Option<AccessControlRequestMethod>) -> &'static str {
+    fn header_name() -> &'static str {
         "Access-Control-Request-Method"
     }
 

--- a/src/header/common/allow.rs
+++ b/src/header/common/allow.rs
@@ -12,7 +12,7 @@ pub struct Allow(pub Vec<Method>);
 deref!(Allow => Vec<Method>);
 
 impl Header for Allow {
-    fn header_name(_: Option<Allow>) -> &'static str {
+    fn header_name() -> &'static str {
         "Allow"
     }
 

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -23,7 +23,7 @@ impl<S: Scheme> DerefMut for Authorization<S> {
 }
 
 impl<S: Scheme> Header for Authorization<S> {
-    fn header_name(_: Option<Authorization<S>>) -> &'static str {
+    fn header_name() -> &'static str {
         "Authorization"
     }
 

--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -10,7 +10,7 @@ pub struct CacheControl(pub Vec<CacheDirective>);
 deref!(CacheControl => Vec<CacheDirective>);
 
 impl Header for CacheControl {
-    fn header_name(_: Option<CacheControl>) -> &'static str {
+    fn header_name() -> &'static str {
         "Cache-Control"
     }
 

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -50,7 +50,7 @@ impl fmt::String for ConnectionOption {
 }
 
 impl Header for Connection {
-    fn header_name(_: Option<Connection>) -> &'static str {
+    fn header_name() -> &'static str {
         "Connection"
     }
 

--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -12,7 +12,7 @@ pub struct ContentLength(pub u64);
 deref!(ContentLength => u64);
 
 impl Header for ContentLength {
-    fn header_name(_: Option<ContentLength>) -> &'static str {
+    fn header_name() -> &'static str {
         "Content-Length"
     }
 

--- a/src/header/common/content_type.rs
+++ b/src/header/common/content_type.rs
@@ -13,7 +13,7 @@ pub struct ContentType(pub Mime);
 deref!(ContentType => Mime);
 
 impl Header for ContentType {
-    fn header_name(_: Option<ContentType>) -> &'static str {
+    fn header_name() -> &'static str {
         "Content-Type"
     }
 

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -19,7 +19,7 @@ pub struct Cookies(pub Vec<Cookie>);
 deref!(Cookies => Vec<Cookie>);
 
 impl Header for Cookies {
-    fn header_name(_: Option<Cookies>) -> &'static str {
+    fn header_name() -> &'static str {
         "Cookie"
     }
 

--- a/src/header/common/date.rs
+++ b/src/header/common/date.rs
@@ -13,7 +13,7 @@ pub struct Date(pub Tm);
 deref!(Date => Tm);
 
 impl Header for Date {
-    fn header_name(_: Option<Date>) -> &'static str {
+    fn header_name() -> &'static str {
         "Date"
     }
 

--- a/src/header/common/etag.rs
+++ b/src/header/common/etag.rs
@@ -17,7 +17,7 @@ pub struct Etag {
 }
 
 impl Header for Etag {
-    fn header_name(_: Option<Etag>) -> &'static str {
+    fn header_name() -> &'static str {
         "Etag"
     }
 

--- a/src/header/common/expires.rs
+++ b/src/header/common/expires.rs
@@ -12,7 +12,7 @@ pub struct Expires(pub Tm);
 deref!(Expires => Tm);
 
 impl Header for Expires {
-    fn header_name(_: Option<Expires>) -> &'static str {
+    fn header_name() -> &'static str {
         "Expires"
     }
 

--- a/src/header/common/host.rs
+++ b/src/header/common/host.rs
@@ -19,7 +19,7 @@ pub struct Host {
 }
 
 impl Header for Host {
-    fn header_name(_: Option<Host>) -> &'static str {
+    fn header_name() -> &'static str {
         "Host"
     }
 

--- a/src/header/common/if_modified_since.rs
+++ b/src/header/common/if_modified_since.rs
@@ -12,7 +12,7 @@ pub struct IfModifiedSince(pub Tm);
 deref!(IfModifiedSince => Tm);
 
 impl Header for IfModifiedSince {
-    fn header_name(_: Option<IfModifiedSince>) -> &'static str {
+    fn header_name() -> &'static str {
         "If-Modified-Since"
     }
 

--- a/src/header/common/last_modified.rs
+++ b/src/header/common/last_modified.rs
@@ -12,7 +12,7 @@ pub struct LastModified(pub Tm);
 deref!(LastModified => Tm);
 
 impl Header for LastModified {
-    fn header_name(_: Option<LastModified>) -> &'static str {
+    fn header_name() -> &'static str {
         "Last-Modified"
     }
 

--- a/src/header/common/location.rs
+++ b/src/header/common/location.rs
@@ -19,7 +19,7 @@ pub struct Location(pub String);
 deref!(Location => String);
 
 impl Header for Location {
-    fn header_name(_: Option<Location>) -> &'static str {
+    fn header_name() -> &'static str {
         "Location"
     }
 

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -86,7 +86,7 @@ macro_rules! impl_list_header(
         deref!($from => $item);
 
         impl header::Header for $from {
-            fn header_name(_: Option<$from>) -> &'static str {
+            fn header_name() -> &'static str {
                 $name
             }
 
@@ -116,7 +116,7 @@ macro_rules! impl_header(
         deref!($from => $item);
 
         impl header::Header for $from {
-            fn header_name(_: Option<$from>) -> &'static str {
+            fn header_name() -> &'static str {
                 $name
             }
 

--- a/src/header/common/referer.rs
+++ b/src/header/common/referer.rs
@@ -16,7 +16,7 @@ pub struct Referer(pub String);
 deref!(Referer => String);
 
 impl Header for Referer {
-    fn header_name(_: Option<Referer>) -> &'static str {
+    fn header_name() -> &'static str {
         "Referer"
     }
 

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -16,7 +16,7 @@ pub struct SetCookie(pub Vec<Cookie>);
 deref!(SetCookie => Vec<Cookie>);
 
 impl Header for SetCookie {
-    fn header_name(_: Option<SetCookie>) -> &'static str {
+    fn header_name() -> &'static str {
         "Set-Cookie"
     }
 

--- a/src/header/common/transfer_encoding.rs
+++ b/src/header/common/transfer_encoding.rs
@@ -22,7 +22,7 @@ pub struct TransferEncoding(pub Vec<Encoding>);
 deref!(TransferEncoding => Vec<Encoding>);
 
 impl Header for TransferEncoding {
-    fn header_name(_: Option<TransferEncoding>) -> &'static str {
+    fn header_name() -> &'static str {
         "Transfer-Encoding"
     }
 

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -39,7 +39,7 @@ impl fmt::String for Protocol {
 }
 
 impl Header for Upgrade {
-    fn header_name(_: Option<Upgrade>) -> &'static str {
+    fn header_name() -> &'static str {
         "Upgrade"
     }
 

--- a/src/header/common/user_agent.rs
+++ b/src/header/common/user_agent.rs
@@ -11,7 +11,7 @@ pub struct UserAgent(pub String);
 deref!(UserAgent => String);
 
 impl Header for UserAgent {
-    fn header_name(_: Option<UserAgent>) -> &'static str {
+    fn header_name() -> &'static str {
         "User-Agent"
     }
 

--- a/src/header/common/vary.rs
+++ b/src/header/common/vary.rs
@@ -15,7 +15,7 @@ pub enum Vary {
 }
 
 impl Header for Vary {
-    fn header_name(_: Option<Vary>) -> &'static str {
+    fn header_name() -> &'static str {
         "Vary"
     }
 


### PR DESCRIPTION
It is no longer required, as we can use `<H as Header>::header_name()`.

BREAKING CHANGE: Implementations of Header will need to adjust the
    header_name method. It no longer takes any arguments.