### PR TITLE
feat(server): Rewrite the accept loop into a custom thread pool.

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -13,6 +13,7 @@ fn hello(_: Request, res: Response) {
 }
 
 fn main() {
-    hyper::Server::http(Ipv4Addr(127, 0, 0, 1), 3000).listen(hello).unwrap();
+    let _listening = hyper::Server::http(Ipv4Addr(127, 0, 0, 1), 3000)
+        .listen(hello).unwrap();
     println!("Listening on http://127.0.0.1:3000");
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -51,7 +51,6 @@ fn echo(mut req: Request, mut res: Response) {
 
 fn main() {
     let server = Server::http(Ipv4Addr(127, 0, 0, 1), 1337);
-    let mut listening = server.listen(echo).unwrap();
+    let _guard = server.listen(echo).unwrap();
     println!("Listening on http://127.0.0.1:1337");
-    listening.await();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(core, collections, hash, io, os, path, std_misc,
-           slicing_syntax, box_syntax)]
+           slicing_syntax, box_syntax, unsafe_destructor)]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(test, feature(alloc, test))]
@@ -130,11 +130,15 @@ extern crate "rustc-serialize" as serialize;
 extern crate time;
 extern crate url;
 extern crate openssl;
-#[macro_use] extern crate log;
-#[cfg(test)] extern crate test;
 extern crate "unsafe-any" as uany;
 extern crate cookie;
 extern crate unicase;
+
+#[macro_use]
+extern crate log;
+
+#[cfg(test)]
+extern crate test;
 
 pub use std::old_io::net::ip::{SocketAddr, IpAddr, Ipv4Addr, Ipv6Addr, Port};
 pub use mimewrapper::mime;

--- a/src/server/acceptor.rs
+++ b/src/server/acceptor.rs
@@ -1,0 +1,95 @@
+use std::thread::{Thread, JoinGuard};
+use std::sync::Arc;
+use std::sync::mpsc;
+use net::NetworkAcceptor;
+
+pub struct AcceptorPool<A: NetworkAcceptor> {
+    acceptor: A
+}
+
+impl<A: NetworkAcceptor> AcceptorPool<A> {
+    /// Create a thread pool to manage the acceptor.
+    pub fn new(acceptor: A) -> AcceptorPool<A> {
+        AcceptorPool { acceptor: acceptor }
+    }
+
+    /// Runs the acceptor pool. Blocks until the acceptors are closed.
+    ///
+    /// ## Panics
+    ///
+    /// Panics if threads == 0.
+    pub fn accept<F: Fn(A::Stream) + Send + Sync>(self,
+                                                  work: F,
+                                                  threads: usize) -> JoinGuard<'static, ()> {
+        assert!(threads != 0, "Can't accept on 0 threads.");
+
+        // Replace with &F when Send changes land.
+        let work = Arc::new(work);
+
+        let (super_tx, supervisor_rx) = mpsc::channel();
+
+        let spawn =
+            move || spawn_with(super_tx.clone(), work.clone(), self.acceptor.clone());
+
+        // Go
+        for _ in 0..threads { spawn() }
+
+        // Spawn the supervisor
+        Thread::scoped(move || for () in supervisor_rx.iter() { spawn() })
+    }
+}
+
+fn spawn_with<A, F>(supervisor: mpsc::Sender<()>, work: Arc<F>, mut acceptor: A)
+where A: NetworkAcceptor,
+      F: Fn(<A as NetworkAcceptor>::Stream) + Send + Sync {
+    use std::old_io::EndOfFile;
+
+    Thread::spawn(move || {
+        let sentinel = Sentinel::new(supervisor, ());
+
+        loop {
+            match acceptor.accept() {
+                Ok(stream) => work(stream),
+                Err(ref e) if e.kind == EndOfFile => {
+                    debug!("Server closed.");
+                    sentinel.cancel();
+                    return;
+                },
+
+                Err(e) => {
+                    error!("Connection failed: {}", e);
+                }
+            }
+        }
+    });
+}
+
+struct Sentinel<T: Send> {
+    value: Option<T>,
+    supervisor: mpsc::Sender<T>,
+    active: bool
+}
+
+impl<T: Send> Sentinel<T> {
+    fn new(channel: mpsc::Sender<T>, data: T) -> Sentinel<T> {
+        Sentinel {
+            value: Some(data),
+            supervisor: channel,
+            active: true
+        }
+    }
+
+    fn cancel(mut self) { self.active = false; }
+}
+
+#[unsafe_destructor]
+impl<T: Send> Drop for Sentinel<T> {
+    fn drop(&mut self) {
+        // If we were cancelled, get out of here.
+        if !self.active { return; }
+
+        // Respawn ourselves
+        let _ = self.supervisor.send(self.value.take().unwrap());
+    }
+}
+


### PR DESCRIPTION
This is a modified and specialized thread pool meant for
managing an acceptor in a multi-threaded way. A single handler
is provided which will be invoked on each stream.

Unlike the old thread pool, this returns a join guard which
will block until the acceptor closes, enabling friendly behavior
for the listening guard.

This improves performance by like 15%, all the way to 105k req/sec
on my machine, which usually gets about 90k.