### PR TITLE
fix(header): export `tm!` macro

### DIFF
--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -98,6 +98,7 @@ macro_rules! deref(
     }
 );
 
+#[macro_export]
 macro_rules! tm {
     ($id:ident, $tm:ident{$($tf:item)*}) => {
         #[allow(unused_imports)]


### PR DESCRIPTION
It is used in the `header!` macro, which is exported as well.
If `tm!` is not exported, external clients cannot user otherwise
exported macros anymore who are dependent on `tm!`.