### PR TITLE
chore(travis): Enable test coverage generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ matrix:
     include:
         - rust: nightly
           env: FEATURES="--features nightly"
+          sudo: false
         - rust: nightly
           env: FEATURES="--features nightly" BENCH=true
+          sudo: false
         - rust: beta
-
-sudo: false
+          sudo: true
 
 cache:
     directories:
@@ -17,6 +18,12 @@ cache:
 script: ./.travis.sh
 
 after_success: |
+    [ $TRAVIS_RUST_VERSION = beta ] &&
+    sudo apt-get install libcurl4-openssl-dev libelf-dev libdw-dev &&
+    wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+    tar xzf master.tar.gz && mkdir kcov-master/build && cd kcov-master/build && cmake .. && make &&
+    sudo make install && cd ../.. &&
+    kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/hyper-*
     [ $TRAVIS_BRANCH = master ] &&
     [ $TRAVIS_PULL_REQUEST = false ] &&
     [ $TRAVIS_RUST_VERSION = beta ] &&


### PR DESCRIPTION
Generates a test coverage using kcov on travis. The coverage is only
generated for beta builds. kcov requires using sudo, so beta builds
can't run on container infrastructure anymore.

Closes #44 
[![Coverage Status](https://coveralls.io/repos/pyfisch/hyper/badge.svg?branch=kcov)](https://coveralls.io/r/pyfisch/hyper?branch=kcov)