### PR TITLE
fix(client): dont call close() inside Request

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -7,6 +7,8 @@ use std::env;
 use std::io;
 
 use hyper::Client;
+use hyper::header::Connection;
+use hyper::header::ConnectionOption::Close;
 
 fn main() {
     env_logger::init().unwrap();
@@ -21,10 +23,9 @@ fn main() {
 
     let mut client = Client::new();
 
-    let mut res = match client.get(&*url).send() {
-        Ok(res) => res,
-        Err(err) => panic!("Failed to connect: {:?}", err)
-    };
+    let mut res = client.get(&*url)
+        .header(Connection(vec![Close]))
+        .send().unwrap();
 
     println!("Response: {}", res.status);
     println!("Headers:\n{}", res.headers);

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -1,7 +1,6 @@
 //! Client Requests
 use std::marker::PhantomData;
 use std::io::{self, Write, BufWriter};
-use std::net::Shutdown;
 
 use url::Url;
 
@@ -9,7 +8,7 @@ use method::{self, Method};
 use header::Headers;
 use header::{self, Host};
 use net::{NetworkStream, NetworkConnector, HttpConnector, Fresh, Streaming};
-use http::{self, HttpWriter, LINE_ENDING};
+use http::{HttpWriter, LINE_ENDING};
 use http::HttpWriter::{ThroughWriter, ChunkedWriter, SizedWriter, EmptyWriter};
 use version;
 use client::{Response, get_host_and_port};
@@ -154,10 +153,7 @@ impl Request<Streaming> {
     ///
     /// Consumes the Request.
     pub fn send(self) -> ::Result<Response> {
-        let mut raw = try!(self.body.end()).into_inner().unwrap(); // end() already flushes
-        if !http::should_keep_alive(self.version, &self.headers) {
-            try!(raw.close(Shutdown::Write));
-        }
+        let raw = try!(self.body.end()).into_inner().unwrap(); // end() already flushes
         Response::new(raw)
     }
 }


### PR DESCRIPTION
Only call close() in the Response, which should already return a
responding `Connection: close`.

Closes #519