### PR TITLE
refactor(headers): Use header!() macro for `ETag` header

### DIFF
--- a/src/header/common/etag.rs
+++ b/src/header/common/etag.rs
@@ -1,67 +1,55 @@
-use header::{EntityTag, Header, HeaderFormat};
-use std::fmt::{self, Display};
-use header::parsing::from_one_raw_str;
+use header::EntityTag;
 
-/// The `Etag` header.
-///
-/// An Etag consists of a string enclosed by two literal double quotes.
-/// Preceding the first double quote is an optional weakness indicator,
-/// which always looks like this: W/
-/// See also: https://tools.ietf.org/html/rfc7232#section-2.3
-#[derive(Clone, PartialEq, Debug)]
-pub struct Etag(pub EntityTag);
-
-deref!(Etag => EntityTag);
-
-impl Header for Etag {
-    fn header_name() -> &'static str {
-        "Etag"
-    }
-
-    fn parse_header(raw: &[Vec<u8>]) -> Option<Etag> {
-
-        from_one_raw_str(raw).and_then(|s: String| {
-            s.parse::<EntityTag>().and_then(|x| Ok(Etag(x))).ok()
-        })
-    }
-}
-
-impl HeaderFormat for Etag {
-    fn fmt_header(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(fmt)
-    }
+header! {
+    #[doc="`ETag` header, defined in [RFC7232](http://tools.ietf.org/html/rfc7232#section-2.3)"]
+    #[doc=""]
+    #[doc="The `ETag` header field in a response provides the current entity-tag"]
+    #[doc="for the selected representation, as determined at the conclusion of"]
+    #[doc="handling the request.  An entity-tag is an opaque validator for"]
+    #[doc="differentiating between multiple representations of the same"]
+    #[doc="resource, regardless of whether those multiple representations are"]
+    #[doc="due to resource state changes over time, content negotiation"]
+    #[doc="resulting in multiple representations being valid at the same time,"]
+    #[doc="or both.  An entity-tag consists of an opaque quoted string, possibly"]
+    #[doc="prefixed by a weakness indicator."]
+    #[doc=""]
+    #[doc="# ABNF"]
+    #[doc="```plain"]
+    #[doc="ETag       = entity-tag"]
+    #[doc="```"]
+    (ETag, "ETag") => [EntityTag]
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Etag;
+    use super::ETag;
     use header::{Header,EntityTag};
 
     #[test]
     fn test_etag_successes() {
         // Expected successes
-        let mut etag: Option<Etag>;
+        let mut etag: Option<ETag>;
 
         etag = Header::parse_header([b"\"foobar\"".to_vec()].as_ref());
-        assert_eq!(etag, Some(Etag(EntityTag::new(false, "foobar".to_string()))));
+        assert_eq!(etag, Some(ETag(EntityTag::new(false, "foobar".to_string()))));
 
         etag = Header::parse_header([b"\"\"".to_vec()].as_ref());
-        assert_eq!(etag, Some(Etag(EntityTag::new(false, "".to_string()))));
+        assert_eq!(etag, Some(ETag(EntityTag::new(false, "".to_string()))));
 
         etag = Header::parse_header([b"W/\"weak-etag\"".to_vec()].as_ref());
-        assert_eq!(etag, Some(Etag(EntityTag::new(true, "weak-etag".to_string()))));
+        assert_eq!(etag, Some(ETag(EntityTag::new(true, "weak-etag".to_string()))));
 
         etag = Header::parse_header([b"W/\"\x65\x62\"".to_vec()].as_ref());
-        assert_eq!(etag, Some(Etag(EntityTag::new(true, "\u{0065}\u{0062}".to_string()))));
+        assert_eq!(etag, Some(ETag(EntityTag::new(true, "\u{0065}\u{0062}".to_string()))));
 
         etag = Header::parse_header([b"W/\"\"".to_vec()].as_ref());
-        assert_eq!(etag, Some(Etag(EntityTag::new(true, "".to_string()))));
+        assert_eq!(etag, Some(ETag(EntityTag::new(true, "".to_string()))));
     }
 
     #[test]
     fn test_etag_failures() {
         // Expected failures
-        let mut etag: Option<Etag>;
+        let mut etag: Option<ETag>;
 
         etag = Header::parse_header([b"no-dquotes".to_vec()].as_ref());
         assert_eq!(etag, None);
@@ -83,4 +71,4 @@ mod tests {
     }
 }
 
-bench_header!(bench, Etag, { vec![b"W/\"nonemptytag\"".to_vec()] });
+bench_header!(bench, ETag, { vec![b"W/\"nonemptytag\"".to_vec()] });

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -20,7 +20,7 @@ pub use self::content_encoding::ContentEncoding;
 pub use self::content_type::ContentType;
 pub use self::cookie::Cookie;
 pub use self::date::Date;
-pub use self::etag::Etag;
+pub use self::etag::ETag;
 pub use self::expect::Expect;
 pub use self::expires::Expires;
 pub use self::host::Host;


### PR DESCRIPTION
Change `Etag` (only the `E` is capitalized) to `ETag` as it is written in the relevant RFC.

BREAKING_CHANGE: `Etag` header field is now `ETag` header field

Depends on #419