### PR TITLE
refactor(headers): Add encode_headers() function

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -27,6 +27,6 @@ fn main() {
     };
 
     println!("Response: {}", res.status);
-    println!("Headers:\n{}", res.headers);
+    println!("Headers:\n{:?}", res.headers);
     io::copy(&mut res, &mut io::stdout()).unwrap();
 }

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -143,33 +143,12 @@ impl FromStr for Basic {
 #[cfg(test)]
 mod tests {
     use super::{Authorization, Basic};
-    use super::super::super::{Headers, Header};
-
-    #[test]
-    fn test_raw_auth() {
-        let mut headers = Headers::new();
-        headers.set(Authorization("foo bar baz".to_string()));
-        assert_eq!(headers.to_string(), "Authorization: foo bar baz\r\n".to_string());
-    }
+    use super::super::super::Header;
 
     #[test]
     fn test_raw_auth_parse() {
         let header: Authorization<String> = Header::parse_header(&[b"foo bar baz".to_vec()]).unwrap();
         assert_eq!(header.0, "foo bar baz");
-    }
-
-    #[test]
-    fn test_basic_auth() {
-        let mut headers = Headers::new();
-        headers.set(Authorization(Basic { username: "Aladdin".to_string(), password: Some("open sesame".to_string()) }));
-        assert_eq!(headers.to_string(), "Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==\r\n".to_string());
-    }
-
-    #[test]
-    fn test_basic_auth_no_password() {
-        let mut headers = Headers::new();
-        headers.set(Authorization(Basic { username: "Aladdin".to_string(), password: None }));
-        assert_eq!(headers.to_string(), "Authorization: Basic QWxhZGRpbjo=\r\n".to_string());
     }
 
     #[test]

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -88,20 +88,6 @@ fn test_parse() {
 }
 
 #[test]
-fn test_fmt() {
-    use header::Headers;
-
-    let mut cookie_pair = CookiePair::new("foo".to_string(), "bar".to_string());
-    cookie_pair.httponly = true;
-    cookie_pair.path = Some("/p".to_string());
-    let cookie_header = Cookie(vec![cookie_pair, CookiePair::new("baz".to_string(), "quux".to_string())]);
-    let mut headers = Headers::new();
-    headers.set(cookie_header);
-
-    assert_eq!(&headers.to_string()[..], "Cookie: foo=bar; baz=quux\r\n");
-}
-
-#[test]
 fn cookie_jar() {
     let cookie_pair = CookiePair::new("foo".to_string(), "bar".to_string());
     let cookie_header = Cookie(vec![cookie_pair]);

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -84,20 +84,6 @@ fn test_parse() {
 }
 
 #[test]
-fn test_fmt() {
-    use header::Headers;
-
-    let mut cookie = Cookie::new("foo".to_string(), "bar".to_string());
-    cookie.httponly = true;
-    cookie.path = Some("/p".to_string());
-    let cookies = SetCookie(vec![cookie, Cookie::new("baz".to_string(), "quux".to_string())]);
-    let mut headers = Headers::new();
-    headers.set(cookies);
-
-    assert_eq!(&headers.to_string()[..], "Set-Cookie: foo=bar; HttpOnly; Path=/p\r\nSet-Cookie: baz=quux; Path=/\r\n");
-}
-
-#[test]
 fn cookie_jar() {
     let jar = CookieJar::new(b"secret");
     let cookie = Cookie::new("foo".to_string(), "bar".to_string());

--- a/src/header/common/user_agent.rs
+++ b/src/header/common/user_agent.rs
@@ -19,11 +19,3 @@ header! {
     // TODO: Maybe write parsing according to the spec? (Split the String)
     (UserAgent, "User-Agent") => [String]
 }
-
-#[test] fn test_format() {
-    use std::borrow::ToOwned;
-    use header::Headers;
-    let mut head = Headers::new();
-    head.set(UserAgent("Bunnies".to_owned()));
-    assert!(head.to_string() == "User-Agent: Bunnies\r\n".to_owned());
-}

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -7,7 +7,7 @@ use std::io::{self, Write};
 
 use time::now_utc;
 
-use header;
+use header::{self, encode_headers};
 use http::{CR, LF, LINE_ENDING, HttpWriter};
 use http::HttpWriter::{ThroughWriter, ChunkedWriter, SizedWriter};
 use status;
@@ -110,7 +110,7 @@ impl<'a> Response<'a, Fresh> {
 
 
         debug!("headers [\n{:?}]", self.headers);
-        try!(write!(&mut self.body, "{}", self.headers));
+        try!(encode_headers(&self.headers, &mut self.body));
         try!(write!(&mut self.body, "{}", LINE_ENDING));
 
         let stream = if chunked {


### PR DESCRIPTION
The HTTP headers block is not always a valid UTF-8 string, so it makes no sense to
implement the Display trait for it (additionally Display is intended for humans
and HTTP header blocks clearly are not). Instead the headers should be encoded as
a byte stream.

Removed a few tests, since they do not work without Display.

Remark: Currently formatted headers can't contain invalid chars, another commit
will enable this.

BREAKING CHANGE: fmt::Display is no longer implemented for Headers.