### PR TITLE
fix(rustup): 1.0.0-nightly (e2fa53e59 2015-03-20)

### DIFF
--- a/src/header/common/host.rs
+++ b/src/header/common/host.rs
@@ -28,7 +28,9 @@ impl Header for Host {
             // https://github.com/servo/rust-url/issues/42
             let idx = {
                 let slice = &s[..];
-                if slice.char_at(1) == '[' {
+                let mut chars = slice.chars();
+                chars.next();
+                if chars.next().unwrap() == '[' {
                     match slice.rfind(']') {
                         Some(idx) => {
                             if slice.len() > idx + 2 {

--- a/src/header/shared/entity.rs
+++ b/src/header/shared/entity.rs
@@ -52,7 +52,7 @@ impl FromStr for EntityTag {
         }
 
         // The etag is weak if its first char is not a DQUOTE.
-        if slice.char_at(0) == '"' /* '"' */ {
+        if slice.chars().next().unwrap() == '"' /* '"' */ {
             // No need to check if the last char is a DQUOTE,
             // we already did that above.
             if check_slice_validity(slice.slice_chars(1, length-1)) {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -264,6 +264,6 @@ mod tests {
         ");
 
         handle_connection(&mut mock, &Reject);
-        assert_eq!(mock.write, b"HTTP/1.1 417 Expectation Failed\r\n\r\n");
+        assert_eq!(mock.write, &b"HTTP/1.1 417 Expectation Failed\r\n\r\n"[..]);
     }
 }


### PR DESCRIPTION
* replace `char_at()` calls with itertor, as suggested by compiler
* fixed comparison in test

# Important Note

**Benchmarks fail if they are run** - this is nothing travis could figure out due to the `--no-run` flag. The error is:
```bash
test header::common::date::asctime::bench_format                    ... thread '<main>' panicked at 'called `Option::unwrap()` on a `None` value', /Users/rustbuild/src/rust-buildbot/slave/nightly-dist-rustc-mac/build/src/libcore/option.rs:362
```

I don't know when this regression sneaked in, it doesn't seem to be related to this commit though.