### PR TITLE
refactor(headers): Rename `Cookies` header to `Cookie`

### DIFF
--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -15,7 +15,7 @@ pub use self::cache_control::{CacheControl, CacheDirective};
 pub use self::connection::{Connection, ConnectionOption};
 pub use self::content_length::ContentLength;
 pub use self::content_type::ContentType;
-pub use self::cookie::Cookies;
+pub use self::cookie::Cookie;
 pub use self::date::Date;
 pub use self::etag::Etag;
 pub use self::expires::Expires;
@@ -164,4 +164,3 @@ mod transfer_encoding;
 mod upgrade;
 mod user_agent;
 mod vary;
-


### PR DESCRIPTION
`Cookie` is the actual name of the header and since all other header structs
use the exact camel-cased version of their name using a different name here
is very inconvienient and confusing. You will encounter weird errors if you
try to use `Cookie` as the header. For this reason rename `Cookies` as
discussed on IRC with @seanmonstar and @reem and use `CookiePair` for real
cookies.

Breaks code using `Cookie` header.