### PR TITLE
chore(build): Enable building hyper in docker containers on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+sudo: false
 
 script:
     - cargo build


### PR DESCRIPTION
By stating that hyper does not need sudo to build it can be compiled in
a container:
http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/