### PR TITLE
feat(net) make HttpStreams implement Debug

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -253,6 +253,15 @@ pub enum HttpStream {
     Https(SslStream<CloneTcpStream>),
 }
 
+impl fmt::Debug for HttpStream {
+  fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    match *self {
+      HttpStream::Http(_) => write!(fmt, "Http HttpStream"),
+      HttpStream::Https(_) => write!(fmt, "Https HttpStream"),
+    }
+  }
+}
+
 impl Read for HttpStream {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {


### PR DESCRIPTION
Pretty simple.  Turns out that last PR I made had Response's implementing Debug... but only if the type param was Debug as well.  Since HttpStream is the default, seems sensible for it to implement Debug.