### PR TITLE
fix(rustup): update io import, Writer::write

### DIFF
--- a/benches/client.rs
+++ b/benches/client.rs
@@ -4,7 +4,7 @@ extern crate hyper;
 extern crate test;
 
 use std::fmt;
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::net::ip::Ipv4Addr;
 use hyper::server::{Request, Response, Server};
 use hyper::header::Headers;
 use hyper::Client;
@@ -26,7 +26,7 @@ macro_rules! try_return(
 fn handle(_r: Request, res: Response) {
     static BODY: &'static [u8] = b"Benchmarking hyper vs others!";
     let mut res = try_return!(res.start());
-    try_return!(res.write(BODY));
+    try_return!(res.write_all(BODY));
     try_return!(res.end());
 }
 

--- a/benches/client_mock_tcp.rs
+++ b/benches/client_mock_tcp.rs
@@ -4,8 +4,8 @@ extern crate hyper;
 extern crate test;
 
 use std::fmt;
-use std::io::{IoResult, MemReader};
-use std::io::net::ip::SocketAddr;
+use std::old_io::{IoResult, MemReader};
+use std::old_io::net::ip::SocketAddr;
 
 use hyper::net;
 
@@ -40,7 +40,7 @@ impl Reader for MockStream {
 }
 
 impl Writer for MockStream {
-    fn write(&mut self, _msg: &[u8]) -> IoResult<()> {
+    fn write_all(&mut self, _msg: &[u8]) -> IoResult<()> {
         // we're mocking, what do we care.
         Ok(())
     }

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -3,7 +3,7 @@ extern crate hyper;
 extern crate test;
 
 use test::Bencher;
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::net::ip::Ipv4Addr;
 
 use hyper::method::Method::Get;
 use hyper::server::{Request, Response};
@@ -17,7 +17,7 @@ fn request(url: hyper::Url) {
 
 fn hyper_handle(_: Request, res: Response) {
     let mut res = res.start().unwrap();
-    res.write(PHRASE).unwrap();
+    res.write_all(PHRASE).unwrap();
     res.end().unwrap();
 }
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -2,8 +2,8 @@
 extern crate hyper;
 
 use std::os;
-use std::io::stdout;
-use std::io::util::copy;
+use std::old_io::stdout;
+use std::old_io::util::copy;
 
 use hyper::Client;
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,14 +1,14 @@
 #![allow(unstable)]
 extern crate hyper;
 
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::net::ip::Ipv4Addr;
 use hyper::server::{Request, Response};
 
 static PHRASE: &'static [u8] = b"Hello World!";
 
 fn hello(_: Request, res: Response) {
     let mut res = res.start().unwrap();
-    res.write(PHRASE).unwrap();
+    res.write_all(PHRASE).unwrap();
     res.end().unwrap();
 }
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -2,8 +2,8 @@
 extern crate hyper;
 #[macro_use] extern crate log;
 
-use std::io::util::copy;
-use std::io::net::ip::Ipv4Addr;
+use std::old_io::util::copy;
+use std::old_io::net::ip::Ipv4Addr;
 
 use hyper::{Get, Post};
 use hyper::header::ContentLength;
@@ -27,7 +27,7 @@ fn echo(mut req: Request, mut res: Response) {
 
                 res.headers_mut().set(ContentLength(out.len() as u64));
                 let mut res = try_return!(res.start());
-                try_return!(res.write(out));
+                try_return!(res.write_all(out));
                 try_return!(res.end());
                 return;
             },

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -18,8 +18,8 @@
 //! to the `status`, the `headers`, and the response body via the `Writer`
 //! trait.
 use std::default::Default;
-use std::io::IoResult;
-use std::io::util::copy;
+use std::old_io::IoResult;
+use std::old_io::util::copy;
 use std::iter::Extend;
 
 use url::UrlParser;

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -1,5 +1,5 @@
 //! Client Requests
-use std::io::{BufferedWriter, IoResult};
+use std::old_io::{BufferedWriter, IoResult};
 
 use url::Url;
 
@@ -157,8 +157,8 @@ impl Request<Streaming> {
 
 impl Writer for Request<Streaming> {
     #[inline]
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> {
-        self.body.write(msg)
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> {
+        self.body.write_all(msg)
     }
 
     #[inline]

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -1,6 +1,6 @@
 //! Client Responses
 use std::num::FromPrimitive;
-use std::io::{BufferedReader, IoResult};
+use std::old_io::{BufferedReader, IoResult};
 
 use header;
 use header::{ContentLength, TransferEncoding};
@@ -97,7 +97,7 @@ impl Reader for Response {
 mod tests {
     use std::borrow::Cow::Borrowed;
     use std::boxed::BoxAny;
-    use std::io::BufferedReader;
+    use std::old_io::BufferedReader;
 
     use header::Headers;
     use header::TransferEncoding;

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -141,7 +141,7 @@ impl FromStr for Basic {
 
 #[cfg(test)]
 mod tests {
-    use std::io::MemReader;
+    use std::old_io::MemReader;
     use super::{Authorization, Basic};
     use super::super::super::{Headers};
 

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -505,7 +505,7 @@ impl<'a, H: HeaderFormat> fmt::Debug for HeaderFormatter<'a, H> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::MemReader;
+    use std::old_io::MemReader;
     use std::fmt;
     use std::borrow::Cow::Borrowed;
     use std::hash::{SipHasher, hash};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ extern crate cookie;
 extern crate mucell;
 extern crate unicase;
 
-pub use std::io::net::ip::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr, Port};
+pub use std::old_io::net::ip::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr, Port};
 pub use mimewrapper::mime;
 pub use url::Url;
 pub use client::Client;
@@ -146,7 +146,7 @@ pub use server::Server;
 
 use std::error::{Error, FromError};
 use std::fmt;
-use std::io::IoError;
+use std::old_io::IoError;
 
 use self::HttpError::{HttpMethodError, HttpUriError, HttpVersionError,
                       HttpHeaderError, HttpStatusError, HttpIoError};

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -1,6 +1,6 @@
 use std::fmt;
-use std::io::{IoResult, MemReader, MemWriter};
-use std::io::net::ip::SocketAddr;
+use std::old_io::{IoResult, MemReader, MemWriter};
+use std::old_io::net::ip::SocketAddr;
 
 use net::{NetworkStream, NetworkConnector};
 
@@ -55,8 +55,8 @@ impl Reader for MockStream {
 }
 
 impl Writer for MockStream {
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> {
-        self.write.write(msg)
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> {
+        self.write.write_all(msg)
     }
 }
 
@@ -86,7 +86,7 @@ macro_rules! mock_connector (
 
         impl ::net::NetworkConnector for $name {
             type Stream = ::mock::MockStream;
-            fn connect(&mut self, host: &str, port: u16, scheme: &str) -> ::std::io::IoResult<::mock::MockStream> {
+            fn connect(&mut self, host: &str, port: u16, scheme: &str) -> ::std::old_io::IoResult<::mock::MockStream> {
                 use std::collections::HashMap;
                 debug!("MockStream::connect({:?}, {:?}, {:?})", host, port, scheme);
                 let mut map = HashMap::new();
@@ -95,10 +95,10 @@ macro_rules! mock_connector (
 
                 let key = format!("{}://{}", scheme, host);
                 // ignore port for now
-                match map.get(&&*key) {
+                match map.get(&*key) {
                     Some(res) => Ok(::mock::MockStream {
-                        write: ::std::io::MemWriter::new(),
-                        read: ::std::io::MemReader::new(res.to_string().into_bytes())
+                        write: ::std::old_io::MemWriter::new(),
+                        read: ::std::old_io::MemReader::new(res.to_string().into_bytes())
                     }),
                     None => panic!("{:?} doesn't know url {}", stringify!($name), key)
                 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,10 +1,10 @@
 //! A collection of traits abstracting over Listeners and Streams.
 use std::any::{Any, TypeId};
 use std::fmt;
-use std::io::{IoResult, IoError, ConnectionAborted, InvalidInput, OtherIoError,
+use std::old_io::{IoResult, IoError, ConnectionAborted, InvalidInput, OtherIoError,
               Stream, Listener, Acceptor};
-use std::io::net::ip::{SocketAddr, ToSocketAddr, Port};
-use std::io::net::tcp::{TcpStream, TcpListener, TcpAcceptor};
+use std::old_io::net::ip::{SocketAddr, ToSocketAddr, Port};
+use std::old_io::net::tcp::{TcpStream, TcpListener, TcpAcceptor};
 use std::mem;
 use std::raw::{self, TraitObject};
 use std::sync::Arc;
@@ -112,7 +112,7 @@ impl Reader for Box<NetworkStream + Send> {
 
 impl Writer for Box<NetworkStream + Send> {
     #[inline]
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> { (**self).write(msg) }
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> { (**self).write_all(msg) }
 
     #[inline]
     fn flush(&mut self) -> IoResult<()> { (**self).flush() }
@@ -125,7 +125,7 @@ impl<'a> Reader for &'a mut NetworkStream {
 
 impl<'a> Writer for &'a mut NetworkStream {
     #[inline]
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> { (**self).write(msg) }
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> { (**self).write_all(msg) }
 
     #[inline]
     fn flush(&mut self) -> IoResult<()> { (**self).flush() }
@@ -282,10 +282,10 @@ impl Reader for HttpStream {
 
 impl Writer for HttpStream {
     #[inline]
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> {
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> {
         match *self {
-            HttpStream::Http(ref mut inner) => inner.write(msg),
-            HttpStream::Https(ref mut inner) => inner.write(msg)
+            HttpStream::Http(ref mut inner) => inner.write_all(msg),
+            HttpStream::Https(ref mut inner) => inner.write_all(msg)
         }
     }
     #[inline]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,6 @@
 //! HTTP Server
-use std::io::{Listener, EndOfFile, BufferedReader, BufferedWriter};
-use std::io::net::ip::{IpAddr, Port, SocketAddr};
+use std::old_io::{Listener, EndOfFile, BufferedReader, BufferedWriter};
+use std::old_io::net::ip::{IpAddr, Port, SocketAddr};
 use std::os;
 use std::sync::{Arc, TaskPool};
 use std::thread::{Builder, JoinGuard};

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -2,8 +2,8 @@
 //!
 //! These are requests that a `hyper::Server` receives, and include its method,
 //! target URI, headers, and message body.
-use std::io::IoResult;
-use std::io::net::ip::SocketAddr;
+use std::old_io::IoResult;
+use std::old_io::net::ip::SocketAddr;
 
 use {HttpResult};
 use version::{HttpVersion};
@@ -84,7 +84,7 @@ mod tests {
     use mock::MockStream;
     use super::Request;
 
-    use std::io::net::ip::SocketAddr;
+    use std::old_io::net::ip::SocketAddr;
 
     fn sock(s: &str) -> SocketAddr {
         s.parse().unwrap()

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -2,7 +2,7 @@
 //!
 //! These are responses sent by a `hyper::Server` to clients, after
 //! receiving a request.
-use std::io::IoResult;
+use std::old_io::IoResult;
 
 use time::now_utc;
 
@@ -141,9 +141,9 @@ impl<'a> Response<'a, Streaming> {
 }
 
 impl<'a> Writer for Response<'a, Streaming> {
-    fn write(&mut self, msg: &[u8]) -> IoResult<()> {
+    fn write_all(&mut self, msg: &[u8]) -> IoResult<()> {
         debug!("write {:?} bytes", msg.len());
-        self.body.write(msg)
+        self.body.write_all(msg)
     }
 
     fn flush(&mut self) -> IoResult<()> {


### PR DESCRIPTION
Make it build with the latest rust-nightly (2015-01-27)

Renamed io import to old_io.
Renamed Writer::write to Writer::write_all