### PR TITLE
docs(readme): Make the README client example work

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ fn main() {
     let mut client = Client::new();
 
     // Creating an outgoing request.
-    let res = client.get("http://www.gooogle.com/")
+    let mut res = client.get("http://www.gooogle.com/")
         // set a header
         .header(Connection(vec![Close]))
         // let 'er go!


### PR DESCRIPTION
`res` needs to be mutable (introduce with #294) otherwise
```
   Compiling toto v0.0.1 (file:///home/ctjhoa/rust/toto)
src/main.rs:14:16: 14:20 error: cannot borrow immutable local variable `resp` as mutable
src/main.rs:14     let body = res.read_to_string().unwrap();
                              ^~~~
error: aborting due to previous error
Could not compile `toto`.
```