### PR TITLE
 refactor(headers): Use header!() macro for 3 headers with a "*" value

### DIFF
--- a/src/header/common/if_none_match.rs
+++ b/src/header/common/if_none_match.rs
@@ -1,8 +1,28 @@
-use header::{Header, HeaderFormat, EntityTag};
-use header::parsing::{from_comma_delimited, fmt_comma_delimited, from_one_raw_str};
-use std::fmt::{self};
+use header::EntityTag;
 
-/// The `If-None-Match` header defined by HTTP/1.1.
+header! {
+    #[doc="`If-None-Match` header, defined in"]
+    #[doc="[RFC7232](https://tools.ietf.org/html/rfc7232#section-3.2)"]
+    #[doc=""]
+    #[doc="The `If-None-Match` header field makes the request method conditional"]
+    #[doc="on a recipient cache or origin server either not having any current"]
+    #[doc="representation of the target resource, when the field-value is \"*\","]
+    #[doc="or having a selected representation with an entity-tag that does not"]
+    #[doc="match any of those listed in the field-value."]
+    #[doc=""]
+    #[doc="A recipient MUST use the weak comparison function when comparing"]
+    #[doc="entity-tags for If-None-Match (Section 2.3.2), since weak entity-tags"]
+    #[doc="can be used for cache validation even if there have been changes to"]
+    #[doc="the representation data."]
+    #[doc=""]
+    #[doc="# ABNF"]
+    #[doc="```plain"]
+    #[doc="If-None-Match = \"*\" / 1#entity-tag"]
+    #[doc="```"]
+    (IfNoneMatch, "If-None-Match") => {Any / (EntityTag)+}
+}
+
+/*/// The `If-None-Match` header defined by HTTP/1.1.
 ///
 /// The "If-None-Match" header field makes the request method conditional
 /// on a recipient cache or origin server either not having any current
@@ -50,7 +70,7 @@ impl HeaderFormat for IfNoneMatch {
             IfNoneMatch::EntityTags(ref fields) => { fmt_comma_delimited(fmt, &fields[..]) }
         }
     }
-}
+}*/
 
 #[cfg(test)]
 mod tests {
@@ -71,7 +91,7 @@ mod tests {
         let weak_etag = EntityTag::new(true, "weak-etag".to_string());
         entities.push(foobar_etag);
         entities.push(weak_etag);
-        assert_eq!(if_none_match, Some(IfNoneMatch::EntityTags(entities)));
+        assert_eq!(if_none_match, Some(IfNoneMatch::Items(entities)));
     }
 }
 

--- a/src/header/common/vary.rs
+++ b/src/header/common/vary.rs
@@ -1,9 +1,23 @@
-use header::{Header, HeaderFormat};
-use std::fmt::{self};
-use header::parsing::{from_comma_delimited, fmt_comma_delimited, from_one_raw_str};
 use unicase::UniCase;
 
-/// The `Allow` header.
+header! {
+    #[doc="`Vary` header, defined in [RFC7231](https://tools.ietf.org/html/rfc7231#section-7.1.4)"]
+    #[doc=""]
+    #[doc="The \"Vary\" header field in a response describes what parts of a"]
+    #[doc="request message, aside from the method, Host header field, and"]
+    #[doc="request target, might influence the origin server's process for"]
+    #[doc="selecting and representing this response.  The value consists of"]
+    #[doc="either a single asterisk (\"*\") or a list of header field names"]
+    #[doc="(case-insensitive)."]
+    #[doc=""]
+    #[doc="# ABNF"]
+    #[doc="```plain"]
+    #[doc="Vary = \"*\" / 1#field-name"]
+    #[doc="```"]
+    (Vary, "Vary") => {Any / (UniCase<String>)+}
+}
+
+/*/// The `Allow` header.
 /// See also https://tools.ietf.org/html/rfc7231#section-7.1.4
 
 #[derive(Clone, PartialEq, Debug)]
@@ -38,7 +52,7 @@ impl HeaderFormat for Vary {
             Vary::Headers(ref fields) => { fmt_comma_delimited(fmt, &fields[..]) }
         }
     }
-}
+}*/
 
 #[cfg(test)]
 mod tests {
@@ -53,8 +67,8 @@ mod tests {
         assert_eq!(vary, Some(Vary::Any));
 
         vary = Header::parse_header([b"etag,cookie,allow".to_vec()].as_ref());
-        assert_eq!(vary, Some(Vary::Headers(vec!["eTag".parse().unwrap(),
-                                                 "cookIE".parse().unwrap(),
-                                                 "AlLOw".parse().unwrap(),])));
+        assert_eq!(vary, Some(Vary::Items(vec!["eTag".parse().unwrap(),
+                                                "cookIE".parse().unwrap(),
+                                                "AlLOw".parse().unwrap(),])));
     }
 }


### PR DESCRIPTION
`If-Match`, `If-None-Match` and `Vary` headers are either a "*" value meaning that the header
matches every possible item or a list of items, one of them must be matched to fulfil the condition.

BREAKING_CHANGE: `If-Match`, `If-None-Match` and `Vary` item variant name changed to `Items`

Depends on #419 