### PR TITLE
feat(error): add Ssl variant to hyper::Error

### DIFF
--- a/benches/client.rs
+++ b/benches/client.rs
@@ -79,7 +79,7 @@ struct MockConnector;
 
 impl net::NetworkConnector for MockConnector {
     type Stream = MockStream;
-    fn connect(&mut self, _: &str, _: u16, _: &str) -> io::Result<MockStream> {
+    fn connect(&mut self, _: &str, _: u16, _: &str) -> hyper::Result<MockStream> {
         Ok(MockStream::new())
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -144,7 +144,7 @@ impl<C: NetworkConnector<Stream=S> + Send, S: NetworkStream + Send> NetworkConne
     type Stream = Box<NetworkStream + Send>;
     #[inline]
     fn connect(&mut self, host: &str, port: u16, scheme: &str)
-        -> io::Result<Box<NetworkStream + Send>> {
+        -> ::Result<Box<NetworkStream + Send>> {
         Ok(try!(self.0.connect(host, port, scheme)).into())
     }
 }
@@ -155,7 +155,7 @@ impl NetworkConnector for Connector {
     type Stream = Box<NetworkStream + Send>;
     #[inline]
     fn connect(&mut self, host: &str, port: u16, scheme: &str)
-        -> io::Result<Box<NetworkStream + Send>> {
+        -> ::Result<Box<NetworkStream + Send>> {
         Ok(try!(self.0.connect(host, port, scheme)).into())
     }
 }

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -98,7 +98,7 @@ impl<S> PoolImpl<S> {
 
 impl<C: NetworkConnector<Stream=S>, S: NetworkStream + Send> NetworkConnector for Pool<C> {
     type Stream = PooledStream<S>;
-    fn connect(&mut self, host: &str, port: u16, scheme: &str) -> io::Result<PooledStream<S>> {
+    fn connect(&mut self, host: &str, port: u16, scheme: &str) -> ::Result<PooledStream<S>> {
         let key = key(host, port, scheme);
         let mut locked = self.inner.lock().unwrap();
         let mut should_remove = false;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -73,7 +73,7 @@ pub struct MockConnector;
 impl NetworkConnector for MockConnector {
     type Stream = MockStream;
 
-    fn connect(&mut self, _host: &str, _port: u16, _scheme: &str) -> io::Result<MockStream> {
+    fn connect(&mut self, _host: &str, _port: u16, _scheme: &str) -> ::Result<MockStream> {
         Ok(MockStream::new())
     }
 }
@@ -88,7 +88,7 @@ macro_rules! mock_connector (
 
         impl ::net::NetworkConnector for $name {
             type Stream = ::mock::MockStream;
-            fn connect(&mut self, host: &str, port: u16, scheme: &str) -> ::std::io::Result<::mock::MockStream> {
+            fn connect(&mut self, host: &str, port: u16, scheme: &str) -> $crate::Result<::mock::MockStream> {
                 use std::collections::HashMap;
                 use std::io::Cursor;
                 debug!("MockStream::connect({:?}, {:?}, {:?})", host, port, scheme);
@@ -99,7 +99,7 @@ macro_rules! mock_connector (
                 let key = format!("{}://{}", scheme, host);
                 // ignore port for now
                 match map.get(&*key) {
-                    Some(res) => Ok(::mock::MockStream {
+                    Some(res) => Ok($crate::mock::MockStream {
                         write: vec![],
                         read: Cursor::new(res.to_string().into_bytes()),
                     }),


### PR DESCRIPTION
The errors from openssl were previously boxed into a
Box<std::error::Error>, which lost some specifics and made it difficult
to match against. To solve this, an `Ssl` variant is added to the
`Error` enum of hyper, and is returned when openssl returns specific
errors.

Closes #483

BREAKING CHANGE: Adds a variant to `hyper::Error`, which may break any
exhaustive matches.

cc @jdm