### PR TITLE
feat(net): remove mut requirement for NetworkConnector.connect()

### DIFF
--- a/benches/client.rs
+++ b/benches/client.rs
@@ -79,7 +79,7 @@ struct MockConnector;
 
 impl net::NetworkConnector for MockConnector {
     type Stream = MockStream;
-    fn connect(&mut self, _: &str, _: u16, _: &str) -> hyper::Result<MockStream> {
+    fn connect(&self, _: &str, _: u16, _: &str) -> hyper::Result<MockStream> {
         Ok(MockStream::new())
     }
 
@@ -93,7 +93,7 @@ fn bench_mock_hyper(b: &mut test::Bencher) {
     let url = "http://127.0.0.1:1337/";
     b.iter(|| {
         let mut req = hyper::client::Request::with_connector(
-            hyper::Get, hyper::Url::parse(url).unwrap(), &mut MockConnector
+            hyper::Get, hyper::Url::parse(url).unwrap(), &MockConnector
         ).unwrap();
         req.headers_mut().set(Foo);
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -140,7 +140,7 @@ struct ConnAdapter<C: NetworkConnector + Send>(C);
 impl<C: NetworkConnector<Stream=S> + Send, S: NetworkStream + Send> NetworkConnector for ConnAdapter<C> {
     type Stream = Box<NetworkStream + Send>;
     #[inline]
-    fn connect(&mut self, host: &str, port: u16, scheme: &str)
+    fn connect(&self, host: &str, port: u16, scheme: &str)
         -> ::Result<Box<NetworkStream + Send>> {
         Ok(try!(self.0.connect(host, port, scheme)).into())
     }
@@ -155,7 +155,7 @@ struct Connector(Box<NetworkConnector<Stream=Box<NetworkStream + Send>> + Send>)
 impl NetworkConnector for Connector {
     type Stream = Box<NetworkStream + Send>;
     #[inline]
-    fn connect(&mut self, host: &str, port: u16, scheme: &str)
+    fn connect(&self, host: &str, port: u16, scheme: &str)
         -> ::Result<Box<NetworkStream + Send>> {
         Ok(try!(self.0.connect(host, port, scheme)).into())
     }
@@ -170,7 +170,7 @@ impl NetworkConnector for Connector {
 /// One of these will be built for you if you use one of the convenience
 /// methods, such as `get()`, `post()`, etc.
 pub struct RequestBuilder<'a, U: IntoUrl> {
-    client: &'a mut Client,
+    client: &'a Client,
     url: U,
     headers: Option<Headers>,
     method: Method,
@@ -225,7 +225,7 @@ impl<'a, U: IntoUrl> RequestBuilder<'a, U> {
         };
 
         loop {
-            let mut req = try!(Request::with_connector(method.clone(), url.clone(), &mut client.connector));
+            let mut req = try!(Request::with_connector(method.clone(), url.clone(), &client.connector));
             headers.as_ref().map(|headers| req.headers_mut().extend(headers.iter()));
 
             match (can_have_body, body.as_ref()) {

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -98,7 +98,7 @@ impl<S> PoolImpl<S> {
 
 impl<C: NetworkConnector<Stream=S>, S: NetworkStream + Send> NetworkConnector for Pool<C> {
     type Stream = PooledStream<S>;
-    fn connect(&mut self, host: &str, port: u16, scheme: &str) -> ::Result<PooledStream<S>> {
+    fn connect(&self, host: &str, port: u16, scheme: &str) -> ::Result<PooledStream<S>> {
         let key = key(host, port, scheme);
         let mut locked = self.inner.lock().unwrap();
         let mut should_remove = false;
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_connect_and_drop() {
-        let mut pool = mocked!();
+        let pool = mocked!();
         let key = key("127.0.0.1", 3000, "http");
         pool.connect("127.0.0.1", 3000, "http").unwrap().is_drained = true;
         {
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn test_closed() {
-        let mut pool = mocked!();
+        let pool = mocked!();
         let mut stream = pool.connect("127.0.0.1", 3000, "http").unwrap();
         stream.close(Shutdown::Both).unwrap();
         drop(stream);

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -47,7 +47,7 @@ impl Request<Fresh> {
     }
 
     /// Create a new client request with a specific underlying NetworkStream.
-    pub fn with_connector<C, S>(method: method::Method, url: Url, connector: &mut C)
+    pub fn with_connector<C, S>(method: method::Method, url: Url, connector: &C)
         -> ::Result<Request<Fresh>> where
         C: NetworkConnector<Stream=S>,
         S: Into<Box<NetworkStream + Send>> {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -74,7 +74,7 @@ pub struct MockConnector;
 impl NetworkConnector for MockConnector {
     type Stream = MockStream;
 
-    fn connect(&mut self, _host: &str, _port: u16, _scheme: &str) -> ::Result<MockStream> {
+    fn connect(&self, _host: &str, _port: u16, _scheme: &str) -> ::Result<MockStream> {
         Ok(MockStream::new())
     }
 
@@ -122,7 +122,7 @@ macro_rules! mock_connector (
 
         impl ::net::NetworkConnector for $name {
             type Stream = ::mock::MockStream;
-            fn connect(&mut self, host: &str, port: u16, scheme: &str) -> $crate::Result<::mock::MockStream> {
+            fn connect(&self, host: &str, port: u16, scheme: &str) -> $crate::Result<::mock::MockStream> {
                 use std::collections::HashMap;
                 use std::io::Cursor;
                 debug!("MockStream::connect({:?}, {:?}, {:?})", host, port, scheme);


### PR DESCRIPTION
BREAKING CHANGE: Any custom Connectors will need to change to &self in
  the connect method. Any Connectors that needed the mutablity need to
  figure out a synchronization strategy.

  Request::with_connector() takes a &NetworkConnector instead of &mut.
  Any uses of with_connector will need to change to passing &C.