### PR TITLE
feat(headers): add AcceptCharset header

### DIFF
--- a/src/header/common/accept_charset.rs
+++ b/src/header/common/accept_charset.rs
@@ -1,0 +1,27 @@
+use header::{self, QualityItem};
+
+pub type Charset = String;
+
+/// The `Accept-Charset` header
+///
+/// The `Accept-Charset` header can be used by clients to indicate what
+/// response charsets they accept.
+#[derive(Clone, PartialEq, Debug)]
+pub struct AcceptCharset(pub Vec<QualityItem<Charset>>);
+
+impl_list_header!(AcceptCharset,
+                  "Accept-Charset",
+                  Vec<QualityItem<Charset>>);
+
+
+#[test]
+fn test_parse_header() {
+    let a: AcceptCharset = header::Header::parse_header(
+        [b"iso-8859-5, unicode-1-1;q=0.8".to_vec()].as_slice()).unwrap();
+    let b = AcceptCharset(vec![
+        QualityItem{item: "iso-8859-5".to_string(), quality: 1.0},
+        QualityItem{item: "unicode-1-1".to_string(), quality: 0.8},
+    ]);
+    assert_eq!(format!("{}", a), format!("{}", b));
+    assert_eq!(a, b);
+}

--- a/src/header/common/accept_charset.rs
+++ b/src/header/common/accept_charset.rs
@@ -1,6 +1,4 @@
-use header::{self, QualityItem};
-
-pub type Charset = String;
+use header::{self, Charset, QualityItem};
 
 /// The `Accept-Charset` header
 ///
@@ -17,10 +15,10 @@ impl_list_header!(AcceptCharset,
 #[test]
 fn test_parse_header() {
     let a: AcceptCharset = header::Header::parse_header(
-        [b"iso-8859-5, unicode-1-1;q=0.8".to_vec()].as_slice()).unwrap();
+        [b"iso-8859-5, iso-8859-6;q=0.8".to_vec()].as_slice()).unwrap();
     let b = AcceptCharset(vec![
-        QualityItem{item: "iso-8859-5".to_string(), quality: 1.0},
-        QualityItem{item: "unicode-1-1".to_string(), quality: 0.8},
+        QualityItem{item: Charset::Iso_8859_5, quality: 1.0},
+        QualityItem{item: Charset::Iso_8859_6, quality: 0.8},
     ]);
     assert_eq!(format!("{}", a), format!("{}", b));
     assert_eq!(a, b);

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -8,6 +8,7 @@
 
 pub use self::access_control::*;
 pub use self::accept::Accept;
+pub use self::accept_charset::AcceptCharset;
 pub use self::accept_encoding::AcceptEncoding;
 pub use self::allow::Allow;
 pub use self::authorization::{Authorization, Scheme, Basic};
@@ -144,6 +145,7 @@ macro_rules! impl_header(
 
 mod access_control;
 mod accept;
+mod accept_charset;
 mod accept_encoding;
 mod allow;
 mod authorization;

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -22,7 +22,7 @@ use unicase::UniCase;
 use self::cell::OptCell;
 use {http, HttpResult, HttpError};
 
-pub use self::shared::{Encoding, EntityTag, QualityItem, qitem};
+pub use self::shared::{Charset,Encoding, EntityTag, QualityItem, qitem};
 pub use self::common::*;
 
 mod cell;

--- a/src/header/shared/charset.rs
+++ b/src/header/shared/charset.rs
@@ -1,0 +1,150 @@
+use std::fmt::{self,Display};
+use std::str::FromStr;
+use std::ascii::AsciiExt;
+
+use self::Charset::*;
+
+/// A Mime charset.
+///
+/// The string representation is normalised to upper case.
+///
+/// See http://www.iana.org/assignments/character-sets/character-sets.xhtml
+#[derive(Clone,Debug,PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum Charset{
+    /// US ASCII
+    Us_Ascii,
+    /// ISO-8859-1
+    Iso_8859_1,
+    /// ISO-8859-2
+    Iso_8859_2,
+    /// ISO-8859-3
+    Iso_8859_3,
+    /// ISO-8859-4
+    Iso_8859_4,
+    /// ISO-8859-5
+    Iso_8859_5,
+    /// ISO-8859-6
+    Iso_8859_6,
+    /// ISO-8859-7
+    Iso_8859_7,
+    /// ISO-8859-8
+    Iso_8859_8,
+    /// ISO-8859-9
+    Iso_8859_9,
+    /// ISO-8859-10
+    Iso_8859_10,
+    /// Shift_JIS
+    Shift_Jis,
+    /// EUC-JP
+    Euc_Jp,
+    /// ISO-2022-KR
+    Iso_2022_Kr,
+    /// EUC-KR
+    Euc_Kr,
+    /// ISO-2022-JP
+    Iso_2022_Jp,
+    /// ISO-2022-JP-2
+    Iso_2022_Jp_2,
+    /// ISO-8859-6-E
+    Iso_8859_6_E,
+    /// ISO-8859-6-I
+    Iso_8859_6_I,
+    /// ISO-8859-8-E
+    Iso_8859_8_E,
+    /// ISO-8859-8-I
+    Iso_8859_8_I,
+    /// GB2312
+    Gb2312,
+    /// Big5
+    Big5,
+    /// KOI8-R
+    Koi8_R,
+    /// An arbitrary charset specified as a string
+    Ext(String)
+}
+
+impl Charset {
+    fn name(&self) -> &str {
+        match *self {
+            Us_Ascii => "US-ASCII",
+            Iso_8859_1 => "ISO-8859-1",
+            Iso_8859_2 => "ISO-8859-2",
+            Iso_8859_3 => "ISO-8859-3",
+            Iso_8859_4 => "ISO-8859-4",
+            Iso_8859_5 => "ISO-8859-5",
+            Iso_8859_6 => "ISO-8859-6",
+            Iso_8859_7 => "ISO-8859-7",
+            Iso_8859_8 => "ISO-8859-8",
+            Iso_8859_9 => "ISO-8859-9",
+            Iso_8859_10 => "ISO-8859-10",
+            Shift_Jis => "Shift-JIS",
+            Euc_Jp => "EUC-JP",
+            Iso_2022_Kr => "ISO-2022-KR",
+            Euc_Kr => "EUC-KR",
+            Iso_2022_Jp => "ISO-2022-JP",
+            Iso_2022_Jp_2 => "ISO-2022-JP-2",
+            Iso_8859_6_E => "ISO-8859-6-E",
+            Iso_8859_6_I => "ISO-8859-6-I",
+            Iso_8859_8_E => "ISO-8859-8-E",
+            Iso_8859_8_I => "ISO-8859-8-I",
+            Gb2312 => "GB2312",
+            Big5 => "5",
+            Koi8_R => "KOI8-R",
+            Ext(ref s) => &s[]
+        }
+    }
+}
+
+impl Display for Charset {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.name())
+    }
+}
+
+impl FromStr for Charset {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Charset, ()> {
+        Ok(match s.to_ascii_uppercase().as_slice() {
+            "US-ASCII" => Us_Ascii,
+            "ISO-8859-1" => Iso_8859_1,
+            "ISO-8859-2" => Iso_8859_2,
+            "ISO-8859-3" => Iso_8859_3,
+            "ISO-8859-4" => Iso_8859_4,
+            "ISO-8859-5" => Iso_8859_5,
+            "ISO-8859-6" => Iso_8859_6,
+            "ISO-8859-7" => Iso_8859_7,
+            "ISO-8859-8" => Iso_8859_8,
+            "ISO-8859-9" => Iso_8859_9,
+            "ISO-8859-10" => Iso_8859_10,
+            "Shift-JIS" => Shift_Jis,
+            "EUC-JP" => Euc_Jp,
+            "ISO-2022-KR" => Iso_2022_Kr,
+            "EUC-KR" => Euc_Kr,
+            "ISO-2022-JP" => Iso_2022_Jp,
+            "ISO-2022-JP-2" => Iso_2022_Jp_2,
+            "ISO-8859-6-E" => Iso_8859_6_E,
+            "ISO-8859-6-I" => Iso_8859_6_I,
+            "ISO-8859-8-E" => Iso_8859_8_E,
+            "ISO-8859-8-I" => Iso_8859_8_I,
+            "GB2312" => Gb2312,
+            "5" => Big5,
+            "KOI8-R" => Koi8_R,
+            s => Ext(s.to_string())
+        })
+    }
+}
+
+#[test]
+fn test_parse() {
+    assert_eq!(Us_Ascii,"us-ascii".parse().unwrap());
+    assert_eq!(Us_Ascii,"US-Ascii".parse().unwrap());
+    assert_eq!(Us_Ascii,"US-ASCII".parse().unwrap());
+    assert_eq!(Ext("ABCD".to_string()),"abcd".parse().unwrap());
+}
+
+#[test]
+fn test_display() {
+    assert_eq!("US-ASCII", format!("{}", Us_Ascii));
+    assert_eq!("ABCD", format!("{}", Ext("ABCD".to_string())));
+}

--- a/src/header/shared/mod.rs
+++ b/src/header/shared/mod.rs
@@ -1,7 +1,9 @@
+pub use self::charset::Charset;
 pub use self::encoding::Encoding;
 pub use self::entity::EntityTag;
 pub use self::quality_item::{QualityItem, qitem};
 
+mod charset;
 mod encoding;
 mod entity;
 mod quality_item;


### PR DESCRIPTION
Adds support for the Accept-Charset header.  Encodes the charset as a string.