### PR TITLE
Revert "fix(server): Drain requests on drop."

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(core, collections, hash, io, os, path, std_misc,
-           slicing_syntax, box_syntax, unsafe_destructor)]
+           slicing_syntax, box_syntax)]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(test, feature(alloc, test))]

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -2,7 +2,7 @@
 //!
 //! These are requests that a `hyper::Server` receives, and include its method,
 //! target URI, headers, and message body.
-use std::old_io::{self, IoResult};
+use std::old_io::IoResult;
 use std::old_io::net::ip::SocketAddr;
 
 use {HttpResult};
@@ -11,7 +11,7 @@ use method::Method::{self, Get, Head};
 use header::{Headers, ContentLength, TransferEncoding};
 use http::{read_request_line};
 use http::HttpReader;
-use http::HttpReader::{SizedReader, ChunkedReader};
+use http::HttpReader::{SizedReader, ChunkedReader, EmptyReader};
 use uri::RequestUri;
 
 /// A request bundles several parts of an incoming `NetworkStream`, given to a `Handler`.
@@ -26,7 +26,7 @@ pub struct Request<'a> {
     pub uri: RequestUri,
     /// The version of HTTP for this request.
     pub version: HttpVersion,
-    body: Body<HttpReader<&'a mut (Reader + 'a)>>
+    body: HttpReader<&'a mut (Reader + 'a)>
 }
 
 
@@ -39,19 +39,18 @@ impl<'a> Request<'a> {
         let headers = try!(Headers::from_raw(&mut stream));
         debug!("{:?}", headers);
 
-        let body = if let Some(len) = headers.get::<ContentLength>() {
-            SizedReader(stream, **len)
+        let body = if method == Get || method == Head {
+            EmptyReader(stream)
+        } else if headers.has::<ContentLength>() {
+            match headers.get::<ContentLength>() {
+                Some(&ContentLength(len)) => SizedReader(stream, len),
+                None => unreachable!()
+            }
         } else if headers.has::<TransferEncoding>() {
             todo!("check for Transfer-Encoding: chunked");
             ChunkedReader(stream, None)
         } else {
-            SizedReader(stream, 0)
-        };
-
-        let body = if method == Get || method == Head {
-            Body::Empty(body)
-        } else {
-            Body::NonEmpty(body)
+            EmptyReader(stream)
         };
 
         Ok(Request {
@@ -69,31 +68,13 @@ impl<'a> Request<'a> {
                                  RequestUri, HttpVersion,
                                  HttpReader<&'a mut (Reader + 'a)>,) {
         (self.remote_addr, self.method, self.headers,
-         self.uri, self.version, self.body.into_inner())
+         self.uri, self.version, self.body)
     }
 }
 
 impl<'a> Reader for Request<'a> {
-    #[inline]
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
-        match self.body {
-            Body::Empty(..) => Err(old_io::standard_error(old_io::EndOfFile)),
-            Body::NonEmpty(ref mut r) => r.read(buf)
-        }
-    }
-}
-
-enum Body<R> {
-    Empty(R),
-    NonEmpty(R),
-}
-
-impl<R> Body<R> {
-    fn into_inner(self) -> R {
-        match self {
-            Body::Empty(r) => r,
-            Body::NonEmpty(r) => r
-        }
+        self.body.read(buf)
     }
 }
 
@@ -114,9 +95,8 @@ mod tests {
         let mut stream = MockStream::with_input(b"\
             GET / HTTP/1.1\r\n\
             Host: example.domain\r\n\
-            Content-Length: 18\r\n\
             \r\n\
-            I'm a bad request.\
+            I'm a bad request.\r\n\
         ");
 
         let mut req = Request::new(&mut stream, sock("127.0.0.1:80")).unwrap();
@@ -128,20 +108,6 @@ mod tests {
         let mut stream = MockStream::with_input(b"\
             HEAD / HTTP/1.1\r\n\
             Host: example.domain\r\n\
-            Content-Length: 18\r\n\
-            \r\n\
-            I'm a bad request.\
-        ");
-
-        let mut req = Request::new(&mut stream, sock("127.0.0.1:80")).unwrap();
-        assert_eq!(req.read_to_string(), Ok("".to_string()));
-    }
-
-    #[test]
-    fn test_post_body_with_no_content_length() {
-        let mut stream = MockStream::with_input(b"\
-            POST / HTTP/1.1\r\n\
-            Host: example.domain\r\n\
             \r\n\
             I'm a bad request.\r\n\
         ");
@@ -151,17 +117,16 @@ mod tests {
     }
 
     #[test]
-    fn test_unexpected_body_drains_upon_drop() {
+    fn test_post_empty_body() {
         let mut stream = MockStream::with_input(b"\
-            GET / HTTP/1.1\r\n\
+            POST / HTTP/1.1\r\n\
             Host: example.domain\r\n\
-            Content-Length: 18\r\n\
             \r\n\
-            I'm a bad request.\
+            I'm a bad request.\r\n\
         ");
 
-        Request::new(&mut stream, sock("127.0.0.1:80")).unwrap().read_to_string().unwrap();
-        assert!(stream.read.eof());
+        let mut req = Request::new(&mut stream, sock("127.0.0.1:80")).unwrap();
+        assert_eq!(req.read_to_string(), Ok("".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Reverts hyperium/hyper#310

This is not a good idea, since it means that the request will be read in its entirety no matter what, which is very much not a desirable property for many servers.