### PR TITLE
chore(travis): Enable caching of ./target folder.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: rust
 sudo: false
 
+cache:
+  directories:
+      - target
+
 script:
     - cargo build
     - cargo test


### PR DESCRIPTION
Travis supports the caching of folders between builds.
By storing the ./target folder we can cache hyper's dependencies.