### PR TITLE
fix(cargo): set openssl to compatible v0.4.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ authors = ["Sean McArthur <sean.monstar@gmail.com>",
 keywords = ["http", "hyper", "hyperium"]
 
 [dependencies]
-cookie = "*"
+cookie = "= 0.1.13"
 log = ">= 0.2.0"
 mime = "*"
-openssl = "*"
+openssl = "0.4.3"
 rustc-serialize = "*"
 time = "*"
 unicase = "*"


### PR DESCRIPTION
In openssl >= 0.5.0, it's using `std::io`, which doesn't work with
std::old_io used in hyper.
To make it work consistently, `Cookie` was reset to the previous
version v0.1.13 as well, which depends on our compatible openssl
version.