### PR TITLE
fix(*) Fixes a few compiler errrors and a ton of warnings

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -197,7 +197,7 @@ impl<'a, U: IntoUrl, C: NetworkConnector> RequestBuilder<'a, U, C> {
                 // punching borrowck here
                 let loc = match res.headers.get::<Location>() {
                     Some(&Location(ref loc)) => {
-                        Some(UrlParser::new().base_url(&url).parse(&loc[]))
+                        Some(UrlParser::new().base_url(&url).parse(&loc))
                     }
                     None => {
                         debug!("no Location header");
@@ -394,7 +394,7 @@ mod tests {
     #[test]
     fn test_redirect_followif() {
         fn follow_if(url: &Url) -> bool {
-            !url.serialize()[].contains("127.0.0.3")
+            !url.serialize().contains("127.0.0.3")
         }
         let mut client = Client::with_connector(MockRedirectPolicy);
         client.set_redirect_policy(RedirectPolicy::FollowIf(follow_if));

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -77,7 +77,7 @@ impl Request<Fresh> {
         //TODO: this needs a test
         if let Some(ref q) = self.url.query {
             uri.push('?');
-            uri.push_str(&q[]);
+            uri.push_str(&q);
         }
 
         debug!("writing head: {:?} {:?} {:?}", self.method, uri, self.version);
@@ -185,7 +185,7 @@ mod tests {
         let stream = *req.body.end().unwrap()
             .into_inner().downcast::<MockStream>().ok().unwrap();
         let bytes = stream.write.into_inner();
-        let s = from_utf8(&bytes[]).unwrap();
+        let s = from_utf8(&bytes).unwrap();
         assert!(!s.contains("Content-Length:"));
         assert!(!s.contains("Transfer-Encoding:"));
     }
@@ -199,7 +199,7 @@ mod tests {
         let stream = *req.body.end().unwrap()
             .into_inner().downcast::<MockStream>().ok().unwrap();
         let bytes = stream.write.into_inner();
-        let s = from_utf8(&bytes[]).unwrap();
+        let s = from_utf8(&bytes).unwrap();
         assert!(!s.contains("Content-Length:"));
         assert!(!s.contains("Transfer-Encoding:"));
     }

--- a/src/header/common/access_control/allow_origin.rs
+++ b/src/header/common/access_control/allow_origin.rs
@@ -29,7 +29,7 @@ impl header::Header for AccessControlAllowOrigin {
 
     fn parse_header(raw: &[Vec<u8>]) -> Option<AccessControlAllowOrigin> {
         if raw.len() == 1 {
-            match str::from_utf8(unsafe { &raw[].get_unchecked(0)[] }) {
+            match str::from_utf8(unsafe { &raw.get_unchecked(0) }) {
                 Ok(s) => {
                     if s == "*" {
                         Some(AccessControlAllowOrigin::AllowStar)

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -29,7 +29,7 @@ impl<S: Scheme> Header for Authorization<S> {
 
     fn parse_header(raw: &[Vec<u8>]) -> Option<Authorization<S>> {
         if raw.len() == 1 {
-            match (from_utf8(unsafe { &raw[].get_unchecked(0)[] }), Scheme::scheme(None::<S>)) {
+            match (from_utf8(unsafe { &raw.get_unchecked(0) }), Scheme::scheme(None::<S>)) {
                 (Ok(header), Some(scheme))
                     if header.starts_with(scheme) && header.len() > scheme.len() + 1 => {
                     header[scheme.len() + 1..].parse::<S>().map(|s| Authorization(s)).ok()
@@ -96,7 +96,7 @@ impl Scheme for Basic {
         let mut text = self.username.clone();
         text.push(':');
         if let Some(ref pass) = self.password {
-            text.push_str(&pass[]);
+            text.push_str(&pass);
         }
         write!(f, "{}", text.as_bytes().to_base64(Config {
             char_set: Standard,
@@ -113,7 +113,7 @@ impl FromStr for Basic {
         match s.from_base64() {
             Ok(decoded) => match String::from_utf8(decoded) {
                 Ok(text) => {
-                    let mut parts = &mut text[].split(':');
+                    let mut parts = &mut text.split(':');
                     let user = match parts.next() {
                         Some(part) => part.to_string(),
                         None => return Err(())

--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -16,7 +16,7 @@ impl Header for CacheControl {
 
     fn parse_header(raw: &[Vec<u8>]) -> Option<CacheControl> {
         let directives = raw.iter()
-            .filter_map(|line| from_one_comma_delimited(&line[]))
+            .filter_map(|line| from_one_comma_delimited(&line))
             .collect::<Vec<Vec<CacheDirective>>>()
             .concat();
         if directives.len() > 0 {
@@ -29,7 +29,7 @@ impl Header for CacheControl {
 
 impl HeaderFormat for CacheControl {
     fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt_comma_delimited(fmt, &self[])
+        fmt_comma_delimited(fmt, &self)
     }
 }
 
@@ -88,7 +88,7 @@ impl fmt::Display for CacheDirective {
             ProxyRevalidate => "proxy-revalidate",
             SMaxAge(secs) => return write!(f, "s-maxage={}", secs),
 
-            Extension(ref name, None) => &name[],
+            Extension(ref name, None) => &name,
             Extension(ref name, Some(ref arg)) => return write!(f, "{}={}", name, arg),
 
         }, f)

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -64,7 +64,7 @@ impl Header for Connection {
 impl HeaderFormat for Connection {
     fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let Connection(ref parts) = *self;
-        fmt_comma_delimited(fmt, &parts[])
+        fmt_comma_delimited(fmt, &parts)
     }
 }
 

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -26,7 +26,7 @@ impl Header for Cookie {
     fn parse_header(raw: &[Vec<u8>]) -> Option<Cookie> {
         let mut cookies = Vec::with_capacity(raw.len());
         for cookies_raw in raw.iter() {
-            match from_utf8(&cookies_raw[]) {
+            match from_utf8(&cookies_raw) {
                 Ok(cookies_str) => {
                     for cookie_str in cookies_str.split(';') {
                         match cookie_str.trim().parse() {
@@ -82,7 +82,7 @@ impl Cookie {
 
 #[test]
 fn test_parse() {
-    let h = Header::parse_header(&[b"foo=bar; baz=quux".to_vec()][]);
+    let h = Header::parse_header(&[b"foo=bar; baz=quux".to_vec()]);
     let c1 = CookiePair::new("foo".to_string(), "bar".to_string());
     let c2 = CookiePair::new("baz".to_string(), "quux".to_string());
     assert_eq!(h, Some(Cookie(vec![c1, c2])));
@@ -99,7 +99,7 @@ fn test_fmt() {
     let mut headers = Headers::new();
     headers.set(cookie_header);
 
-    assert_eq!(&headers.to_string()[], "Cookie: foo=bar; baz=quux\r\n");
+    assert_eq!(&headers.to_string(), "Cookie: foo=bar; baz=quux\r\n");
 }
 
 #[test]

--- a/src/header/common/host.rs
+++ b/src/header/common/host.rs
@@ -28,7 +28,7 @@ impl Header for Host {
             // FIXME: use rust-url to parse this
             // https://github.com/servo/rust-url/issues/42
             let idx = {
-                let slice = &s[];
+                let slice = &s;
                 if slice.char_at(1) == '[' {
                     match slice.rfind(']') {
                         Some(idx) => {

--- a/src/header/common/if_match.rs
+++ b/src/header/common/if_match.rs
@@ -25,7 +25,7 @@ impl Header for IfMatch {
 
     fn parse_header(raw: &[Vec<u8>]) -> Option<IfMatch> {
         from_one_raw_str(raw).and_then(|s: String| {
-            let slice = &s[];
+            let slice = &s;
             match slice {
                 "" => None,
                 "*" => Some(IfMatch::Any),
@@ -39,7 +39,7 @@ impl HeaderFormat for IfMatch {
     fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             IfMatch::Any => write!(fmt, "*"),
-            IfMatch::EntityTags(ref fields) => fmt_comma_delimited(fmt, &fields[])
+            IfMatch::EntityTags(ref fields) => fmt_comma_delimited(fmt, &fields)
         }
     }
 }

--- a/src/header/common/if_none_match.rs
+++ b/src/header/common/if_none_match.rs
@@ -33,7 +33,7 @@ impl Header for IfNoneMatch {
 
     fn parse_header(raw: &[Vec<u8>]) -> Option<IfNoneMatch> {
         from_one_raw_str(raw).and_then(|s: String| {
-            let slice = &s[];
+            let slice = &s;
             match slice {
                 "" => None,
                 "*" => Some(IfNoneMatch::Any),
@@ -47,7 +47,7 @@ impl HeaderFormat for IfNoneMatch {
     fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             IfNoneMatch::Any => { write!(fmt, "*") }
-            IfNoneMatch::EntityTags(ref fields) => { fmt_comma_delimited(fmt, &fields[]) }
+            IfNoneMatch::EntityTags(ref fields) => { fmt_comma_delimited(fmt, &fields) }
         }
     }
 }

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -50,13 +50,13 @@ macro_rules! bench_header(
             fn bench_parse(b: &mut Bencher) {
                 let val = $value;
                 b.iter(|| {
-                    let _: $ty = Header::parse_header(&val[]).unwrap();
+                    let _: $ty = Header::parse_header(&val).unwrap();
                 });
             }
 
             #[bench]
             fn bench_format(b: &mut Bencher) {
-                let val: $ty = Header::parse_header(&$value[]).unwrap();
+                let val: $ty = Header::parse_header(&$value).unwrap();
                 let fmt = HeaderFormatter(&val);
                 b.iter(|| {
                     format!("{}", fmt);
@@ -102,7 +102,7 @@ macro_rules! impl_list_header(
 
         impl $crate::header::HeaderFormat for $from {
             fn fmt_header(&self, fmt: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                $crate::header::parsing::fmt_comma_delimited(fmt, &self[])
+                $crate::header::parsing::fmt_comma_delimited(fmt, &self)
             }
         }
 

--- a/src/header/common/pragma.rs
+++ b/src/header/common/pragma.rs
@@ -31,7 +31,7 @@ impl Header for Pragma {
 
     fn parse_header(raw: &[Vec<u8>]) -> Option<Pragma> {
         parsing::from_one_raw_str(raw).and_then(|s: String| {
-            let slice = &s.to_ascii_lowercase()[];
+            let slice = &s.to_ascii_lowercase();
             match slice {
                 "" => None,
                 "no-cache" => Some(Pragma::NoCache),

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -23,7 +23,7 @@ impl Header for SetCookie {
     fn parse_header(raw: &[Vec<u8>]) -> Option<SetCookie> {
         let mut set_cookies = Vec::with_capacity(raw.len());
         for set_cookies_raw in raw.iter() {
-            match from_utf8(&set_cookies_raw[]) {
+            match from_utf8(&set_cookies_raw) {
                 Ok(s) if !s.is_empty() => {
                     match s.parse() {
                         Ok(cookie) => set_cookies.push(cookie),
@@ -76,7 +76,7 @@ impl SetCookie {
 
 #[test]
 fn test_parse() {
-    let h = Header::parse_header(&[b"foo=bar; HttpOnly".to_vec()][]);
+    let h = Header::parse_header(&[b"foo=bar; HttpOnly".to_vec()]);
     let mut c1 = Cookie::new("foo".to_string(), "bar".to_string());
     c1.httponly = true;
 
@@ -94,7 +94,7 @@ fn test_fmt() {
     let mut headers = Headers::new();
     headers.set(cookies);
 
-    assert_eq!(&headers.to_string()[], "Set-Cookie: foo=bar; HttpOnly; Path=/p\r\nSet-Cookie: baz=quux; Path=/\r\n");
+    assert_eq!(&headers.to_string(), "Set-Cookie: foo=bar; HttpOnly; Path=/p\r\nSet-Cookie: baz=quux; Path=/\r\n");
 }
 
 #[test]

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -55,7 +55,7 @@ impl Header for Upgrade {
 impl HeaderFormat for Upgrade {
     fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let Upgrade(ref parts) = *self;
-        fmt_comma_delimited(fmt, &parts[])
+        fmt_comma_delimited(fmt, &parts)
     }
 }
 

--- a/src/header/common/vary.rs
+++ b/src/header/common/vary.rs
@@ -21,7 +21,7 @@ impl Header for Vary {
 
     fn parse_header(raw: &[Vec<u8>]) -> Option<Vary> {
         from_one_raw_str(raw).and_then(|s: String| {
-            let slice = &s[];
+            let slice = &s;
             match slice {
                 "" => None,
                 "*" => Some(Vary::Any),
@@ -35,7 +35,7 @@ impl HeaderFormat for Vary {
     fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Vary::Any => { write!(fmt, "*") }
-            Vary::Headers(ref fields) => { fmt_comma_delimited(fmt, &fields[]) }
+            Vary::Headers(ref fields) => { fmt_comma_delimited(fmt, &fields) }
         }
     }
 }

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -139,7 +139,7 @@ impl Headers {
         loop {
             match try!(http::read_header(rdr)) {
                 Some((name, value)) => {
-                    debug!("raw header: {:?}={:?}", name, &value[]);
+                    debug!("raw header: {:?}={:?}", name, &value);
                     count += (name.len() + value.len()) as u32;
                     if count > MAX_HEADERS_LENGTH {
                         debug!("Max header size reached, aborting");
@@ -183,14 +183,14 @@ impl Headers {
             .get(&UniCase(Borrowed(unsafe { mem::transmute::<&str, &str>(name) })))
             .and_then(|item| {
                 if let Some(ref raw) = *item.raw {
-                    return Some(&raw[]);
+                    return Some(&raw);
                 }
 
                 let raw = vec![item.typed.as_ref().unwrap().to_string().into_bytes()];
                 item.raw.set(raw);
 
                 let raw = item.raw.as_ref().unwrap();
-                Some(&raw[])
+                Some(&raw)
             })
     }
 
@@ -203,7 +203,7 @@ impl Headers {
     /// # let mut headers = Headers::new();
     /// headers.set_raw("content-length", vec![b"5".to_vec()]);
     /// ```
-    pub fn set_raw<K: IntoCow<'static, String, str>>(&mut self, name: K, value: Vec<Vec<u8>>) {
+    pub fn set_raw<K: IntoCow<'static, str>>(&mut self, name: K, value: Vec<Vec<u8>>) {
         self.data.insert(UniCase(name.into_cow()), Item::new_raw(value));
     }
 
@@ -451,7 +451,7 @@ fn get_or_parse_mut<H: Header + HeaderFormat>(item: &mut Item) -> Option<&mut It
 
 fn parse<H: Header + HeaderFormat>(item: &Item) {
     match *item.raw {
-        Some(ref raw) => match Header::parse_header(&raw[]) {
+        Some(ref raw) => match Header::parse_header(&raw) {
             Some::<H>(h) => item.typed.set(box h as Box<HeaderFormat + Send + Sync>),
             None => ()
         },
@@ -476,7 +476,7 @@ impl fmt::Display for Item {
             None => match *self.raw {
                 Some(ref raw) => {
                     for part in raw.iter() {
-                        match from_utf8(&part[]) {
+                        match from_utf8(&part) {
                             Ok(s) => try!(fmt.write_str(s)),
                             Err(e) => {
                                 error!("raw header value is not utf8. header={:?}, error={:?}", part, e);
@@ -595,7 +595,7 @@ mod tests {
                 return None;
             }
             // we JUST checked that raw.len() == 1, so raw[0] WILL exist.
-            match from_utf8(unsafe { &raw[].get_unchecked(0)[] }) {
+            match from_utf8(unsafe { &raw.get_unchecked(0) }) {
                 Ok(s) => FromStr::from_str(s).ok(),
                 Err(_) => None
             }.map(|u| CrazyLength(Some(false), u))

--- a/src/header/parsing.rs
+++ b/src/header/parsing.rs
@@ -11,7 +11,7 @@ pub fn from_one_raw_str<T: str::FromStr>(raw: &[Vec<u8>]) -> Option<T> {
         return None;
     }
     // we JUST checked that raw.len() == 1, so raw[0] WILL exist.
-    match str::from_utf8(&raw[0][]) {
+    match str::from_utf8(&raw[0]) {
         Ok(s) => str::FromStr::from_str(s).ok(),
         Err(_) => None
     }
@@ -24,7 +24,7 @@ pub fn from_comma_delimited<T: str::FromStr>(raw: &[Vec<u8>]) -> Option<Vec<T>> 
         return None;
     }
     // we JUST checked that raw.len() == 1, so raw[0] WILL exist.
-    from_one_comma_delimited(&raw[0][])
+    from_one_comma_delimited(&raw[0])
 }
 
 /// Reads a comma-delimited raw string into a Vec.

--- a/src/header/shared/entity.rs
+++ b/src/header/shared/entity.rs
@@ -42,7 +42,7 @@ impl FromStr for EntityTag {
     type Err = ();
     fn from_str(s: &str) -> Result<EntityTag, ()> {
         let length: usize = s.len();
-        let slice = &s[];
+        let slice = &s;
 
         // Early exits:
         // 1. The string is empty, or,

--- a/src/header/shared/quality_item.rs
+++ b/src/header/shared/quality_item.rs
@@ -39,7 +39,7 @@ impl<T: fmt::Display> fmt::Display for QualityItem<T> {
             write!(f, "{}", self.item)
         } else {
             write!(f, "{}; q={}", self.item,
-                   format!("{:.3}", self.quality).trim_right_matches(&['0', '.'][]))
+                   format!("{:.3}", self.quality).trim_right_matches(&['0', '.']))
         }
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -395,7 +395,7 @@ pub fn read_method<R: Reader>(stream: &mut R) -> HttpResult<method::Method> {
 
     debug!("maybe_method = {:?}", maybe_method);
 
-    match (maybe_method, &buf[]) {
+    match (maybe_method, &buf) {
         (Some(method), _) => Ok(method),
         (None, ext) => {
             // We already checked that the buffer is ASCII
@@ -664,7 +664,7 @@ pub fn read_status<R: Reader>(stream: &mut R) -> HttpResult<RawStatus> {
         }
     }
 
-    let reason = match str::from_utf8(&buf[]) {
+    let reason = match str::from_utf8(&buf) {
         Ok(s) => s.trim(),
         Err(_) => return Err(HttpStatusError)
     };

--- a/src/net.rs
+++ b/src/net.rs
@@ -58,7 +58,7 @@ pub trait NetworkAcceptor: Clone + Send {
 }
 
 /// An iterator wrapper over a NetworkAcceptor.
-pub struct NetworkConnections<'a, N: NetworkAcceptor>(&'a mut N);
+pub struct NetworkConnections<'a, N: 'a + NetworkAcceptor>(&'a mut N);
 
 impl<'a, N: NetworkAcceptor> Iterator for NetworkConnections<'a, N> {
     type Item = IoResult<N::Stream>;


### PR DESCRIPTION
I tried to add hyper as a dependency as a new dependency in a project when I noticed it didn't compile
with the nightly build of rust.

A few things I fixed were

1) an incorrect number of type parameters provided to Cow ( seems to have changed in https://github.com/rust-lang/rust/pull/22210/files )
2) A compiler error with the lifetime of a type parameter with an Authorization header's Scheme type ( the fix was outlined here http://stackoverflow.com/questions/25920796/how-do-i-implement-a-struct-that-takes-a-generic-vector-with-lifetime-annotation )
3) fixed a one of compiler warnings related to slicing ([] is now obsolete)

There are still a few compiler errors I couldn't figure out how to fix but I thought this would get you started :)