### PR TITLE
refactor(headers): Implement CookiePair inside of hyper, drop dependency...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ authors = ["Sean McArthur <sean.monstar@gmail.com>",
 keywords = ["http", "hyper", "hyperium"]
 
 [dependencies]
-cookie = "*"
 httparse = "*"
 log = ">= 0.2.0"
 mime = "*"
@@ -27,4 +26,3 @@ typeable = "*"
 
 [dev-dependencies]
 env_logger = "*"
-

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -2,8 +2,7 @@ use header::{Header, HeaderFormat};
 use std::fmt;
 use std::str::from_utf8;
 
-use cookie::Cookie as CookiePair;
-use cookie::CookieJar;
+use header::CookiePair;
 
 /// The `Cookie` header. Defined in [RFC6265](tools.ietf.org/html/rfc6265#section-5.4):
 ///
@@ -60,25 +59,6 @@ impl HeaderFormat for Cookie {
     }
 }
 
-impl Cookie {
-    /// This method can be used to create CookieJar that can be used
-    /// to manipulate cookies and create a corresponding `SetCookie` header afterwards.
-    pub fn to_cookie_jar(&self, key: &[u8]) -> CookieJar<'static> {
-        let mut jar = CookieJar::new(key);
-        for cookie in self.iter() {
-            jar.add_original(cookie.clone());
-        }
-        jar
-    }
-
-    /// Extracts all cookies from `CookieJar` and creates Cookie header.
-    /// Useful for clients.
-    pub fn from_cookie_jar(jar: &CookieJar) -> Cookie {
-        Cookie(jar.iter().collect())
-    }
-}
-
-
 #[test]
 fn test_parse() {
     let h = Header::parse_header(&[b"foo=bar; baz=quux".to_vec()][..]);
@@ -100,16 +80,5 @@ fn test_fmt() {
 
     assert_eq!(&headers.to_string()[..], "Cookie: foo=bar; baz=quux\r\n");
 }
-
-#[test]
-fn cookie_jar() {
-    let cookie_pair = CookiePair::new("foo".to_string(), "bar".to_string());
-    let cookie_header = Cookie(vec![cookie_pair]);
-    let jar = cookie_header.to_cookie_jar(&[]);
-    let new_cookie_header = Cookie::from_cookie_jar(&jar);
-
-    assert_eq!(cookie_header, new_cookie_header);
-}
-
 
 bench_header!(bench, Cookie, { vec![b"foo=bar; baz=quux".to_vec()] });

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -2,8 +2,7 @@ use header::{Header, HeaderFormat};
 use std::fmt;
 use std::str::from_utf8;
 
-use cookie::Cookie;
-use cookie::CookieJar;
+use header::CookiePair;
 
 /// The `Set-Cookie` header
 ///
@@ -11,9 +10,9 @@ use cookie::CookieJar;
 /// "Set-Cookie" followed by a ":" and a cookie.  Each cookie begins with
 /// a name-value-pair, followed by zero or more attribute-value pairs.
 #[derive(Clone, PartialEq, Debug)]
-pub struct SetCookie(pub Vec<Cookie>);
+pub struct SetCookie(pub Vec<CookiePair>);
 
-deref!(SetCookie => Vec<Cookie>);
+deref!(SetCookie => Vec<CookiePair>);
 
 impl Header for SetCookie {
     fn header_name() -> &'static str {
@@ -56,28 +55,10 @@ impl HeaderFormat for SetCookie {
     }
 }
 
-
-impl SetCookie {
-    /// Use this to create SetCookie header from CookieJar using
-    /// calculated delta.
-    pub fn from_cookie_jar(jar: &CookieJar) -> SetCookie {
-        SetCookie(jar.delta())
-    }
-
-    /// Use this on client to apply changes from SetCookie to CookieJar.
-    /// Note that this will `panic!` if `CookieJar` is not root.
-    pub fn apply_to_cookie_jar(&self, jar: &mut CookieJar) {
-        for cookie in self.iter() {
-            jar.add_original(cookie.clone())
-        }
-    }
-}
-
-
 #[test]
 fn test_parse() {
     let h = Header::parse_header(&[b"foo=bar; HttpOnly".to_vec()][..]);
-    let mut c1 = Cookie::new("foo".to_string(), "bar".to_string());
+    let mut c1 = CookiePair::new("foo".to_string(), "bar".to_string());
     c1.httponly = true;
 
     assert_eq!(h, Some(SetCookie(vec![c1])));
@@ -87,27 +68,12 @@ fn test_parse() {
 fn test_fmt() {
     use header::Headers;
 
-    let mut cookie = Cookie::new("foo".to_string(), "bar".to_string());
+    let mut cookie = CookiePair::new("foo".to_string(), "bar".to_string());
     cookie.httponly = true;
     cookie.path = Some("/p".to_string());
-    let cookies = SetCookie(vec![cookie, Cookie::new("baz".to_string(), "quux".to_string())]);
+    let cookies = SetCookie(vec![cookie, CookiePair::new("baz".to_string(), "quux".to_string())]);
     let mut headers = Headers::new();
     headers.set(cookies);
 
     assert_eq!(&headers.to_string()[..], "Set-Cookie: foo=bar; HttpOnly; Path=/p\r\nSet-Cookie: baz=quux; Path=/\r\n");
-}
-
-#[test]
-fn cookie_jar() {
-    let jar = CookieJar::new(b"secret");
-    let cookie = Cookie::new("foo".to_string(), "bar".to_string());
-    jar.encrypted().add(cookie);
-
-    let cookies = SetCookie::from_cookie_jar(&jar);
-
-    let mut new_jar = CookieJar::new(b"secret");
-    cookies.apply_to_cookie_jar(&mut new_jar);
-
-    assert_eq!(jar.encrypted().find("foo"), new_jar.encrypted().find("foo"));
-    assert_eq!(jar.iter().collect::<Vec<Cookie>>(), new_jar.iter().collect::<Vec<Cookie>>());
 }

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -19,7 +19,7 @@ use unicase::UniCase;
 use self::internals::Item;
 use error::HttpResult;
 
-pub use self::shared::{Charset, Encoding, EntityTag, HttpDate, Quality, QualityItem, qitem, q};
+pub use self::shared::*;
 pub use self::common::*;
 
 mod common;

--- a/src/header/shared/cookie.rs
+++ b/src/header/shared/cookie.rs
@@ -1,0 +1,230 @@
+use std::ascii::AsciiExt;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::str::FromStr;
+
+use url;
+
+use header::HttpDate;
+
+// Copied from https://github.com/alexcrichton/cookie-rs
+
+/// A single HTTP cookie
+#[derive(PartialEq, Clone, Debug)]
+pub struct CookiePair {
+    /// The name, or key of the cookie
+    pub name: String,
+    /// The value of the cookie
+    pub value: String,
+    /// The date the cookie should not be sent after
+    pub expires: Option<HttpDate>,
+    /// The time from now in seconds the cookie expires
+    // FIXME: Use duration?
+    pub max_age: Option<u64>,
+    /// The domain the cookie is valid for
+    // FIXME: Use more specific type
+    pub domain: Option<String>,
+    /// The domain path the cookie is valid for
+    // FIXME: Use more specific type
+    pub path: Option<String>,
+    /// `true` if the cookie should only get transmitted over secure connections
+    pub secure: bool,
+    /// `true` if the cookie should only get transmitted over HTTP connections
+    pub httponly: bool,
+    /// custom extension attributes
+    pub custom: BTreeMap<String, String>,
+}
+
+
+impl CookiePair {
+    /// Creates a new cookie-pair, with a given name and value
+    ///
+    /// The other optional arguments are set to default values.
+    pub fn new(name: String, value: String) -> CookiePair {
+        CookiePair {
+            name: name,
+            value: value,
+            expires: None,
+            max_age: None,
+            domain: None,
+            path: Some("/".to_string()),
+            secure: false,
+            httponly: false,
+            custom: BTreeMap::new(),
+        }
+    }
+
+    /// Returns the name-value part of the cookie
+    pub fn pair(&self) -> AttrVal {
+        AttrVal(&self.name, &self.value)
+    }
+}
+
+/// Struct of the name-value part of the cookie, excluding arguments
+pub struct AttrVal<'a>(pub &'a str, pub &'a str);
+
+impl<'a> fmt::Display for AttrVal<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let AttrVal(ref attr, ref val) = *self;
+        write!(f, "{}={}", attr, url::percent_encode(val.as_bytes(),
+                                                     url::DEFAULT_ENCODE_SET))
+    }
+}
+
+impl fmt::Display for CookiePair {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        try!(AttrVal(&self.name, &self.value).fmt(f));
+        if self.httponly { try!(write!(f, "; HttpOnly")); }
+        if self.secure { try!(write!(f, "; Secure")); }
+        match self.path {
+            Some(ref s) => try!(write!(f, "; Path={}", s)),
+            None => {}
+        }
+        match self.domain {
+            Some(ref s) => try!(write!(f, "; Domain={}", s)),
+            None => {}
+        }
+        match self.max_age {
+            Some(n) => try!(write!(f, "; Max-Age={}", n)),
+            None => {}
+        }
+        match self.expires {
+            Some(ref t) => try!(write!(f, "; Expires={}", t)),
+            None => {}
+        }
+
+        for (k, v) in self.custom.iter() {
+            try!(write!(f, "; {}", AttrVal(&k, &v)));
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for CookiePair {
+    type Err = ();
+    fn from_str(s: &str) -> Result<CookiePair, ()> {
+        macro_rules! unwrap_or_skip{ ($e:expr) => (
+            match $e { Some(s) => s, None => continue, }
+        ) }
+
+        let mut c = CookiePair::new(String::new(), String::new());
+        let mut pairs = s.trim().split(';');
+        let keyval = match pairs.next() { Some(s) => s, _ => return Err(()) };
+        let (name, value) = try!(split(keyval));
+        let name = url::percent_decode(name.as_bytes());
+        if name.is_empty() {
+            return Err(());
+        }
+        let value = url::percent_decode(value.as_bytes());
+        c.name = try!(String::from_utf8(name).map_err(|_| ()));
+        c.value = try!(String::from_utf8(value).map_err(|_| ()));
+
+        for attr in pairs {
+            let trimmed = attr.trim();
+            match &trimmed.to_ascii_lowercase()[..] {
+                "secure" => c.secure = true,
+                "httponly" => c.httponly = true,
+                _ => {
+                    let (k, v) = unwrap_or_skip!(split(trimmed).ok());
+                    match &k.to_ascii_lowercase()[..] {
+                        "max-age" => c.max_age = Some(unwrap_or_skip!(v.parse().ok())),
+                        "domain" => {
+                            if v.is_empty() {
+                                continue;
+                            }
+
+                            let domain = if v.chars().next() == Some('.') {
+                                &v[1..]
+                            } else {
+                                v
+                            };
+                            c.domain = Some(domain.to_ascii_lowercase());
+                        }
+                        "path" => c.path = Some(v.to_string()),
+                        "expires" => {
+                            match v.parse() {
+                                Ok(date) => c.expires = Some(date),
+                                Err(_) => {}
+                            }
+                        }
+                        _ => { c.custom.insert(k.to_string(), v.to_string()); }
+                    }
+                }
+            }
+        }
+
+        return Ok(c);
+
+        fn split<'a>(s: &'a str) -> Result<(&'a str, &'a str), ()> {
+            macro_rules! try {
+                ($e:expr) => (match $e { Some(s) => s, None => return Err(()) })
+            }
+            let mut parts = s.trim().splitn(2, '=');
+            let first = try!(parts.next()).trim();
+            let second = try!(parts.next()).trim();
+            Ok((first, second))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CookiePair;
+
+    #[test]
+    fn parse() {
+        assert!("bar".parse::<CookiePair>().is_err());
+        assert!("=bar".parse::<CookiePair>().is_err());
+        assert!(" =bar".parse::<CookiePair>().is_err());
+        assert!("foo=".parse::<CookiePair>().is_ok());
+        let mut expected = CookiePair::new("foo".to_string(), "bar".to_string());
+        assert_eq!("foo=bar".parse::<CookiePair>().ok().unwrap(), expected);
+        assert_eq!("foo = bar".parse::<CookiePair>().ok().unwrap(), expected);
+        assert_eq!("foo=bar ".parse::<CookiePair>().ok().unwrap(), expected);
+        assert_eq!("foo=bar ;Domain=".parse::<CookiePair>().ok().unwrap(), expected);
+        assert_eq!("foo=bar ;Domain= ".parse::<CookiePair>().ok().unwrap(), expected);
+        assert_eq!("foo=bar ;Ignored".parse::<CookiePair>().ok().unwrap(), expected);
+        expected.httponly = true;
+        assert_eq!("foo=bar ;HttpOnly".parse::<CookiePair>().ok().unwrap(), expected);
+        assert_eq!("foo=bar ;httponly".parse::<CookiePair>().ok().unwrap(), expected);
+        assert_eq!("foo=bar ;HTTPONLY".parse::<CookiePair>().ok().unwrap(), expected);
+        assert_eq!("foo=bar ; sekure; HTTPONLY".parse::<CookiePair>().ok().unwrap(), expected);
+        expected.secure = true;
+        assert_eq!("foo=bar ;HttpOnly; Secure".parse::<CookiePair>().ok().unwrap(), expected);
+        expected.max_age = Some(4);
+        assert_eq!("foo=bar ;HttpOnly; Secure; \
+                    Max-Age=4".parse::<CookiePair>().ok().unwrap(), expected);
+        assert_eq!("foo=bar ;HttpOnly; Secure; \
+                    Max-Age = 4 ".parse::<CookiePair>().ok().unwrap(), expected);
+        expected.path = Some("/foo".to_string());
+        assert_eq!("foo=bar ;HttpOnly; Secure; \
+                    Max-Age=4; Path=/foo".parse::<CookiePair>().ok().unwrap(), expected);
+        expected.domain = Some("foo.com".to_string());
+        assert_eq!("foo=bar ;HttpOnly; Secure; \
+                    Max-Age=4; Path=/foo; \
+                    Domain=foo.com".parse::<CookiePair>().ok().unwrap(), expected);
+        assert_eq!("foo=bar ;HttpOnly; Secure; \
+                    Max-Age=4; Path=/foo; \
+                    Domain=FOO.COM".parse::<CookiePair>().ok().unwrap(), expected);
+        expected.custom.insert("wut".to_string(), "lol".to_string());
+        assert_eq!("foo=bar ;HttpOnly; Secure; \
+                    Max-Age=4; Path=/foo; \
+                    Domain=foo.com; wut=lol".parse::<CookiePair>().ok().unwrap(), expected);
+
+        assert_eq!(expected.to_string(),
+                   "foo=bar; HttpOnly; Secure; Path=/foo; Domain=foo.com; \
+                    Max-Age=4; wut=lol");
+    }
+
+    #[test]
+    fn odd_characters() {
+        let expected = CookiePair::new("foo".to_string(), "b/r".to_string());
+        assert_eq!("foo=b%2Fr".parse::<CookiePair>().ok().unwrap(), expected);
+    }
+
+    #[test]
+    fn pair() {
+        let cookie = CookiePair::new("foo".to_string(), "bar".to_string());
+        assert_eq!(cookie.pair().to_string(), "foo=bar".to_string());
+    }
+}

--- a/src/header/shared/mod.rs
+++ b/src/header/shared/mod.rs
@@ -1,10 +1,12 @@
 pub use self::charset::Charset;
+pub use self::cookie::CookiePair;
 pub use self::encoding::Encoding;
 pub use self::entity::EntityTag;
 pub use self::httpdate::HttpDate;
 pub use self::quality_item::{Quality, QualityItem, qitem, q};
 
 mod charset;
+mod cookie;
 mod encoding;
 mod entity;
 mod httpdate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,6 @@ extern crate rustc_serialize as serialize;
 extern crate time;
 extern crate url;
 extern crate openssl;
-extern crate cookie;
 extern crate unicase;
 extern crate httparse;
 extern crate num_cpus;


### PR DESCRIPTION
... on cookie-rs

Remove the dependency on alexcrichton's cookie-rs because it depends on openssl and does to much
work with the cookies that should be placed in a higher level lib and not in hyper. Remove all
methods that require a CookieJar. Copied and adapted the Cookie type from cookie-rs to hyper.

Originally proposed by @seanmonstar.

Set openssl version to 0.5 to make this compiling.

BREAKING CHANGE: All methods using CookieJar removed from headers.