### PR TITLE
fix(net): switch to Tlsv1_2 for default ssl method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,16 @@ httparse = "*"
 log = ">= 0.2.0"
 mime = "*"
 num_cpus = "*"
-openssl = "*"
 rustc-serialize = "*"
 time = "*"
 unicase = "*"
 url = "*"
 traitobject = "*"
 typeable = "*"
+
+[dependencies.openssl]
+version = "*"
+features = ["tlsv1_2"]
 
 [dev-dependencies]
 env_logger = "*"

--- a/src/net.rs
+++ b/src/net.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use openssl::ssl::{Ssl, SslStream, SslContext, SSL_VERIFY_NONE};
-use openssl::ssl::SslMethod::Sslv23;
+use openssl::ssl::SslMethod::Tlsv1_2;
 use openssl::ssl::error::{SslError, StreamError, OpenSslErrors, SslSessionClosed};
 use openssl::x509::X509FileType;
 
@@ -159,7 +159,7 @@ impl HttpListener {
 
     /// Start listening to an address over HTTPS.
     pub fn https<To: ToSocketAddrs>(addr: To, cert: &Path, key: &Path) -> io::Result<HttpListener> {
-        let mut ssl_context = try!(SslContext::new(Sslv23).map_err(lift_ssl_error));
+        let mut ssl_context = try!(SslContext::new(Tlsv1_2).map_err(lift_ssl_error));
         try!(ssl_context.set_cipher_list("DEFAULT").map_err(lift_ssl_error));
         try!(ssl_context.set_certificate_file(cert, X509FileType::PEM).map_err(lift_ssl_error));
         try!(ssl_context.set_private_key_file(key, X509FileType::PEM).map_err(lift_ssl_error));
@@ -299,7 +299,7 @@ impl NetworkConnector for HttpConnector {
             "https" => {
                 debug!("https scheme");
                 let stream = CloneTcpStream(try!(TcpStream::connect(addr)));
-                let mut context = try!(SslContext::new(Sslv23).map_err(lift_ssl_error));
+                let mut context = try!(SslContext::new(Tlsv1_2).map_err(lift_ssl_error));
                 if let Some(ref mut verifier) = self.0 {
                     verifier(&mut context);
                 }


### PR DESCRIPTION
This change substitutes the previous insecure [default ssl method](https://github.com/sfackler/rust-openssl/blob/master/openssl/src/ssl/mod.rs#L90-L91) with a [more secure default](https://github.com/sfackler/rust-openssl/blob/master/openssl/src/ssl/mod.rs#L97-L99). Without this I was blocked writing a client interface for a secure server supporting the more secure tls method and there wasn't a way I could find to provide the ssl method used but the client.

A more thorough changeset would probably involve something like adding a new ssl provider interface to then network connector and network listener interfaces that allow's for user defined ssl contexts, but I think that would be a breaking change. This was a much smaller change, makes the defaults more secure, and shouldn't be a breaking change, so I went with this instead.