### PR TITLE
refactor(server): Add explicit lifetime annotations for Handler trait

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -175,7 +175,7 @@ pub trait Handler: Sync + Send {
     /// Receives a `Request`/`Response` pair, and should perform some action on them.
     ///
     /// This could reading from the request, and writing to the response.
-    fn handle(&self, Request, Response<Fresh>);
+    fn handle<'a>(&'a self, Request<'a>, Response<'a, Fresh>);
 }
 
 impl<F> Handler for F where F: Fn(Request, Response<Fresh>), F: Sync + Send {


### PR DESCRIPTION
It's different from the elided lifetimes, but having at least one explicit shared lifetime has allowed me to actually get the compiler to trust me on some dependent code. 

Any concerns on this being too restrictive?