### PR TITLE
perf(http): changes http parsing to use httparse crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["http", "hyper", "hyperium"]
 
 [dependencies]
 cookie = "*"
+httparse = "*"
 log = ">= 0.2.0"
 mime = "*"
 openssl = "*"
@@ -20,3 +21,7 @@ rustc-serialize = "*"
 time = "*"
 unicase = "*"
 url = "*"
+
+[dev-dependencies]
+env_logger = "*"
+

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,11 +1,15 @@
 #![deny(warnings)]
 extern crate hyper;
 
+extern crate env_logger;
+
 use std::env;
 
 use hyper::Client;
 
 fn main() {
+    env_logger::init().unwrap();
+
     let url = match env::args().nth(1) {
         Some(url) => url,
         None => {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,6 +1,7 @@
 #![deny(warnings)]
 #![feature(io, net)]
 extern crate hyper;
+extern crate env_logger;
 
 use std::io::Write;
 use std::net::IpAddr;
@@ -15,6 +16,7 @@ fn hello(_: Request, res: Response) {
 }
 
 fn main() {
+    env_logger::init().unwrap();
     let _listening = hyper::Server::http(hello)
         .listen(IpAddr::new_v4(127, 0, 0, 1), 3000).unwrap();
     println!("Listening on http://127.0.0.1:3000");

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 #![feature(io, net)]
 extern crate hyper;
-#[macro_use] extern crate log;
+extern crate env_logger;
 
 use std::io::{Write, copy};
 use std::net::IpAddr;
@@ -15,7 +15,7 @@ macro_rules! try_return(
     ($e:expr) => {{
         match $e {
             Ok(v) => v,
-            Err(e) => { error!("Error: {}", e); return; }
+            Err(e) => { println!("Error: {}", e); return; }
         }
     }}
 );
@@ -51,6 +51,7 @@ fn echo(mut req: Request, mut res: Response) {
 }
 
 fn main() {
+    env_logger::init().unwrap();
     let server = Server::http(echo);
     let _guard = server.listen(IpAddr::new_v4(127, 0, 0, 1), 1337).unwrap();
     println!("Listening on http://127.0.0.1:1337");

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,88 @@
+//! HttpError and HttpResult module.
+use std::error::{Error, FromError};
+use std::fmt;
+use std::io::Error as IoError;
+
+use httparse;
+use url;
+
+use self::HttpError::{HttpMethodError, HttpUriError, HttpVersionError,
+                      HttpHeaderError, HttpStatusError, HttpIoError,
+                      HttpTooLargeError};
+
+
+/// Result type often returned from methods that can have `HttpError`s.
+pub type HttpResult<T> = Result<T, HttpError>;
+
+/// A set of errors that can occur parsing HTTP streams.
+#[derive(Debug, PartialEq, Clone)]
+pub enum HttpError {
+    /// An invalid `Method`, such as `GE,T`.
+    HttpMethodError,
+    /// An invalid `RequestUri`, such as `exam ple.domain`.
+    HttpUriError(url::ParseError),
+    /// An invalid `HttpVersion`, such as `HTP/1.1`
+    HttpVersionError,
+    /// An invalid `Header`.
+    HttpHeaderError,
+    /// A message head is too large to be reasonable.
+    HttpTooLargeError,
+    /// An invalid `Status`, such as `1337 ELITE`.
+    HttpStatusError,
+    /// An `IoError` that occured while trying to read or write to a network stream.
+    HttpIoError(IoError),
+}
+
+impl fmt::Display for HttpError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.description())
+    }
+}
+
+impl Error for HttpError {
+    fn description(&self) -> &str {
+        match *self {
+            HttpMethodError => "Invalid Method specified",
+            HttpUriError(_) => "Invalid Request URI specified",
+            HttpVersionError => "Invalid HTTP version specified",
+            HttpHeaderError => "Invalid Header provided",
+            HttpTooLargeError => "Message head is too large",
+            HttpStatusError => "Invalid Status provided",
+            HttpIoError(_) => "An IoError occurred while connecting to the specified network",
+        }
+    }
+
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            HttpIoError(ref error) => Some(error as &Error),
+            HttpUriError(ref error) => Some(error as &Error),
+            _ => None,
+        }
+    }
+}
+
+impl FromError<IoError> for HttpError {
+    fn from_error(err: IoError) -> HttpError {
+        HttpIoError(err)
+    }
+}
+
+impl FromError<url::ParseError> for HttpError {
+    fn from_error(err: url::ParseError) -> HttpError {
+        HttpUriError(err)
+    }
+}
+
+impl FromError<httparse::Error> for HttpError {
+    fn from_error(err: httparse::Error) -> HttpError {
+        match err {
+            httparse::Error::HeaderName => HttpHeaderError,
+            httparse::Error::HeaderValue => HttpHeaderError,
+            httparse::Error::NewLine => HttpHeaderError,
+            httparse::Error::Status => HttpStatusError,
+            httparse::Error::Token => HttpHeaderError,
+            httparse::Error::TooManyHeaders => HttpTooLargeError,
+            httparse::Error::Version => HttpVersionError,
+        }
+    }
+}

--- a/src/method.rs
+++ b/src/method.rs
@@ -2,6 +2,7 @@
 use std::fmt;
 use std::str::FromStr;
 
+use error::HttpError;
 use self::Method::{Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch,
                    Extension};
 
@@ -68,10 +69,10 @@ impl Method {
 }
 
 impl FromStr for Method {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Method, ()> {
+    type Err = HttpError;
+    fn from_str(s: &str) -> Result<Method, HttpError> {
         if s == "" {
-            Err(())
+            Err(HttpError::HttpMethodError)
         } else {
             Ok(match s {
                 "OPTIONS" => Options,

--- a/src/net.rs
+++ b/src/net.rs
@@ -66,7 +66,6 @@ pub trait NetworkStream: Read + Write + Any + StreamClone + Send {
     fn peer_addr(&mut self) -> io::Result<SocketAddr>;
 }
 
-
 #[doc(hidden)]
 pub trait StreamClone {
     fn clone_box(&self) -> Box<NetworkStream + Send>;


### PR DESCRIPTION
httparse is a http1 stateless push parser. This not only speeds up
parsing right now with sync io, but will also be useful for when we get
async io, since it's push based instead of pull.

BREAKING CHANGE: Several public functions and types in the `http` module
  have been removed. They have been replaced with 2 methods that handle
  all of the http1 parsing.