### PR TITLE
fix(server): Drain requests on drop.

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -3,7 +3,10 @@ use std::borrow::Cow::{Borrowed, Owned};
 use std::borrow::IntoCow;
 use std::cmp::min;
 use std::old_io::{self, Reader, IoResult, BufWriter};
+use std::old_io::util as io_util;
+use std::mem;
 use std::num::from_u16;
+use std::ptr;
 use std::str;
 use std::string::CowString;
 
@@ -20,7 +23,7 @@ use HttpError::{HttpHeaderError, HttpIoError, HttpMethodError, HttpStatusError,
                 HttpUriError, HttpVersionError};
 use HttpResult;
 
-use self::HttpReader::{SizedReader, ChunkedReader, EofReader, EmptyReader};
+use self::HttpReader::{SizedReader, ChunkedReader, EofReader};
 use self::HttpWriter::{ThroughWriter, ChunkedWriter, SizedWriter, EmptyWriter};
 
 /// Readers to handle different Transfer-Encodings.
@@ -47,22 +50,30 @@ pub enum HttpReader<R> {
     /// > reliably; the server MUST respond with the 400 (Bad Request)
     /// > status code and then close the connection.
     EofReader(R),
-    /// A Reader used for messages that should never have a body.
-    ///
-    /// See https://tools.ietf.org/html/rfc7230#section-3.3.3
-    EmptyReader(R),
 }
 
 impl<R: Reader> HttpReader<R> {
 
     /// Unwraps this HttpReader and returns the underlying Reader.
+    #[inline]
     pub fn unwrap(self) -> R {
-        match self {
-            SizedReader(r, _) => r,
-            ChunkedReader(r, _) => r,
-            EofReader(r) => r,
-            EmptyReader(r) => r,
-        }
+        let r = unsafe {
+            ptr::read(match self {
+                SizedReader(ref r, _) => r,
+                ChunkedReader(ref r, _) => r,
+                EofReader(ref r) => r,
+            })
+        };
+        unsafe { mem::forget(self); }
+        r
+    }
+}
+
+#[unsafe_destructor]
+impl<R: Reader> Drop for HttpReader<R> {
+    #[inline]
+    fn drop(&mut self) {
+        let _cant_use = io_util::copy(self, &mut io_util::NullWriter);
     }
 }
 
@@ -116,7 +127,6 @@ impl<R: Reader> Reader for HttpReader<R> {
             EofReader(ref mut body) => {
                 body.read(buf)
             },
-            EmptyReader(_) => Err(old_io::standard_error(old_io::EndOfFile))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(core, collections, hash, io, os, path, std_misc,
-           slicing_syntax, box_syntax)]
+           slicing_syntax, box_syntax, unsafe_destructor)]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(test, feature(alloc, test))]


### PR DESCRIPTION
If a client sent an illegal request (like a GET request with a message
body), or if there was a legal request with a body but the Handler
didn't read all of it, the remaining bytes would be left in the stream.
The next request to come from the same client would error, as the server
would confuse the remaining bytes, and think the request was malformed.

Fixes #197
Fixes #309