### PR TITLE
feat(client): add a default UserAgent

### DIFF
--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -184,7 +184,7 @@ mod tests {
     #[test]
     fn test_get_empty_body() {
         let req = Request::with_connector(
-            Get, Url::parse("http://example.dom").unwrap(), &mut MockConnector
+            Get, Url::parse("http://example.dom").unwrap(), &mut MockConnector(b"")
         ).unwrap();
         let req = req.start().unwrap();
         let stream = *req.body.end().unwrap()
@@ -198,7 +198,7 @@ mod tests {
     #[test]
     fn test_head_empty_body() {
         let req = Request::with_connector(
-            Head, Url::parse("http://example.dom").unwrap(), &mut MockConnector
+            Head, Url::parse("http://example.dom").unwrap(), &mut MockConnector(b"")
         ).unwrap();
         let req = req.start().unwrap();
         let stream = *req.body.end().unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,7 @@ extern crate log;
 #[cfg(test)]
 extern crate test;
 
+pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 pub use mimewrapper::mime;
 pub use url::Url;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -68,13 +68,13 @@ impl NetworkStream for MockStream {
     }
 }
 
-pub struct MockConnector;
+pub struct MockConnector(pub &'static [u8]);
 
 impl NetworkConnector for MockConnector {
     type Stream = MockStream;
 
     fn connect(&mut self, _host: &str, _port: u16, _scheme: &str) -> io::Result<MockStream> {
-        Ok(MockStream::new())
+        Ok(MockStream::with_input(self.0))
     }
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -86,7 +86,7 @@ pub trait NetworkConnector {
     fn connect(&mut self, host: &str, port: u16, scheme: &str) -> io::Result<Self::Stream>;
 }
 
-impl fmt::Debug for Box<NetworkStream + Send> {
+impl fmt::Debug for Box<NetworkStream> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.pad("Box<NetworkStream>")
     }


### PR DESCRIPTION
The user agent of a client can be changed via the `set_user_agent`
method. If not changed, the default will be `hyper/$VERSION`.

Closes #373