### PR TITLE
chore(all): Move downcasting to a stable implementation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ rustc-serialize = "*"
 time = "*"
 unicase = "*"
 url = "*"
+traitobject = "*"
+typeable = "*"
 
 [dev-dependencies]
 env_logger = "*"

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -6,14 +6,12 @@
 //! are already provided, such as `Host`, `ContentType`, `UserAgent`, and others.
 use std::any::Any;
 use std::borrow::{Cow, ToOwned};
-use std::fmt;
 use std::collections::HashMap;
 use std::collections::hash_map::{Iter, Entry};
 use std::iter::{FromIterator, IntoIterator};
-use std::raw::TraitObject;
-use std::{mem, raw};
+use std::{mem, fmt};
 
-use httparse;
+use {httparse, traitobject};
 use unicase::UniCase;
 
 use self::internals::Item;
@@ -76,12 +74,12 @@ impl<T: HeaderFormat + Send + Sync + Clone> HeaderClone for T {
 impl HeaderFormat + Send + Sync {
     #[inline]
     unsafe fn downcast_ref_unchecked<T: 'static>(&self) -> &T {
-        mem::transmute(mem::transmute::<&HeaderFormat, raw::TraitObject>(self).data)
+        mem::transmute(traitobject::data(self))
     }
 
     #[inline]
     unsafe fn downcast_mut_unchecked<T: 'static>(&mut self) -> &mut T {
-        mem::transmute(mem::transmute::<&mut HeaderFormat, raw::TraitObject>(self).data)
+        mem::transmute(traitobject::data_mut(self))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(test, feature(test))]
 
 //! # Hyper
+//!
 //! Hyper is a fast, modern HTTP implementation written in and for Rust. It
 //! is a low-level typesafe abstraction over raw HTTP, providing an elegant
 //! layer over "stringly-typed" HTTP.
@@ -134,6 +135,8 @@ extern crate cookie;
 extern crate unicase;
 extern crate httparse;
 extern crate num_cpus;
+extern crate traitobject;
+extern crate typeable;
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Removes the need for raw::TraitObject and Any::get_type_id