### PR TITLE
feat(headers): Parse Upgrade header protocols further

### DIFF
--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -42,7 +42,7 @@ pub use self::referer::Referer;
 pub use self::server::Server;
 pub use self::set_cookie::SetCookie;
 pub use self::transfer_encoding::TransferEncoding;
-pub use self::upgrade::{Upgrade, Protocol};
+pub use self::upgrade::{Upgrade, Protocol, ProtocolName};
 pub use self::user_agent::UserAgent;
 pub use self::vary::Vary;
 


### PR DESCRIPTION
Parses protocols into a name and a value part matching the RFC.
An enum contains all registered or known protocols, but contains
an extension variant.

Closes #480

BREAKING CHANGE: Upgrade header Protocol changed.