### PR TITLE
fix(headers): use $crate when referring to hyper modules on macros

### DIFF
--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -108,7 +108,7 @@ macro_rules! impl_list_header(
 
         impl ::std::fmt::Display for $from {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                use header::HeaderFormat;
+                use $crate::header::HeaderFormat;
                 self.fmt_header(f)
             }
         }
@@ -138,7 +138,7 @@ macro_rules! impl_header(
 
         impl ::std::fmt::Display for $from {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                use header::HeaderFormat;
+                use $crate::header::HeaderFormat;
                 self.fmt_header(f)
             }
         }


### PR DESCRIPTION
This adds a `$crate` variable missed by de1be6726

Note that even though this PR targets master, it needs #324 (or some equivalent PR) to build on the current rust nightly. Let me know if I should rebase.

Closes #323