### PR TITLE
Bugfix: HttpTooLagreError on TCP close fixed

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -58,7 +58,8 @@ impl<R: Read> BufReader<R> {
             self.cap += nread;
             Ok(nread)
         } else {
-            Ok(0)
+            Err(io::Error::new(io::ErrorKind::InvalidInput,
+                               "Buffer capacity error."))
         }
     }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -352,8 +352,8 @@ fn parse<R: Read, T: TryParse<Subject=I>, I>(rdr: &mut BufReader<R>) -> HttpResu
             },
             _partial => ()
         }
-        match try!(rdr.read_into_buf()) {
-            0 => return Err(HttpTooLargeError),
+        match rdr.read_into_buf() {
+            Err(_) => return Err(HttpTooLargeError),
             _ => ()
         }
     }


### PR DESCRIPTION
 When TCP connection finished, NetworkStream::read returns Ok(0), so
 buffer::read_info_buf() also returns Ok(0), but parse function treats
 it as the HttpTooLargeError and we have annoying errors in debug mode.
 We should return some kind of Err() in read_info_buf and check this
 error in parse function instead of treating Ok(0) as error.
