### PR TITLE
Fixes around std::io being renamed to std::old_io

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -2,8 +2,8 @@
 extern crate hyper;
 
 use std::os;
-use std::io::stdout;
-use std::io::util::copy;
+use std::old_io::stdout;
+use std::old_io::util::copy;
 
 use hyper::Client;
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,14 +1,14 @@
 #![allow(unstable)]
 extern crate hyper;
 
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::net::ip::Ipv4Addr;
 use hyper::server::{Request, Response};
 
 static PHRASE: &'static [u8] = b"Hello World!";
 
 fn hello(_: Request, res: Response) {
     let mut res = res.start().unwrap();
-    res.write(PHRASE).unwrap();
+    res.write_all(PHRASE).unwrap();
     res.end().unwrap();
 }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -2,8 +2,8 @@
 extern crate hyper;
 #[macro_use] extern crate log;
 
-use std::io::util::copy;
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::util::copy;
+use std::old_io::net::ip::Ipv4Addr;
 
 use hyper::{Get, Post};
 use hyper::header::ContentLength;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -18,8 +18,8 @@
 //! to the `status`, the `headers`, and the response body via the `Writer`
 //! trait.
 use std::default::Default;
-use std::io::IoResult;
-use std::io::util::copy;
+use std::old_io::IoResult;
+use std::old_io::util::copy;
 use std::iter::Extend;
 
 use url::UrlParser;

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -1,5 +1,5 @@
 //! Client Requests
-use std::io::{BufferedWriter, IoResult};
+use std::old_io::{BufferedWriter, IoResult};
 
 use url::Url;
 
@@ -157,8 +157,8 @@ impl Request<Streaming> {
 
 impl Writer for Request<Streaming> {
     #[inline]
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> {
-        self.body.write(msg)
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> {
+        self.body.write_all(msg)
     }
 
     #[inline]

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -1,6 +1,6 @@
 //! Client Responses
 use std::num::FromPrimitive;
-use std::io::{BufferedReader, IoResult};
+use std::old_io::{BufferedReader, IoResult};
 
 use header;
 use header::{ContentLength, TransferEncoding};
@@ -97,7 +97,7 @@ impl Reader for Response {
 mod tests {
     use std::borrow::Cow::Borrowed;
     use std::boxed::BoxAny;
-    use std::io::BufferedReader;
+    use std::old_io::BufferedReader;
 
     use header::Headers;
     use header::TransferEncoding;

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -141,7 +141,7 @@ impl FromStr for Basic {
 
 #[cfg(test)]
 mod tests {
-    use std::io::MemReader;
+    use std::old_io::MemReader;
     use super::{Authorization, Basic};
     use super::super::super::{Headers};
 

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -505,7 +505,7 @@ impl<'a, H: HeaderFormat> fmt::Debug for HeaderFormatter<'a, H> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::MemReader;
+    use std::old_io::MemReader;
     use std::fmt;
     use std::borrow::Cow::Borrowed;
     use std::hash::{SipHasher, hash};

--- a/src/http.rs
+++ b/src/http.rs
@@ -2,7 +2,7 @@
 use std::borrow::Cow::{Borrowed, Owned};
 use std::borrow::IntoCow;
 use std::cmp::min;
-use std::io::{self, Reader, IoResult, BufWriter};
+use std::old_io::{self, Reader, IoResult, BufWriter};
 use std::num::from_u16;
 use std::str::{self, FromStr};
 use std::string::CowString;
@@ -72,7 +72,7 @@ impl<R: Reader> Reader for HttpReader<R> {
             SizedReader(ref mut body, ref mut remaining) => {
                 debug!("Sized read, remaining={:?}", remaining);
                 if *remaining == 0 {
-                    Err(io::standard_error(io::EndOfFile))
+                    Err(old_io::standard_error(old_io::EndOfFile))
                 } else {
                     let num = try!(body.read(buf)) as u64;
                     if num > *remaining {
@@ -98,7 +98,7 @@ impl<R: Reader> Reader for HttpReader<R> {
                     // if the 0 digit was missing from the stream, it would
                     // be an InvalidInput error instead.
                     debug!("end of chunked");
-                    return Err(io::standard_error(io::EndOfFile));
+                    return Err(old_io::standard_error(old_io::EndOfFile));
                 }
 
                 let to_read = min(rem as usize, buf.len());
@@ -116,7 +116,7 @@ impl<R: Reader> Reader for HttpReader<R> {
             EofReader(ref mut body) => {
                 body.read(buf)
             },
-            EmptyReader(_) => Err(io::standard_error(io::EndOfFile))
+            EmptyReader(_) => Err(old_io::standard_error(old_io::EndOfFile))
         }
     }
 }
@@ -125,7 +125,7 @@ fn eat<R: Reader>(rdr: &mut R, bytes: &[u8]) -> IoResult<()> {
     for &b in bytes.iter() {
         match try!(rdr.read_byte()) {
             byte if byte == b => (),
-            _ => return Err(io::standard_error(io::InvalidInput))
+            _ => return Err(old_io::standard_error(old_io::InvalidInput))
         }
     }
     Ok(())
@@ -154,7 +154,7 @@ fn read_chunk_size<R: Reader>(rdr: &mut R) -> IoResult<u64> {
             CR => {
                 match try!(rdr.read_byte()) {
                     LF => break,
-                    _ => return Err(io::standard_error(io::InvalidInput))
+                    _ => return Err(old_io::standard_error(old_io::InvalidInput))
                 }
             },
             // If we weren't in the extension yet, the ";" signals its start
@@ -178,7 +178,7 @@ fn read_chunk_size<R: Reader>(rdr: &mut R) -> IoResult<u64> {
             // Finally, if we aren't in the extension and we're reading any
             // other octet, the chunk size line is invalid!
             _ => {
-                return Err(io::standard_error(io::InvalidInput));
+                return Err(old_io::standard_error(old_io::InvalidInput));
             }
         }
     }
@@ -239,11 +239,11 @@ impl<W: Writer> HttpWriter<W> {
 
     /// Ends the HttpWriter, and returns the underlying Writer.
     ///
-    /// A final `write()` is called with an empty message, and then flushed.
+    /// A final `write_all()` is called with an empty message, and then flushed.
     /// The ChunkedWriter variant will use this to write the 0-sized last-chunk.
     #[inline]
     pub fn end(mut self) -> IoResult<W> {
-        try!(self.write(&[]));
+        try!(self.write_all(&[]));
         try!(self.flush());
         Ok(self.unwrap())
     }
@@ -251,14 +251,14 @@ impl<W: Writer> HttpWriter<W> {
 
 impl<W: Writer> Writer for HttpWriter<W> {
     #[inline]
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> {
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> {
         match *self {
-            ThroughWriter(ref mut w) => w.write(msg),
+            ThroughWriter(ref mut w) => w.write_all(msg),
             ChunkedWriter(ref mut w) => {
                 let chunk_size = msg.len();
                 debug!("chunked write, size = {:?}", chunk_size);
                 try!(write!(w, "{:X}{}", chunk_size, LINE_ENDING));
-                try!(w.write(msg));
+                try!(w.write_all(msg));
                 w.write_str(LINE_ENDING)
             },
             SizedWriter(ref mut w, ref mut remaining) => {
@@ -266,11 +266,11 @@ impl<W: Writer> Writer for HttpWriter<W> {
                 if len > *remaining {
                     let len = *remaining;
                     *remaining = 0;
-                    try!(w.write(&msg[..len as usize]));
-                    Err(io::standard_error(io::ShortWrite(len as usize)))
+                    try!(w.write_all(&msg[..len as usize]));
+                    Err(old_io::standard_error(old_io::ShortWrite(len as usize)))
                 } else {
                     *remaining -= len;
-                    w.write(msg)
+                    w.write_all(msg)
                 }
             },
             EmptyWriter(..) => {
@@ -278,8 +278,8 @@ impl<W: Writer> Writer for HttpWriter<W> {
                 if bytes == 0 {
                     Ok(())
                 } else {
-                    Err(io::IoError {
-                        kind: io::ShortWrite(bytes),
+                    Err(old_io::IoError {
+                        kind: old_io::ShortWrite(bytes),
                         desc: "EmptyWriter cannot write any bytes",
                         detail: Some("Cannot include a body with this kind of message".to_string())
                     })
@@ -347,7 +347,7 @@ pub fn is_token(b: u8) -> bool {
 ///
 /// The remaining contents of `buf` are left untouched.
 fn read_token_until_space<R: Reader>(stream: &mut R, buf: &mut [u8]) -> HttpResult<bool> {
-    use std::io::BufWriter;
+    use std::old_io::BufWriter;
     let mut bufwrt = BufWriter::new(buf);
 
     loop {
@@ -697,7 +697,7 @@ fn expect(r: IoResult<u8>, expected: u8) -> HttpResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{self, MemReader, MemWriter, IoResult};
+    use std::old_io::{self, MemReader, MemWriter, IoResult};
     use std::borrow::Cow::{Borrowed, Owned};
     use test::Bencher;
     use uri::RequestUri;
@@ -812,7 +812,7 @@ mod tests {
         use std::str::from_utf8;
         let mut w = super::HttpWriter::SizedWriter(MemWriter::new(), 8);
         w.write(b"foo bar").unwrap();
-        assert_eq!(w.write(b"baz"), Err(io::standard_error(io::ShortWrite(1))));
+        assert_eq!(w.write(b"baz"), Err(old_io::standard_error(old_io::ShortWrite(1))));
 
         let buf = w.end().unwrap().into_inner();
         let s = from_utf8(buf.as_slice()).unwrap();
@@ -834,13 +834,13 @@ mod tests {
         read("Ff\r\n", Ok(255));
         read("Ff   \r\n", Ok(255));
         // Missing LF or CRLF
-        read("F\rF", Err(io::standard_error(io::InvalidInput)));
-        read("F", Err(io::standard_error(io::EndOfFile)));
+        read("F\rF", Err(old_io::standard_error(old_io::InvalidInput)));
+        read("F", Err(old_io::standard_error(old_io::EndOfFile)));
         // Invalid hex digit
-        read("X\r\n", Err(io::standard_error(io::InvalidInput)));
-        read("1X\r\n", Err(io::standard_error(io::InvalidInput)));
-        read("-\r\n", Err(io::standard_error(io::InvalidInput)));
-        read("-1\r\n", Err(io::standard_error(io::InvalidInput)));
+        read("X\r\n", Err(old_io::standard_error(old_io::InvalidInput)));
+        read("1X\r\n", Err(old_io::standard_error(old_io::InvalidInput)));
+        read("-\r\n", Err(old_io::standard_error(old_io::InvalidInput)));
+        read("-1\r\n", Err(old_io::standard_error(old_io::InvalidInput)));
         // Acceptable (if not fully valid) extensions do not influence the size
         read("1;extension\r\n", Ok(1));
         read("a;ext name=value\r\n", Ok(10));
@@ -851,9 +851,9 @@ mod tests {
         read("3   ;\r\n", Ok(3));
         read("3   ;   \r\n", Ok(3));
         // Invalid extensions cause an error
-        read("1 invalid extension\r\n", Err(io::standard_error(io::InvalidInput)));
-        read("1 A\r\n", Err(io::standard_error(io::InvalidInput)));
-        read("1;no CRLF", Err(io::standard_error(io::EndOfFile)));
+        read("1 invalid extension\r\n", Err(old_io::standard_error(old_io::InvalidInput)));
+        read("1 A\r\n", Err(old_io::standard_error(old_io::InvalidInput)));
+        read("1;no CRLF", Err(old_io::standard_error(old_io::EndOfFile)));
     }
 
     #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ extern crate cookie;
 extern crate mucell;
 extern crate unicase;
 
-pub use std::io::net::ip::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr, Port};
+pub use std::old_io::net::ip::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr, Port};
 pub use mimewrapper::mime;
 pub use url::Url;
 pub use client::Client;
@@ -146,7 +146,7 @@ pub use server::Server;
 
 use std::error::{Error, FromError};
 use std::fmt;
-use std::io::IoError;
+use std::old_io::IoError;
 
 use self::HttpError::{HttpMethodError, HttpUriError, HttpVersionError,
                       HttpHeaderError, HttpStatusError, HttpIoError};

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,6 +1,6 @@
 use std::fmt;
-use std::io::{IoResult, MemReader, MemWriter};
-use std::io::net::ip::SocketAddr;
+use std::old_io::{IoResult, MemReader, MemWriter};
+use std::old_io::net::ip::SocketAddr;
 
 use net::{NetworkStream, NetworkConnector};
 
@@ -55,7 +55,7 @@ impl Reader for MockStream {
 }
 
 impl Writer for MockStream {
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> {
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> {
         self.write.write(msg)
     }
 }
@@ -86,7 +86,7 @@ macro_rules! mock_connector (
 
         impl ::net::NetworkConnector for $name {
             type Stream = ::mock::MockStream;
-            fn connect(&mut self, host: &str, port: u16, scheme: &str) -> ::std::io::IoResult<::mock::MockStream> {
+            fn connect(&mut self, host: &str, port: u16, scheme: &str) -> ::std::old_io::IoResult<::mock::MockStream> {
                 use std::collections::HashMap;
                 debug!("MockStream::connect({:?}, {:?}, {:?})", host, port, scheme);
                 let mut map = HashMap::new();
@@ -97,8 +97,8 @@ macro_rules! mock_connector (
                 // ignore port for now
                 match map.get(&&*key) {
                     Some(res) => Ok(::mock::MockStream {
-                        write: ::std::io::MemWriter::new(),
-                        read: ::std::io::MemReader::new(res.to_string().into_bytes())
+                        write: ::std::old_io::MemWriter::new(),
+                        read: ::std::old_io::MemReader::new(res.to_string().into_bytes())
                     }),
                     None => panic!("{:?} doesn't know url {}", stringify!($name), key)
                 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,10 +1,10 @@
 //! A collection of traits abstracting over Listeners and Streams.
 use std::any::{Any, TypeId};
 use std::fmt;
-use std::io::{IoResult, IoError, ConnectionAborted, InvalidInput, OtherIoError,
+use std::old_io::{IoResult, IoError, ConnectionAborted, InvalidInput, OtherIoError,
               Stream, Listener, Acceptor};
-use std::io::net::ip::{SocketAddr, ToSocketAddr, Port};
-use std::io::net::tcp::{TcpStream, TcpListener, TcpAcceptor};
+use std::old_io::net::ip::{SocketAddr, ToSocketAddr, Port};
+use std::old_io::net::tcp::{TcpStream, TcpListener, TcpAcceptor};
 use std::mem;
 use std::raw::{self, TraitObject};
 use std::sync::Arc;
@@ -112,7 +112,7 @@ impl Reader for Box<NetworkStream + Send> {
 
 impl Writer for Box<NetworkStream + Send> {
     #[inline]
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> { (**self).write(msg) }
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> { (**self).write_all(msg) }
 
     #[inline]
     fn flush(&mut self) -> IoResult<()> { (**self).flush() }
@@ -125,7 +125,7 @@ impl<'a> Reader for &'a mut NetworkStream {
 
 impl<'a> Writer for &'a mut NetworkStream {
     #[inline]
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> { (**self).write(msg) }
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> { (**self).write_all(msg) }
 
     #[inline]
     fn flush(&mut self) -> IoResult<()> { (**self).flush() }
@@ -282,12 +282,13 @@ impl Reader for HttpStream {
 
 impl Writer for HttpStream {
     #[inline]
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> {
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> {
         match *self {
-            HttpStream::Http(ref mut inner) => inner.write(msg),
-            HttpStream::Https(ref mut inner) => inner.write(msg)
+            HttpStream::Http(ref mut inner) => inner.write_all(msg),
+            HttpStream::Https(ref mut inner) => inner.write_all(msg)
         }
     }
+
     #[inline]
     fn flush(&mut self) -> IoResult<()> {
         match *self {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,6 @@
 //! HTTP Server
-use std::io::{Listener, EndOfFile, BufferedReader, BufferedWriter};
-use std::io::net::ip::{IpAddr, Port, SocketAddr};
+use std::old_io::{Listener, EndOfFile, BufferedReader, BufferedWriter};
+use std::old_io::net::ip::{IpAddr, Port, SocketAddr};
 use std::os;
 use std::sync::{Arc, TaskPool};
 use std::thread::{Builder, JoinGuard};

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -2,8 +2,8 @@
 //!
 //! These are requests that a `hyper::Server` receives, and include its method,
 //! target URI, headers, and message body.
-use std::io::IoResult;
-use std::io::net::ip::SocketAddr;
+use std::old_io::IoResult;
+use std::old_io::net::ip::SocketAddr;
 
 use {HttpResult};
 use version::{HttpVersion};
@@ -84,7 +84,7 @@ mod tests {
     use mock::MockStream;
     use super::Request;
 
-    use std::io::net::ip::SocketAddr;
+    use std::old_io::net::ip::SocketAddr;
 
     fn sock(s: &str) -> SocketAddr {
         s.parse().unwrap()

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -2,7 +2,7 @@
 //!
 //! These are responses sent by a `hyper::Server` to clients, after
 //! receiving a request.
-use std::io::IoResult;
+use std::old_io::IoResult;
 
 use time::now_utc;
 
@@ -141,9 +141,9 @@ impl<'a> Response<'a, Streaming> {
 }
 
 impl<'a> Writer for Response<'a, Streaming> {
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> {
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> {
         debug!("write {:?} bytes", msg.len());
-        self.body.write(msg)
+        self.body.write_all(msg)
     }
 
     fn flush(&mut self) -> IoResult<()> {


### PR DESCRIPTION
  - Fixed imports and io:: references
  - Fixed deprecated Writer::write calls to use Writer::write_all

`cargo test` still has unrelated compile errors, but `cargo build` succeeds.