### PR TITLE
feat(http): Implement Debug for HttpReader/Writer.

### DIFF
--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -14,6 +14,7 @@ use version;
 use HttpResult;
 
 /// A response for a client request to a remote server.
+#[derive(Debug)]
 pub struct Response<S = HttpStream> {
     /// The status from the server.
     pub status: status::StatusCode,

--- a/src/http.rs
+++ b/src/http.rs
@@ -2,6 +2,7 @@
 use std::borrow::{Cow, ToOwned};
 use std::cmp::min;
 use std::io::{self, Read, Write, BufRead};
+use std::fmt;
 
 use httparse;
 
@@ -56,6 +57,18 @@ impl<R: Read> HttpReader<R> {
             ChunkedReader(r, _) => r,
             EofReader(r) => r,
             EmptyReader(r) => r,
+        }
+    }
+}
+
+impl<R> fmt::Debug for HttpReader<R> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            SizedReader(_,rem) => write!(fmt, "SizedReader(remaining={:?})", rem),
+            ChunkedReader(_, None) => write!(fmt, "ChunkedReader(chunk_remaining=unknown)"),
+            ChunkedReader(_, Some(rem)) => write!(fmt, "ChunkedReader(chunk_remaining={:?})", rem),
+            EofReader(_) => write!(fmt, "EofReader"),
+            EmptyReader(_) => write!(fmt, "EmptyReader"),
         }
     }
 }
@@ -301,6 +314,17 @@ impl<W: Write> Write for HttpWriter<W> {
             ChunkedWriter(ref mut w) => w.flush(),
             SizedWriter(ref mut w, _) => w.flush(),
             EmptyWriter(ref mut w) => w.flush(),
+        }
+    }
+}
+
+impl<W: Write> fmt::Debug for HttpWriter<W> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ThroughWriter(_) => write!(fmt, "ThroughWriter"),
+            ChunkedWriter(_) => write!(fmt, "ChunkedWriter"),
+            SizedWriter(_, rem) => write!(fmt, "SizedWriter(remaining={:?})", rem),
+            EmptyWriter(_) => write!(fmt, "EmptyWriter"),
         }
     }
 }

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -15,6 +15,7 @@ use net::{Fresh, Streaming};
 use version;
 
 /// The outgoing half for a Tcp connection, created by a `Server` and given to a `Handler`.
+#[derive(Debug)]
 pub struct Response<'a, W = Fresh> {
     /// The HTTP version of this response.
     pub version: version::HttpVersion,


### PR DESCRIPTION
Also derives it for Responses, since that's easy now.