### PR TITLE
fix(rustup): rustc 1.0.0-nightly (ea8b82e90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Hello World Server:
 extern crate hyper;
 
 use std::io::Write;
-use std::net::IpAddr;
+use std::net::Ipv4Addr;
 
 use hyper::Server;
 use hyper::server::Request;
@@ -42,7 +42,7 @@ fn hello(_: Request, mut res: Response<Fresh>) {
 }
 
 fn main() {
-    Server::http(hello).listen(IpAddr::new_v4(127, 0, 0, 1), 3000).unwrap();
+    Server::http(hello).listen(Ipv4Addr::new(127, 0, 0, 1), 3000).unwrap();
 }
 ```
 

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-#![feature(collections, io, net, test)]
+#![feature(collections, test)]
 extern crate hyper;
 
 extern crate test;

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -5,7 +5,7 @@ extern crate test;
 
 use test::Bencher;
 use std::io::{Read, Write};
-use std::net::IpAddr;
+use std::net::Ipv4Addr;
 
 use hyper::method::Method::Get;
 use hyper::server::{Request, Response};
@@ -27,7 +27,7 @@ fn hyper_handle(_: Request, res: Response) {
 #[bench]
 fn bench_hyper(b: &mut Bencher) {
     let server = hyper::Server::http(hyper_handle);
-    let mut listener = server.listen(IpAddr::new_v4(127, 0, 0, 1), 0).unwrap();
+    let mut listener = server.listen(Ipv4Addr::new(127, 0, 0, 1), 0).unwrap();
 
     let url = hyper::Url::parse(&*format!("http://{}", listener.socket)).unwrap();
     b.iter(|| request(url.clone()));

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-#![feature(net, test)]
+#![feature(test)]
 extern crate hyper;
 extern crate test;
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,10 +1,9 @@
 #![deny(warnings)]
-#![feature(net)]
 extern crate hyper;
 extern crate env_logger;
 
 use std::io::Write;
-use std::net::IpAddr;
+use std::net::Ipv4Addr;
 use hyper::server::{Request, Response};
 
 static PHRASE: &'static [u8] = b"Hello World!";
@@ -18,6 +17,6 @@ fn hello(_: Request, res: Response) {
 fn main() {
     env_logger::init().unwrap();
     let _listening = hyper::Server::http(hello)
-        .listen(IpAddr::new_v4(127, 0, 0, 1), 3000).unwrap();
+        .listen(Ipv4Addr::new(127, 0, 0, 1), 3000).unwrap();
     println!("Listening on http://127.0.0.1:3000");
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,10 +1,9 @@
 #![deny(warnings)]
-#![feature(net)]
 extern crate hyper;
 extern crate env_logger;
 
 use std::io::{Write, copy};
-use std::net::IpAddr;
+use std::net::Ipv4Addr;
 
 use hyper::{Get, Post};
 use hyper::header::ContentLength;
@@ -53,6 +52,6 @@ fn echo(mut req: Request, mut res: Response) {
 fn main() {
     env_logger::init().unwrap();
     let server = Server::http(echo);
-    let _guard = server.listen(IpAddr::new_v4(127, 0, 0, 1), 1337).unwrap();
+    let _guard = server.listen(Ipv4Addr::new(127, 0, 0, 1), 1337).unwrap();
     println!("Listening on http://127.0.0.1:1337");
 }

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -75,7 +75,7 @@ impl<T: HeaderFormat + Send + Sync + Clone> HeaderClone for T {
     }
 }
 
-impl HeaderFormat {
+impl HeaderFormat + Send + Sync {
     #[inline]
     unsafe fn downcast_ref_unchecked<T: 'static>(&self) -> &T {
         mem::transmute(mem::transmute::<&HeaderFormat, raw::TraitObject>(self).data)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(core, collections, io, net,
+#![feature(core, collections, io,
            std_misc, box_syntax, unsafe_destructor)]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]

--- a/src/net.rs
+++ b/src/net.rs
@@ -215,8 +215,8 @@ impl NetworkListener for HttpListener {
     #[inline]
     fn socket_addr(&mut self) -> io::Result<SocketAddr> {
         match *self {
-            HttpListener::Http(ref mut tcp) => tcp.socket_addr(),
-            HttpListener::Https(ref mut tcp, _) => tcp.socket_addr(),
+            HttpListener::Http(ref mut tcp) => tcp.local_addr(),
+            HttpListener::Https(ref mut tcp, _) => tcp.local_addr(),
         }
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -97,7 +97,7 @@ impl Clone for Box<NetworkStream + Send> {
     fn clone(&self) -> Box<NetworkStream + Send> { self.clone_box() }
 }
 
-impl NetworkStream {
+impl NetworkStream + Send {
     unsafe fn downcast_ref_unchecked<T: 'static>(&self) -> &T {
         mem::transmute(mem::transmute::<&NetworkStream,
                                         raw::TraitObject>(self).data)
@@ -108,13 +108,13 @@ impl NetworkStream {
                                         raw::TraitObject>(self).data)
     }
 
-    unsafe fn downcast_unchecked<T: 'static>(self: Box<NetworkStream>) -> Box<T>  {
-        mem::transmute(mem::transmute::<Box<NetworkStream>,
+    unsafe fn downcast_unchecked<T: 'static>(self: Box<NetworkStream + Send>) -> Box<T>  {
+        mem::transmute(mem::transmute::<Box<NetworkStream + Send>,
                                         raw::TraitObject>(self).data)
     }
 }
 
-impl NetworkStream {
+impl NetworkStream + Send {
     /// Is the underlying type in this trait object a T?
     #[inline]
     pub fn is<T: 'static>(&self) -> bool {
@@ -143,8 +143,8 @@ impl NetworkStream {
     }
 
     /// If the underlying type is T, extract it.
-    pub fn downcast<T: 'static>(self: Box<NetworkStream>)
-            -> Result<Box<T>, Box<NetworkStream>> {
+    pub fn downcast<T: 'static>(self: Box<NetworkStream + Send>)
+            -> Result<Box<T>, Box<NetworkStream + Send>> {
         if self.is::<T>() {
             Ok(unsafe { self.downcast_unchecked() })
         } else {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,7 +1,7 @@
 //! HTTP Server
 use std::io::{BufReader, BufWriter, Write};
 use std::marker::PhantomData;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::Path;
 use std::thread::{self, JoinGuard};
 
@@ -76,7 +76,7 @@ impl<'a, H: Handler + 'static> Server<'a, H, HttpListener> {
 
 impl<'a, H: Handler + 'static> Server<'a, H, HttpListener> {
     /// Binds to a socket, and starts handling connections using a task pool.
-    pub fn listen_threads(self, ip: IpAddr, port: u16, threads: usize) -> HttpResult<Listening> {
+    pub fn listen_threads(self, ip: Ipv4Addr, port: u16, threads: usize) -> HttpResult<Listening> {
         let addr = &(ip, port);
         let listener = try!(match self.ssl {
             Some((cert, key)) => HttpListener::https(addr, cert, key),
@@ -86,7 +86,7 @@ impl<'a, H: Handler + 'static> Server<'a, H, HttpListener> {
     }
 
     /// Binds to a socket and starts handling connections.
-    pub fn listen(self, ip: IpAddr, port: u16) -> HttpResult<Listening> {
+    pub fn listen(self, ip: Ipv4Addr, port: u16) -> HttpResult<Listening> {
         self.listen_threads(ip, port, num_cpus::get() * 5 / 4)
     }
 }


### PR DESCRIPTION
This PR fixes `cargo build` and `cargo test`, and includes the PR of @adrianheine .

Method lookup on traits seems to have changed to force
`impl TraitName` expressions to be more specific. That means that
`method` will not be found anymore on an object of type `&Trait+Send`,
unless you provide an `impl Trait+Send`.

Now `NetworkStream` and `HeaderFormat` trait implementations
are done against `* + Send`, which helps the compiler to find the
respective `downcast*` method implementations once again.