### PR TITLE
fix(client): keep the underlying connector when setting an SSL verifier

### DIFF
--- a/benches/client.rs
+++ b/benches/client.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use std::io::{self, Read, Write, Cursor};
 use std::net::SocketAddr;
 
-use hyper::net;
+use hyper::net::{self, ContextVerifier};
 
 static README: &'static [u8] = include_bytes!("../README.md");
 
@@ -83,6 +83,9 @@ impl net::NetworkConnector for MockConnector {
         Ok(MockStream::new())
     }
 
+    fn set_ssl_verifier(&mut self, _verifier: ContextVerifier) {
+        // pass
+    }
 }
 
 #[bench]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -147,6 +147,10 @@ impl<C: NetworkConnector<Stream=S> + Send, S: NetworkStream + Send> NetworkConne
         -> ::Result<Box<NetworkStream + Send>> {
         Ok(try!(self.0.connect(host, port, scheme)).into())
     }
+    #[inline]
+    fn set_ssl_verifier(&mut self, verifier: ContextVerifier) {
+        self.0.set_ssl_verifier(verifier);
+    }
 }
 
 struct Connector(Box<NetworkConnector<Stream=Box<NetworkStream + Send>> + Send>);
@@ -157,6 +161,10 @@ impl NetworkConnector for Connector {
     fn connect(&mut self, host: &str, port: u16, scheme: &str)
         -> ::Result<Box<NetworkStream + Send>> {
         Ok(try!(self.0.connect(host, port, scheme)).into())
+    }
+    #[inline]
+    fn set_ssl_verifier(&mut self, verifier: ContextVerifier) {
+        self.0.set_ssl_verifier(verifier);
     }
 }
 


### PR DESCRIPTION
The client no longer drops the old `Connector` instance, along with its
entire context (such as the settings and pooled connections in the case
of a `Pool` connector); rather, it passes the SSL verifier on to the
`Connector` so that it uses it for any future connections that it needs
to establish.
    
A regression test is included.
    
Closes #495
