### PR TITLE
fix(rustup): rustc 1.0.0-nightly (123a754cb 2015-03-24)

### DIFF
--- a/src/header/common/accept.rs
+++ b/src/header/common/accept.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[test]
     fn test_parse_header_no_quality() {
-        let a: Accept = Header::parse_header([b"text/plain; charset=utf-8".to_vec()].as_slice()).unwrap();
+        let a: Accept = Header::parse_header([b"text/plain; charset=utf-8".to_vec()].as_ref()).unwrap();
         let b = Accept(vec![
             qitem(Mime(TopLevel::Text, SubLevel::Plain, vec![(Attr::Charset, Value::Utf8)])),
         ]);
@@ -48,7 +48,7 @@ mod tests {
 
     #[test]
     fn test_parse_header_with_quality() {
-        let a: Accept = Header::parse_header([b"text/plain; charset=utf-8; q=0.5".to_vec()].as_slice()).unwrap();
+        let a: Accept = Header::parse_header([b"text/plain; charset=utf-8; q=0.5".to_vec()].as_ref()).unwrap();
         let b = Accept(vec![
             QualityItem::new(Mime(TopLevel::Text, SubLevel::Plain, vec![(Attr::Charset, Value::Utf8)]), Quality(500)),
         ]);

--- a/src/header/common/accept_charset.rs
+++ b/src/header/common/accept_charset.rs
@@ -16,7 +16,7 @@ impl_list_header!(AcceptCharset,
 fn test_parse_header() {
     use header::{self, q};
     let a: AcceptCharset = header::Header::parse_header(
-        [b"iso-8859-5, iso-8859-6;q=0.8".to_vec()].as_slice()).unwrap();
+        [b"iso-8859-5, iso-8859-6;q=0.8".to_vec()].as_ref()).unwrap();
     let b = AcceptCharset(vec![
         QualityItem { item: Charset::Iso_8859_5, quality: q(1.0) },
         QualityItem { item: Charset::Iso_8859_6, quality: q(0.8) },

--- a/src/header/common/accept_encoding.rs
+++ b/src/header/common/accept_encoding.rs
@@ -19,7 +19,7 @@ mod tests {
 
     #[test]
     fn test_parse_header() {
-        let a: AcceptEncoding = Header::parse_header([b"gzip;q=1.0, identity; q=0.5".to_vec()].as_slice()).unwrap();
+        let a: AcceptEncoding = Header::parse_header([b"gzip;q=1.0, identity; q=0.5".to_vec()].as_ref()).unwrap();
         let b = AcceptEncoding(vec![
             qitem(Encoding::Gzip),
             QualityItem::new(Encoding::Identity, Quality(500)),

--- a/src/header/common/accept_language.rs
+++ b/src/header/common/accept_language.rs
@@ -54,7 +54,7 @@ mod tests {
     #[test]
     fn test_parse_header() {
         let a: AcceptLanguage = Header::parse_header(
-            [b"en-us;q=1.0, en;q=0.5, fr".to_vec()].as_slice()).unwrap();
+            [b"en-us;q=1.0, en;q=0.5, fr".to_vec()].as_ref()).unwrap();
         let b = AcceptLanguage(vec![
             qitem(Language{primary: "en".to_string(), sub: Some("us".to_string())}),
             QualityItem::new(Language{primary: "en".to_string(), sub: None},

--- a/src/header/common/access_control/allow_headers.rs
+++ b/src/header/common/access_control/allow_headers.rs
@@ -27,6 +27,6 @@ impl header::Header for AccessControlAllowHeaders {
 impl header::HeaderFormat for AccessControlAllowHeaders {
     fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let AccessControlAllowHeaders(ref parts) = *self;
-        header::parsing::fmt_comma_delimited(f, parts.as_slice())
+        header::parsing::fmt_comma_delimited(f, parts.as_ref())
     }
 }

--- a/src/header/common/access_control/allow_methods.rs
+++ b/src/header/common/access_control/allow_methods.rs
@@ -28,6 +28,6 @@ impl header::Header for AccessControlAllowMethods {
 impl header::HeaderFormat for AccessControlAllowMethods {
     fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let AccessControlAllowMethods(ref parts) = *self;
-        header::parsing::fmt_comma_delimited(f, parts.as_slice())
+        header::parsing::fmt_comma_delimited(f, parts.as_ref())
     }
 }

--- a/src/header/common/access_control/request_headers.rs
+++ b/src/header/common/access_control/request_headers.rs
@@ -26,6 +26,6 @@ impl header::Header for AccessControlRequestHeaders {
 impl header::HeaderFormat for AccessControlRequestHeaders {
     fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let AccessControlRequestHeaders(ref parts) = *self;
-        header::parsing::fmt_comma_delimited(f, parts.as_slice())
+        header::parsing::fmt_comma_delimited(f, parts.as_ref())
     }
 }

--- a/src/header/common/allow.rs
+++ b/src/header/common/allow.rs
@@ -20,10 +20,10 @@ mod tests {
     fn test_allow() {
         let mut allow: Option<Allow>;
 
-        allow = Header::parse_header([b"OPTIONS,GET,PUT,POST,DELETE,HEAD,TRACE,CONNECT,PATCH,fOObAr".to_vec()].as_slice());
+        allow = Header::parse_header([b"OPTIONS,GET,PUT,POST,DELETE,HEAD,TRACE,CONNECT,PATCH,fOObAr".to_vec()].as_ref());
         assert_eq!(allow, Some(Allow(vec![Options, Get, Put, Post, Delete, Head, Trace, Connect, Patch, Extension("fOObAr".to_string())])));
 
-        allow = Header::parse_header([b"".to_vec()].as_slice());
+        allow = Header::parse_header([b"".to_vec()].as_ref());
         assert_eq!(allow, Some(Allow(Vec::<Method>::new())));
     }
 }

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -46,7 +46,7 @@ impl fmt::Display for ConnectionOption {
         write!(fmt, "{}", match *self {
             KeepAlive => "keep-alive",
             Close => "close",
-            ConnectionHeader(UniCase(ref s)) => s.as_slice()
+            ConnectionHeader(UniCase(ref s)) => s.as_ref()
         })
     }
 }

--- a/src/header/common/etag.rs
+++ b/src/header/common/etag.rs
@@ -45,31 +45,31 @@ mod tests {
         // Expected successes
         let mut etag: Option<Etag>;
 
-        etag = Header::parse_header([b"\"foobar\"".to_vec()].as_slice());
+        etag = Header::parse_header([b"\"foobar\"".to_vec()].as_ref());
         assert_eq!(etag, Some(Etag(EntityTag{
             weak: false,
             tag: "foobar".to_string()
         })));
 
-        etag = Header::parse_header([b"\"\"".to_vec()].as_slice());
+        etag = Header::parse_header([b"\"\"".to_vec()].as_ref());
         assert_eq!(etag, Some(Etag(EntityTag{
             weak: false,
             tag: "".to_string()
         })));
 
-        etag = Header::parse_header([b"W/\"weak-etag\"".to_vec()].as_slice());
+        etag = Header::parse_header([b"W/\"weak-etag\"".to_vec()].as_ref());
         assert_eq!(etag, Some(Etag(EntityTag{
             weak: true,
             tag: "weak-etag".to_string()
         })));
 
-        etag = Header::parse_header([b"W/\"\x65\x62\"".to_vec()].as_slice());
+        etag = Header::parse_header([b"W/\"\x65\x62\"".to_vec()].as_ref());
         assert_eq!(etag, Some(Etag(EntityTag{
             weak: true,
             tag: "\u{0065}\u{0062}".to_string()
         })));
 
-        etag = Header::parse_header([b"W/\"\"".to_vec()].as_slice());
+        etag = Header::parse_header([b"W/\"\"".to_vec()].as_ref());
         assert_eq!(etag, Some(Etag(EntityTag{
             weak: true,
             tag: "".to_string()
@@ -81,22 +81,22 @@ mod tests {
         // Expected failures
         let mut etag: Option<Etag>;
 
-        etag = Header::parse_header([b"no-dquotes".to_vec()].as_slice());
+        etag = Header::parse_header([b"no-dquotes".to_vec()].as_ref());
         assert_eq!(etag, None);
 
-        etag = Header::parse_header([b"w/\"the-first-w-is-case-sensitive\"".to_vec()].as_slice());
+        etag = Header::parse_header([b"w/\"the-first-w-is-case-sensitive\"".to_vec()].as_ref());
         assert_eq!(etag, None);
 
-        etag = Header::parse_header([b"".to_vec()].as_slice());
+        etag = Header::parse_header([b"".to_vec()].as_ref());
         assert_eq!(etag, None);
 
-        etag = Header::parse_header([b"\"unmatched-dquotes1".to_vec()].as_slice());
+        etag = Header::parse_header([b"\"unmatched-dquotes1".to_vec()].as_ref());
         assert_eq!(etag, None);
 
-        etag = Header::parse_header([b"unmatched-dquotes2\"".to_vec()].as_slice());
+        etag = Header::parse_header([b"unmatched-dquotes2\"".to_vec()].as_ref());
         assert_eq!(etag, None);
 
-        etag = Header::parse_header([b"matched-\"dquotes\"".to_vec()].as_slice());
+        etag = Header::parse_header([b"matched-\"dquotes\"".to_vec()].as_ref());
         assert_eq!(etag, None);
     }
 }

--- a/src/header/common/host.rs
+++ b/src/header/common/host.rs
@@ -81,14 +81,14 @@ mod tests {
 
     #[test]
     fn test_host() {
-        let host = Header::parse_header([b"foo.com".to_vec()].as_slice());
+        let host = Header::parse_header([b"foo.com".to_vec()].as_ref());
         assert_eq!(host, Some(Host {
             hostname: "foo.com".to_string(),
             port: None
         }));
 
 
-        let host = Header::parse_header([b"foo.com:8080".to_vec()].as_slice());
+        let host = Header::parse_header([b"foo.com:8080".to_vec()].as_ref());
         assert_eq!(host, Some(Host {
             hostname: "foo.com".to_string(),
             port: Some(8080)

--- a/src/header/common/if_match.rs
+++ b/src/header/common/if_match.rs
@@ -48,12 +48,12 @@ impl HeaderFormat for IfMatch {
 fn test_parse_header() {
     {
         let a: IfMatch = Header::parse_header(
-        [b"*".to_vec()].as_slice()).unwrap();
+        [b"*".to_vec()].as_ref()).unwrap();
         assert_eq!(a, IfMatch::Any);
     }
     {
         let a: IfMatch = Header::parse_header(
-            [b"\"xyzzy\", \"r2d2xxxx\", \"c3piozzzz\"".to_vec()].as_slice()).unwrap();
+            [b"\"xyzzy\", \"r2d2xxxx\", \"c3piozzzz\"".to_vec()].as_ref()).unwrap();
         let b = IfMatch::EntityTags(
             vec![EntityTag{weak:false, tag: "xyzzy".to_string()},
                  EntityTag{weak:false, tag: "r2d2xxxx".to_string()},

--- a/src/header/common/if_none_match.rs
+++ b/src/header/common/if_none_match.rs
@@ -62,10 +62,10 @@ mod tests {
     fn test_if_none_match() {
         let mut if_none_match: Option<IfNoneMatch>;
 
-        if_none_match = Header::parse_header([b"*".to_vec()].as_slice());
+        if_none_match = Header::parse_header([b"*".to_vec()].as_ref());
         assert_eq!(if_none_match, Some(IfNoneMatch::Any));
 
-        if_none_match = Header::parse_header([b"\"foobar\", W/\"weak-etag\"".to_vec()].as_slice());
+        if_none_match = Header::parse_header([b"\"foobar\", W/\"weak-etag\"".to_vec()].as_ref());
         let mut entities: Vec<EntityTag> = Vec::new();
         let foobar_etag = EntityTag {
             weak: false,

--- a/src/header/common/pragma.rs
+++ b/src/header/common/pragma.rs
@@ -52,10 +52,10 @@ impl HeaderFormat for Pragma {
 
 #[test]
 fn test_parse_header() {
-    let a: Pragma = Header::parse_header([b"no-cache".to_vec()].as_slice()).unwrap();
+    let a: Pragma = Header::parse_header([b"no-cache".to_vec()].as_ref()).unwrap();
     let b = Pragma::NoCache;
     assert_eq!(a, b);
-    let c: Pragma = Header::parse_header([b"FoObar".to_vec()].as_slice()).unwrap();
+    let c: Pragma = Header::parse_header([b"FoObar".to_vec()].as_ref()).unwrap();
     let d = Pragma::Ext("FoObar".to_string());
     assert_eq!(c, d);
 }

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -37,7 +37,7 @@ impl fmt::Display for Protocol {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{}", match *self {
             WebSocket => "websocket",
-            ProtocolExt(ref s) => s.as_slice()
+            ProtocolExt(ref s) => s.as_ref()
         })
     }
 }

--- a/src/header/common/vary.rs
+++ b/src/header/common/vary.rs
@@ -49,10 +49,10 @@ mod tests {
     fn test_vary() {
         let mut vary: Option<Vary>;
 
-        vary = Header::parse_header([b"*".to_vec()].as_slice());
+        vary = Header::parse_header([b"*".to_vec()].as_ref());
         assert_eq!(vary, Some(Vary::Any));
 
-        vary = Header::parse_header([b"etag,cookie,allow".to_vec()].as_slice());
+        vary = Header::parse_header([b"etag,cookie,allow".to_vec()].as_ref());
         assert_eq!(vary, Some(Vary::Headers(vec!["eTag".parse().unwrap(),
                                                  "cookIE".parse().unwrap(),
                                                  "AlLOw".parse().unwrap(),])));

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -272,7 +272,7 @@ impl<'a> HeaderView<'a> {
     /// Get the Header name as a slice.
     #[inline]
     pub fn name(&self) -> &'a str {
-        self.0.as_slice()
+        self.0.as_ref()
     }
 
     /// Cast the value to a certain Header type.
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_content_type() {
-        let content_type = Header::parse_header([b"text/plain".to_vec()].as_slice());
+        let content_type = Header::parse_header([b"text/plain".to_vec()].as_ref());
         assert_eq!(content_type, Some(ContentType(Mime(Text, Plain, vec![]))));
     }
 
@@ -386,10 +386,10 @@ mod tests {
         let text_plain = qitem(Mime(Text, Plain, vec![]));
         let application_vendor = "application/vnd.github.v3.full+json; q=0.5".parse().unwrap();
 
-        let accept = Header::parse_header([b"text/plain".to_vec()].as_slice());
+        let accept = Header::parse_header([b"text/plain".to_vec()].as_ref());
         assert_eq!(accept, Some(Accept(vec![text_plain.clone()])));
 
-        let accept = Header::parse_header([b"application/vnd.github.v3.full+json; q=0.5, text/plain".to_vec()].as_slice());
+        let accept = Header::parse_header([b"application/vnd.github.v3.full+json; q=0.5, text/plain".to_vec()].as_ref());
         assert_eq!(accept, Some(Accept(vec![application_vendor, text_plain])));
     }
 

--- a/src/header/parsing.rs
+++ b/src/header/parsing.rs
@@ -30,7 +30,7 @@ pub fn from_comma_delimited<T: str::FromStr>(raw: &[Vec<u8>]) -> Option<Vec<T>> 
 pub fn from_one_comma_delimited<T: str::FromStr>(raw: &[u8]) -> Option<Vec<T>> {
     match str::from_utf8(raw) {
         Ok(s) => {
-            Some(s.as_slice()
+            Some(s
                  .split(',')
                  .map(|x| x.trim())
                  .filter_map(|x| x.parse().ok())

--- a/src/header/shared/charset.rs
+++ b/src/header/shared/charset.rs
@@ -105,7 +105,7 @@ impl Display for Charset {
 impl FromStr for Charset {
     type Err = ();
     fn from_str(s: &str) -> Result<Charset, ()> {
-        Ok(match s.to_ascii_uppercase().as_slice() {
+        Ok(match s.to_ascii_uppercase().as_ref() {
             "US-ASCII" => Us_Ascii,
             "ISO-8859-1" => Iso_8859_1,
             "ISO-8859-2" => Iso_8859_2,

--- a/src/header/shared/encoding.rs
+++ b/src/header/shared/encoding.rs
@@ -31,7 +31,7 @@ impl fmt::Display for Encoding {
             Deflate => "deflate",
             Compress => "compress",
             Identity => "identity",
-            EncodingExt(ref s) => s.as_slice()
+            EncodingExt(ref s) => s.as_ref()
         })
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -399,7 +399,7 @@ mod tests {
         w.write_all(b"foo bar").unwrap();
         w.write_all(b"baz quux herp").unwrap();
         let buf = w.end().unwrap();
-        let s = from_utf8(buf.as_slice()).unwrap();
+        let s = from_utf8(buf.as_ref()).unwrap();
         assert_eq!(s, "7\r\nfoo bar\r\nD\r\nbaz quux herp\r\n0\r\n\r\n");
     }
 
@@ -411,7 +411,7 @@ mod tests {
         assert_eq!(w.write(b"baz"), Ok(1));
 
         let buf = w.end().unwrap();
-        let s = from_utf8(buf.as_slice()).unwrap();
+        let s = from_utf8(buf.as_ref()).unwrap();
         assert_eq!(s, "foo barb");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc(html_root_url = "https://hyperium.github.io/hyper/hyper/index.html")]
 #![feature(core, collections, io,
-           std_misc, box_syntax, unsafe_destructor)]
+           box_syntax, unsafe_destructor, into_cow, convert)]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(test, feature(alloc, test))]
@@ -127,7 +127,7 @@
 //! implement `Reader` and can be read to get the data out of a `Response`.
 //!
 
-extern crate "rustc-serialize" as serialize;
+extern crate rustc_serialize as serialize;
 extern crate time;
 extern crate url;
 extern crate openssl;

--- a/src/method.rs
+++ b/src/method.rs
@@ -102,7 +102,7 @@ impl fmt::Display for Method {
             Trace => "TRACE",
             Connect => "CONNECT",
             Patch => "PATCH",
-            Extension(ref s) => s.as_slice()
+            Extension(ref s) => s.as_ref()
         })
     }
 }

--- a/src/status.rs
+++ b/src/status.rs
@@ -20,6 +20,7 @@ use std::cmp::Ordering;
 /// `self.class().default_code()`:
 ///
 /// ```rust
+/// #![feature(core)]
 /// # use std::num::FromPrimitive;
 /// # use hyper::status::StatusCode;
 /// let statusopt: Option<StatusCode> = FromPrimitive::from_u16(137u16);
@@ -357,19 +358,19 @@ impl Copy for StatusCode {}
 ///
 /// ```rust
 /// # use hyper::status::StatusCode::{ImATeapot, Unregistered};
-/// assert_eq!(format!("{}", ImATeapot).as_slice(),
-///            "418 I'm a teapot");
-/// assert_eq!(format!("{}", Unregistered(123)).as_slice(),
+/// assert_eq!(format!("{}", ImATeapot), "418 I'm a teapot");
+/// assert_eq!(format!("{}", Unregistered(123)),
 ///            "123 <unknown status code>");
 /// ```
 ///
 /// If you wish to just include the number, convert to `u16` instead:
 ///
 /// ```rust
+/// #![feature(core)]
 /// # use std::num::ToPrimitive;
 /// # use hyper::status::StatusCode::{ImATeapot, Unregistered};
-/// assert_eq!(format!("{}", ImATeapot.to_u16().unwrap()).as_slice(), "418");
-/// assert_eq!(format!("{}", Unregistered(123).to_u16().unwrap()).as_slice(), "123");
+/// assert_eq!(format!("{}", ImATeapot.to_u16().unwrap()), "418");
+/// assert_eq!(format!("{}", Unregistered(123).to_u16().unwrap()), "123");
 /// ```
 impl fmt::Display for StatusCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
* fix `extern crate` declaration for rustc-serialize
* enable `into_cow` feature
* replace as_slice() calls by as_ref and enable `convert` feature