### PR TITLE
fix(rustup): add type parameter to JoinHandle

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -182,7 +182,7 @@ pub struct Listening {
     #[cfg(feature = "nightly")]
     _guard: Option<JoinHandle<()>>,
     #[cfg(not(feature = "nightly"))]
-    _guard: Option<JoinHandle>,
+    _guard: Option<JoinHandle<()>>,
     /// The socket addresses that the server is bound to.
     pub socket: SocketAddr,
 }


### PR DESCRIPTION
`JoinHandle` now has a type parameter. Setting it to `()` gives the old behaviour.