### PR TITLE
Quick fix to limit upstream dependency versions to latest working stuff.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "hyper"
-version = "0.2.1"
+version = "0.2.2"
 description = "A modern HTTP library."
 readme = "README.md"
 documentation = "http://hyperium.github.io/hyper/hyper/index.html"
@@ -12,10 +12,10 @@ authors = ["Sean McArthur <sean.monstar@gmail.com>",
 keywords = ["http", "hyper", "hyperium"]
 
 [dependencies]
-cookie = "*"
+cookie = "= 0.1.13"
 log = ">= 0.2.0"
 mime = "*"
-openssl = "*"
+openssl = "0.4"
 rustc-serialize = "*"
 time = "*"
 unicase = "*"


### PR DESCRIPTION
@reem said that he'd got an actual fix for migrating to new IO and path, and he's gonna finish with it tomorrow. Meanwhile, this Cargo.toml fix will prevent hyper using the newest versions of the changed dependencies.