### PR TITLE
feat(client): add cookies support (FIXME)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "hyper"
-version = "0.2.0"
+version = "0.2.1"
 description = "A modern HTTP library."
 readme = "README.md"
 documentation = "http://hyperium.github.io/hyper/hyper/index.html"
@@ -21,3 +21,4 @@ time = "*"
 unicase = "*"
 unsafe-any = "*"
 url = "*"
+rand = "*" # src/client/mod.rs // for generate some keys which cookiejar needs.


### PR DESCRIPTION
#345 
Almost, but I don't know to do now.
Can you tell me where I should do?
I don't know do I can add "CookieJar" in the Client struct.
```rust
pub struct Client<C> {
    connector: C,
    cookie_jar: CookieJar,
    cookies_policy: CookiesPolicy,
    redirect_policy: RedirectPolicy,
}
```

The test
```rust
extern crate hyper;
extern crate cookie;
use hyper::Client;
use hyper::header::{
	Headers,
};
use hyper::header::Cookie as HCookie;	
use cookie::{
	Cookie,
	CookieJar
};
use hyper::client::RedirectPolicy;


fn main() {
	let c = CookieJar::new(b"f8f9eaf1ecdedff5e5b749c58115441e");
	let mut header = {
		let mut a = Headers::new();
		a.set(HCookie::from_cookie_jar(&c));
		a
	};
	c.add(Cookie::new("key".to_string(), "value".to_string()));
	c.add(Cookie::new("a2".to_string(), "3".to_string()));
	header.set(HCookie::from_cookie_jar(&c));
	let mut session = Client::new();
	session.set_redirect_policy(RedirectPolicy::FollowAll);
	// let mut cookjar = 
	let mut res = session.get("http://httpbin.org/get?a=1&f=2").headers(header.clone()).send().unwrap();
	println!("{}", res.headers);
	println!("{}", res.read_to_string().unwrap());
	let mut res = session.get("http://httpbin.org/cookies").headers(header.clone()).send().unwrap();
	println!("{}", header);
	println!("{}", res.headers);
	println!("{}", res.read_to_string().unwrap());
	let mut res = session.get("http://httpbin.org/cookies/set?k1=v1&k2=v2").headers(header.clone()).send().unwrap();
	println!("{}", header);
	println!("{}", res.headers);
	println!("{}", res.read_to_string().unwrap());
	session.set_redirect_policy(RedirectPolicy::FollowNone);
	let mut res = session.get("http://httpbin.org/cookies/set?k1=v1&k2=v2").send().unwrap();
	println!("{}", res.headers);
	println!("{}", res.read_to_string().unwrap());
}
```