### PR TITLE
feat(client): remove generic parameter for Connector

### DIFF
--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -51,13 +51,11 @@ impl Request<Fresh> {
     pub fn with_connector<C, S>(method: method::Method, url: Url, connector: &mut C)
         -> HttpResult<Request<Fresh>> where
         C: NetworkConnector<Stream=S>,
-        S: NetworkStream + Send {
+        S: Into<Box<NetworkStream + Send>> {
         debug!("{} {}", method, url);
         let (host, port) = try!(get_host_and_port(&url));
 
-        let stream = try!(connector.connect(&*host, port, &*url.scheme));
-        // FIXME: Use Type ascription
-        let stream: Box<NetworkStream + Send> = Box::new(stream);
+        let stream = try!(connector.connect(&*host, port, &*url.scheme)).into();
         let stream = ThroughWriter(BufWriter::new(stream));
 
         let mut headers = Headers::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,7 @@ mod mimewrapper {
 
 #[allow(unconditional_recursion)]
 fn _assert_send<T: Send>() {
+    _assert_send::<Client>();
     _assert_send::<client::Request<net::Fresh>>();
     _assert_send::<client::Response>();
 }


### PR DESCRIPTION
Closes #379

BREAKING CHANGE: For people using the default HttpConnector and Client,
    everything should continue to just work. If the Client has been
    used with a generic parameter, it should be removed.

However, there were some breaking changes to the internals of
    NetworkConnectors. Specifically, they no longer return a
    NetworkStream, but instead a `Into<Box<NetworkStream + Send>>`. All
    implementations of NetworkStream should continue to just work,
    however.

Possible breakages could come from the stricter usage of Send
    throughout the Client API.

cc @Manishearth @reem 