### PR TITLE
refactor(headers): switch from MuCell to OptCell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ keywords = ["http", "hyper", "hyperium"]
 cookie = "*"
 log = ">= 0.2.0"
 mime = "*"
-mucell = "*"
 openssl = "*"
 rustc-serialize = "*"
 time = "*"

--- a/src/header/cell.rs
+++ b/src/header/cell.rs
@@ -1,0 +1,41 @@
+use std::cell::UnsafeCell;
+use std::ops::Deref;
+
+pub struct OptCell<T>(UnsafeCell<Option<T>>);
+
+impl<T> OptCell<T> {
+    #[inline]
+    pub fn new(val: Option<T>) -> OptCell<T> {
+        OptCell(UnsafeCell::new(val))
+    }
+
+    #[inline]
+    pub fn set(&self, val: T) {
+        unsafe {
+            let opt = self.0.get();
+            debug_assert!((*opt).is_none());
+            *opt = Some(val)
+        }
+    }
+
+    #[inline]
+    pub unsafe fn get_mut(&mut self) -> &mut T {
+        let opt = &mut *self.0.get();
+        opt.as_mut().unwrap()
+    }
+}
+
+impl<T> Deref for OptCell<T> {
+    type Target = Option<T>;
+    #[inline]
+    fn deref<'a>(&'a self) -> &'a Option<T> {
+        unsafe { &*self.0.get() }
+    }
+}
+
+impl<T: Clone> Clone for OptCell<T> {
+    #[inline]
+    fn clone(&self) -> OptCell<T> {
+        OptCell::new((**self).clone())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,6 @@ extern crate openssl;
 #[cfg(test)] extern crate test;
 extern crate "unsafe-any" as uany;
 extern crate cookie;
-extern crate mucell;
 extern crate unicase;
 
 pub use std::old_io::net::ip::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr, Port};


### PR DESCRIPTION
It turns out, we don't need capabilities of MuCell (or even RefCell).
We don't to have sophisticated interior mutability. We don't ever lend
out references that may be mutated later. Instead, if there is no value
to lend, then we generate the value, require interior mutability to save
the value internally, and then we return a reference. We never ever
change a value once it's been generated. It can be changed, but only via
&mut self methods, where we can safely reason about mutability.

This means we don't need keep borrow checking code at runtime, which
helps performance. We also are able to reduce the amount of unsafe
transmutes. The internal API more safely constrains the usage of unsafe,
enforcing our invariants, instead of shotgunning unsafe usage with Refs
and promising we're doing it correctly.

On a machine with lower memory (1GB):

    Before:
    test bench_mock_hyper ... bench:    251772 ns/iter (+/- 128445)

    After:
    test bench_mock_hyper ... bench:    152603 ns/iter (+/- 25928)

On a machine with more memory, weaker CPU:

    Before:
    test bench_mock_hyper ... bench:    129398 ns/iter (+/- 51740)

    After:
    test bench_mock_hyper ... bench:    115935 ns/iter (+/- 28555)

Closes #252 

/cc @reem @chris-morgan 