### PR TITLE
fix(headers): make ConnectionHeader and search for websocket protocol unicase

### DIFF
--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -2,6 +2,7 @@ use header::{Header, HeaderFormat};
 use std::fmt;
 use std::str::FromStr;
 use header::parsing::{from_comma_delimited, fmt_comma_delimited};
+use unicase::UniCase;
 
 pub use self::ConnectionOption::{KeepAlive, Close, ConnectionHeader};
 
@@ -26,7 +27,7 @@ pub enum ConnectionOption {
     // TODO: it would be nice if these "Strings" could be stronger types, since
     // they are supposed to relate to other Header fields (which we have strong
     // types for).
-    ConnectionHeader(String),
+    ConnectionHeader(UniCase<String>),
 }
 
 impl FromStr for ConnectionOption {
@@ -34,7 +35,7 @@ impl FromStr for ConnectionOption {
         match s {
             "keep-alive" => Some(KeepAlive),
             "close" => Some(Close),
-            s => Some(ConnectionHeader(s.to_string()))
+            s => Some(ConnectionHeader(UniCase(s.to_string())))
         }
     }
 }
@@ -44,7 +45,7 @@ impl fmt::Display for ConnectionOption {
         write!(fmt, "{}", match *self {
             KeepAlive => "keep-alive",
             Close => "close",
-            ConnectionHeader(ref s) => s.as_slice()
+            ConnectionHeader(UniCase(ref s)) => s.as_slice()
         })
     }
 }

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -2,6 +2,7 @@ use header::{Header, HeaderFormat};
 use std::fmt;
 use std::str::FromStr;
 use header::parsing::{from_comma_delimited, fmt_comma_delimited};
+use unicase::UniCase;
 
 use self::Protocol::{WebSocket, ProtocolExt};
 
@@ -22,9 +23,11 @@ pub enum Protocol {
 
 impl FromStr for Protocol {
     fn from_str(s: &str) -> Option<Protocol> {
-        match s {
-            "websocket" => Some(WebSocket),
-            s => Some(ProtocolExt(s.to_string()))
+        if UniCase(s) == UniCase("websocket") {
+            Some(WebSocket)
+        }
+        else {
+            Some(ProtocolExt(s.to_string()))
         }
     }
 }


### PR DESCRIPTION
This makes ConnectionHeader case-insensitive since HTTP header field names are case-insensitive.

RFC6455 requires the Upgrade Protocol to search case-insensitively for "websocket". At the moment only lower-case works (I hit this when trying to get Autobahn to work with my websocket library).

Other protocol values may be case-sensitive, however, so ProtocolExt is still a normal case-sensitive String.