### PR TITLE
refactor(error): remove redundant parts of error names

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -43,8 +43,8 @@ use header::{ContentLength, Location};
 use method::Method;
 use net::{NetworkConnector, NetworkStream, HttpConnector, ContextVerifier};
 use status::StatusClass::Redirection;
-use {Url, HttpResult};
-use HttpError::HttpUriError;
+use {Url};
+use Error;
 
 pub use self::pool::Pool;
 pub use self::request::Request;
@@ -203,7 +203,7 @@ impl<'a, U: IntoUrl> RequestBuilder<'a, U> {
     }
 
     /// Execute this request and receive a Response back.
-    pub fn send(self) -> HttpResult<Response> {
+    pub fn send(self) -> ::Result<Response> {
         let RequestBuilder { client, method, url, headers, body } = self;
         let mut url = try!(url.into_url());
         trace!("send {:?} {:?}", method, url);
@@ -382,15 +382,15 @@ impl Default for RedirectPolicy {
     }
 }
 
-fn get_host_and_port(url: &Url) -> HttpResult<(String, u16)> {
+fn get_host_and_port(url: &Url) -> ::Result<(String, u16)> {
     let host = match url.serialize_host() {
         Some(host) => host,
-        None => return Err(HttpUriError(UrlError::EmptyHost))
+        None => return Err(Error::Uri(UrlError::EmptyHost))
     };
     trace!("host={:?}", host);
     let port = match url.port_or_default() {
         Some(port) => port,
-        None => return Err(HttpUriError(UrlError::InvalidPort))
+        None => return Err(Error::Uri(UrlError::InvalidPort))
     };
     trace!("port={:?}", port);
     Ok((host, port))

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -12,7 +12,6 @@ use net::{NetworkStream, NetworkConnector, HttpConnector, Fresh, Streaming};
 use http::{self, HttpWriter, LINE_ENDING};
 use http::HttpWriter::{ThroughWriter, ChunkedWriter, SizedWriter, EmptyWriter};
 use version;
-use HttpResult;
 use client::{Response, get_host_and_port};
 
 
@@ -43,14 +42,14 @@ impl<W> Request<W> {
 
 impl Request<Fresh> {
     /// Create a new client request.
-    pub fn new(method: method::Method, url: Url) -> HttpResult<Request<Fresh>> {
+    pub fn new(method: method::Method, url: Url) -> ::Result<Request<Fresh>> {
         let mut conn = HttpConnector(None);
         Request::with_connector(method, url, &mut conn)
     }
 
     /// Create a new client request with a specific underlying NetworkStream.
     pub fn with_connector<C, S>(method: method::Method, url: Url, connector: &mut C)
-        -> HttpResult<Request<Fresh>> where
+        -> ::Result<Request<Fresh>> where
         C: NetworkConnector<Stream=S>,
         S: Into<Box<NetworkStream + Send>> {
         let (host, port) = try!(get_host_and_port(&url));
@@ -76,7 +75,7 @@ impl Request<Fresh> {
 
     /// Consume a Fresh Request, writing the headers and method,
     /// returning a Streaming Request.
-    pub fn start(mut self) -> HttpResult<Request<Streaming>> {
+    pub fn start(mut self) -> ::Result<Request<Streaming>> {
         let mut uri = self.url.serialize_path().unwrap();
         //TODO: this needs a test
         if let Some(ref q) = self.url.query {
@@ -154,7 +153,7 @@ impl Request<Streaming> {
     /// Completes writing the request, and returns a response to read from.
     ///
     /// Consumes the Request.
-    pub fn send(self) -> HttpResult<Response> {
+    pub fn send(self) -> ::Result<Response> {
         let mut raw = try!(self.body.end()).into_inner().unwrap(); // end() already flushes
         if !http::should_keep_alive(self.version, &self.headers) {
             try!(raw.close(Shutdown::Write));

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -12,7 +12,6 @@ use http::{self, HttpReader, RawStatus};
 use http::HttpReader::{SizedReader, ChunkedReader, EofReader};
 use status;
 use version;
-use HttpResult;
 
 /// A response for a client request to a remote server.
 #[derive(Debug)]
@@ -32,7 +31,7 @@ pub struct Response<S = HttpStream> {
 impl Response {
 
     /// Creates a new response from a server.
-    pub fn new(stream: Box<NetworkStream + Send>) -> HttpResult<Response> {
+    pub fn new(stream: Box<NetworkStream + Send>) -> ::Result<Response> {
         let mut stream = BufReader::new(stream);
 
         let head = try!(http::parse_response(&mut stream));

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -17,7 +17,6 @@ use typeable::Typeable;
 use unicase::UniCase;
 
 use self::internals::Item;
-use error::HttpResult;
 
 pub use self::shared::*;
 pub use self::common::*;
@@ -113,7 +112,7 @@ impl Headers {
     }
 
     #[doc(hidden)]
-    pub fn from_raw<'a>(raw: &[httparse::Header<'a>]) -> HttpResult<Headers> {
+    pub fn from_raw<'a>(raw: &[httparse::Header<'a>]) -> ::Result<Headers> {
         let mut headers = Headers::new();
         for header in raw {
             trace!("raw header: {:?}={:?}", header.name, &header.value[..]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ extern crate test;
 pub use mimewrapper::mime;
 pub use url::Url;
 pub use client::Client;
-pub use error::{HttpResult, HttpError};
+pub use error::{Result, Error};
 pub use method::Method::{Get, Head, Post, Delete};
 pub use status::StatusCode::{Ok, BadRequest, NotFound};
 pub use server::Server;

--- a/src/method.rs
+++ b/src/method.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::convert::AsRef;
 
-use error::HttpError;
+use error::Error;
 use self::Method::{Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch,
                    Extension};
 
@@ -87,10 +87,10 @@ impl Method {
 }
 
 impl FromStr for Method {
-    type Err = HttpError;
-    fn from_str(s: &str) -> Result<Method, HttpError> {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Method, Error> {
         if s == "" {
-            Err(HttpError::HttpMethodError)
+            Err(Error::Method)
         } else {
             Ok(match s {
                 "OPTIONS" => Options,

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -5,7 +5,6 @@
 use std::io::{self, Read};
 use std::net::SocketAddr;
 
-use {HttpResult};
 use buffer::BufReader;
 use net::NetworkStream;
 use version::{HttpVersion};
@@ -35,7 +34,7 @@ impl<'a, 'b: 'a> Request<'a, 'b> {
     /// Create a new Request, reading the StartLine and Headers so they are
     /// immediately useful.
     pub fn new(mut stream: &'a mut BufReader<&'b mut NetworkStream>, addr: SocketAddr)
-        -> HttpResult<Request<'a, 'b>> {
+        -> ::Result<Request<'a, 'b>> {
 
         let Incoming { version, subject: (method, uri), headers } = try!(http::parse_request(stream));
         debug!("Request Line: {:?} {:?} {:?}", method, uri, version);

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use url::Url;
 use url::ParseError as UrlError;
 
-use error::HttpError;
+use Error;
 
 /// The Request-URI of a Request's StartLine.
 ///
@@ -50,12 +50,12 @@ pub enum RequestUri {
 }
 
 impl FromStr for RequestUri {
-    type Err = HttpError;
+    type Err = Error;
 
-    fn from_str(s: &str) -> Result<RequestUri, HttpError> {
+    fn from_str(s: &str) -> Result<RequestUri, Error> {
         let bytes = s.as_bytes();
         if bytes == [] {
-            Err(HttpError::HttpUriError(UrlError::InvalidCharacter))
+            Err(Error::Uri(UrlError::InvalidCharacter))
         } else if bytes == b"*" {
             Ok(RequestUri::Star)
         } else if bytes.starts_with(b"/") {


### PR DESCRIPTION
The old names followed the old style of including the module name and
"Error" in each variant. The new style is to refer to an error from its
owning module, and variants are now scoped to their enum, so there's no
need to include the enum name in the variant name.

BREAKING CHANGE: The terms `Http` and `Error` have been removed from the Error
  type and its variants. `HttpError` should now be accessed as `hyper::Error`,
  and variants like `HttpIoError` should be accessed as `Error::Io`.