### PR TITLE
fix(http): fix HttpTooLagreError on TCP close

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -58,7 +58,8 @@ impl<R: Read> BufReader<R> {
             self.cap += nread;
             Ok(nread)
         } else {
-            Ok(0)
+            Err(io::Error::new(io::ErrorKind::InvalidInput,
+                               "Buffer capacity error."))
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use url;
 
 use self::HttpError::{HttpMethodError, HttpUriError, HttpVersionError,
                       HttpHeaderError, HttpStatusError, HttpIoError,
-                      HttpTooLargeError};
+                      HttpTooLargeError, HttpClosed};
 
 
 /// Result type often returned from methods that can have `HttpError`s.
@@ -31,6 +31,8 @@ pub enum HttpError {
     HttpStatusError,
     /// An `IoError` that occured while trying to read or write to a network stream.
     HttpIoError(IoError),
+    /// TCP FIN
+    HttpClosed,
 }
 
 impl fmt::Display for HttpError {
@@ -49,6 +51,7 @@ impl Error for HttpError {
             HttpTooLargeError => "Message head is too large",
             HttpStatusError => "Invalid Status provided",
             HttpIoError(_) => "An IoError occurred while connecting to the specified network",
+            HttpClosed => "TCP connection closed",
         }
     }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -12,7 +12,7 @@ use method::Method;
 use status::StatusCode;
 use uri::RequestUri;
 use version::HttpVersion::{self, Http10, Http11};
-use HttpError:: HttpTooLargeError;
+use HttpError::{HttpTooLargeError, HttpClosed};
 use {HttpError, HttpResult};
 
 use self::HttpReader::{SizedReader, ChunkedReader, EofReader, EmptyReader};
@@ -354,6 +354,7 @@ fn parse<R: Read, T: TryParse<Subject=I>, I>(rdr: &mut BufReader<R>) -> HttpResu
         }
         match rdr.read_into_buf() {
             Err(_) => return Err(HttpTooLargeError),
+            Ok(0)  => return Err(HttpClosed),
             _ => ()
         }
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -352,8 +352,8 @@ fn parse<R: Read, T: TryParse<Subject=I>, I>(rdr: &mut BufReader<R>) -> HttpResu
             },
             _partial => ()
         }
-        match try!(rdr.read_into_buf()) {
-            0 => return Err(HttpTooLargeError),
+        match rdr.read_into_buf() {
+            Err(_) => return Err(HttpTooLargeError),
             _ => ()
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -12,7 +12,7 @@ pub use self::response::Response;
 
 pub use net::{Fresh, Streaming};
 
-use HttpError::HttpIoError;
+use HttpError::{HttpIoError,HttpClosed};
 use {HttpResult};
 use buffer::BufReader;
 use header::{Headers, Connection, Expect};
@@ -134,6 +134,7 @@ where S: NetworkStream + Clone, H: Handler {
     while keep_alive {
         let req = match Request::new(&mut rdr, addr) {
             Ok(req) => req,
+            Err(HttpClosed) => break,
             Err(e@HttpIoError(_)) => {
                 debug!("ioerror in keepalive loop = {:?}", e);
                 break;


### PR DESCRIPTION
When TCP connection finished, NetworkStream::read returns Ok(0), so
buffer::read_info_buf() also returns Ok(0), but parse function treats
it as the HttpTooLargeError and we have annoying errors in debug mode.
We should return some kind of Err() in read_info_buf and check this
error in parse function instead of treating Ok(0) as error.