### PR TITLE
chore(git): clarify CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,8 @@ The body should include the motivation for the change and contrast this with pre
 The footer should contain any information about **Breaking Changes** and is also the place to
 reference GitHub issues that this commit **Closes**.
 
+The last line of commits introducing breaking changes should be in the form `BREAKING_CHANGE: <desc>`
+
 
 A detailed explanation can be found in this [document][commit-message-format].
 


### PR DESCRIPTION
It turned out in #271 that the current description for commit messages introducing breaking changes is not clear enough.