### PR TITLE
fix(header): exporting test_header! macro

### DIFF
--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -95,6 +95,7 @@ macro_rules! deref(
     }
 );
 
+#[macro_export]
 macro_rules! test_header {
     ($id:ident, $raw:expr) => {
         #[test]


### PR DESCRIPTION
That way, third-parties can keep using the `header!` macro, which
now requires the `test_header!` macro as well.

Considering the `header!` macro is exported and part of the public
API, it was not desired to prevent it's usage in any way.