### PR TITLE
fix(server): JoinHandle type parameter

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -181,10 +181,7 @@ where S: NetworkStream + Clone, H: Handler {
 
 /// A listening server, which can later be closed.
 pub struct Listening {
-    #[cfg(feature = "nightly")]
     _guard: Option<JoinHandle<()>>,
-    #[cfg(not(feature = "nightly"))]
-    _guard: Option<JoinHandle>,
     /// The socket addresses that the server is bound to.
     pub socket: SocketAddr,
 }


### PR DESCRIPTION
The new beta adopts the new `JoinHandle` API which has a type parameter.