### PR TITLE
fix(rustup): static bounds required on Type definition, trivial_casts

### DIFF
--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -56,7 +56,9 @@ impl Request<Fresh> {
         let (host, port) = try!(get_host_and_port(&url));
 
         let stream = try!(connector.connect(&*host, port, &*url.scheme));
-        let stream = ThroughWriter(BufWriter::new(box stream as Box<NetworkStream + Send>));
+        // FIXME: Use Type ascription
+        let stream: Box<NetworkStream + Send> = box stream;
+        let stream = ThroughWriter(BufWriter::new(stream));
 
         let mut headers = Headers::new();
         headers.set(Host {

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -112,7 +112,6 @@ mod tests {
     use http::HttpReader::EofReader;
     use http::RawStatus;
     use mock::MockStream;
-    use net::NetworkStream;
     use status;
     use version;
 
@@ -131,7 +130,7 @@ mod tests {
             status: status::StatusCode::Ok,
             headers: Headers::new(),
             version: version::HttpVersion::Http11,
-            body: EofReader(BufReader::new(box MockStream::new() as Box<NetworkStream + Send>)),
+            body: EofReader(BufReader::new(box MockStream::new())),
             status_raw: RawStatus(200, Borrowed("OK")),
             _marker: PhantomData,
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,8 +54,8 @@ impl Error for HttpError {
 
     fn cause(&self) -> Option<&Error> {
         match *self {
-            HttpIoError(ref error) => Some(error as &Error),
-            HttpUriError(ref error) => Some(error as &Error),
+            HttpIoError(ref error) => Some(error),
+            HttpUriError(ref error) => Some(error),
             _ => None,
         }
     }

--- a/src/header/internals/item.rs
+++ b/src/header/internals/item.rs
@@ -83,7 +83,11 @@ impl Item {
 
 #[inline]
 fn parse<H: Header + HeaderFormat>(raw: &Vec<Vec<u8>>) -> Option<Box<HeaderFormat + Send + Sync>> {
-    Header::parse_header(&raw[..]).map(|h: H| box h as Box<HeaderFormat + Send + Sync>)
+    Header::parse_header(&raw[..]).map(|h: H| {
+        // FIXME: Use Type ascription
+        let h: Box<HeaderFormat + Send + Sync> = box h;
+        h
+    })
 }
 
 impl fmt::Display for Item {

--- a/src/http.rs
+++ b/src/http.rs
@@ -462,12 +462,12 @@ mod tests {
     fn bench_parse_incoming(b: &mut Bencher) {
         use std::io::BufReader;
         use mock::MockStream;
-        use net::NetworkStream;
+
         use super::parse_request;
         b.iter(|| {
             let mut raw = MockStream::with_input(b"GET /echo HTTP/1.1\r\nHost: hyper.rs\r\n\r\n");
-            let mut buf = BufReader::new(&mut raw as &mut NetworkStream);
-            
+            let mut buf = BufReader::new(&mut raw);
+
             parse_request(&mut buf).unwrap();
         });
     }

--- a/src/net.rs
+++ b/src/net.rs
@@ -354,7 +354,8 @@ mod tests {
 
     #[test]
     fn test_downcast_box_stream() {
-        let stream = box MockStream::new() as Box<NetworkStream + Send>;
+        // FIXME: Use Type ascription
+        let stream: Box<NetworkStream + Send> = box MockStream::new();
 
         let mock = stream.downcast::<MockStream>().ok().unwrap();
         assert_eq!(mock, box MockStream::new());
@@ -363,7 +364,8 @@ mod tests {
 
     #[test]
     fn test_downcast_unchecked_box_stream() {
-        let stream = box MockStream::new() as Box<NetworkStream + Send>;
+        // FIXME: Use Type ascription
+        let stream: Box<NetworkStream + Send> = box MockStream::new();
 
         let mock = unsafe { stream.downcast_unchecked::<MockStream>() };
         assert_eq!(mock, box MockStream::new());

--- a/src/server/listener.rs
+++ b/src/server/listener.rs
@@ -62,13 +62,13 @@ where A: NetworkListener + Send + 'a,
     })
 }
 
-struct Sentinel<T: Send> {
+struct Sentinel<T: Send + 'static> {
     value: Option<T>,
     supervisor: mpsc::Sender<T>,
     //active: bool
 }
 
-impl<T: Send> Sentinel<T> {
+impl<T: Send + 'static> Sentinel<T> {
     fn new(channel: mpsc::Sender<T>, data: T) -> Sentinel<T> {
         Sentinel {
             value: Some(data),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -124,8 +124,9 @@ where S: NetworkStream + Clone, H: Handler {
         }
     };
 
-    let mut stream_clone = stream.clone();
-    let mut rdr = BufReader::new(&mut stream_clone as &mut NetworkStream);
+    // FIXME: Use Type ascription
+    let stream_clone: &mut NetworkStream = &mut stream.clone();
+    let mut rdr = BufReader::new(stream_clone);
     let mut wrt = BufWriter::new(stream);
 
     let mut keep_alive = true;

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -108,7 +108,9 @@ mod tests {
             I'm a bad request.\r\n\
         ");
 
-        let mut stream = BufReader::new(&mut mock as &mut NetworkStream);
+        // FIXME: Use Type ascription
+        let mock: &mut NetworkStream = &mut mock;
+        let mut stream = BufReader::new(mock);
 
         let req = Request::new(&mut stream, sock("127.0.0.1:80")).unwrap();
         assert_eq!(read_to_string(req), Ok("".to_string()));
@@ -122,7 +124,10 @@ mod tests {
             \r\n\
             I'm a bad request.\r\n\
         ");
-        let mut stream = BufReader::new(&mut mock as &mut NetworkStream);
+
+        // FIXME: Use Type ascription
+        let mock: &mut NetworkStream = &mut mock;
+        let mut stream = BufReader::new(mock);
 
         let req = Request::new(&mut stream, sock("127.0.0.1:80")).unwrap();
         assert_eq!(read_to_string(req), Ok("".to_string()));
@@ -136,7 +141,10 @@ mod tests {
             \r\n\
             I'm a bad request.\r\n\
         ");
-        let mut stream = BufReader::new(&mut mock as &mut NetworkStream);
+
+        // FIXME: Use Type ascription
+        let mock: &mut NetworkStream = &mut mock;
+        let mut stream = BufReader::new(mock);
 
         let req = Request::new(&mut stream, sock("127.0.0.1:80")).unwrap();
         assert_eq!(read_to_string(req), Ok("".to_string()));
@@ -158,7 +166,10 @@ mod tests {
             0\r\n\
             \r\n"
         );
-        let mut stream = BufReader::new(&mut mock as &mut NetworkStream);
+
+        // FIXME: Use Type ascription
+        let mock: &mut NetworkStream = &mut mock;
+        let mut stream = BufReader::new(mock);
 
         let req = Request::new(&mut stream, sock("127.0.0.1:80")).unwrap();
 
@@ -194,7 +205,10 @@ mod tests {
             0\r\n\
             \r\n"
         );
-        let mut stream = BufReader::new(&mut mock as &mut NetworkStream);
+
+        // FIXME: Use Type ascription
+        let mock: &mut NetworkStream = &mut mock;
+        let mut stream = BufReader::new(mock);
 
         let req = Request::new(&mut stream, sock("127.0.0.1:80")).unwrap();
 
@@ -215,7 +229,10 @@ mod tests {
             0\r\n\
             \r\n"
         );
-        let mut stream = BufReader::new(&mut mock as &mut NetworkStream);
+
+        // FIXME: Use Type ascription
+        let mock: &mut NetworkStream = &mut mock;
+        let mut stream = BufReader::new(mock);
 
         let req = Request::new(&mut stream, sock("127.0.0.1:80")).unwrap();
 
@@ -236,7 +253,10 @@ mod tests {
             0\r\n\
             \r\n"
         );
-        let mut stream = BufReader::new(&mut mock as &mut NetworkStream);
+
+        // FIXME: Use Type ascription
+        let mock: &mut NetworkStream = &mut mock;
+        let mut stream = BufReader::new(mock);
 
         let req = Request::new(&mut stream, sock("127.0.0.1:80")).unwrap();
 


### PR DESCRIPTION
Removing the remaining casts trigger inference failures... so they're... not trivial?