### PR TITLE
Rename tm! to __hyper__tm!, and export it, and rename deref!

### DIFF
--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -23,7 +23,7 @@ use header::parsing::{from_one_comma_delimited, fmt_comma_delimited};
 #[derive(PartialEq, Clone, Debug)]
 pub struct CacheControl(pub Vec<CacheDirective>);
 
-deref!(CacheControl => Vec<CacheDirective>);
+__hyper__deref!(CacheControl => Vec<CacheDirective>);
 
 impl Header for CacheControl {
     fn header_name() -> &'static str {

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -20,7 +20,7 @@ use cookie::CookieJar;
 #[derive(Clone, PartialEq, Debug)]
 pub struct Cookie(pub Vec<CookiePair>);
 
-deref!(Cookie => Vec<CookiePair>);
+__hyper__deref!(Cookie => Vec<CookiePair>);
 
 impl Header for Cookie {
     fn header_name() -> &'static str {

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -80,7 +80,7 @@ macro_rules! bench_header(
 );
 
 #[macro_export]
-macro_rules! deref(
+macro_rules! __hyper__deref {
     ($from:ty => $to:ty) => {
         impl ::std::ops::Deref for $from {
             type Target = $to;
@@ -96,7 +96,7 @@ macro_rules! deref(
             }
         }
     }
-);
+}
 
 #[macro_export]
 macro_rules! __hyper__tm {
@@ -166,7 +166,7 @@ macro_rules! header {
         $(#[$a])*
         #[derive(Clone, Debug, PartialEq)]
         pub struct $id(pub Vec<$item>);
-        deref!($id => Vec<$item>);
+        __hyper__deref!($id => Vec<$item>);
         impl $crate::header::Header for $id {
             fn header_name() -> &'static str {
                 $n
@@ -192,7 +192,7 @@ macro_rules! header {
         $(#[$a])*
         #[derive(Clone, Debug, PartialEq)]
         pub struct $id(pub Vec<$item>);
-        deref!($id => Vec<$item>);
+        __hyper__deref!($id => Vec<$item>);
         impl $crate::header::Header for $id {
             fn header_name() -> &'static str {
                 $n
@@ -218,7 +218,7 @@ macro_rules! header {
         $(#[$a])*
         #[derive(Clone, Debug, PartialEq)]
         pub struct $id(pub $value);
-        deref!($id => $value);
+        __hyper__deref!($id => $value);
         impl $crate::header::Header for $id {
             fn header_name() -> &'static str {
                 $n

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -98,7 +98,8 @@ macro_rules! deref(
     }
 );
 
-macro_rules! tm {
+#[macro_export]
+macro_rules! __hyper__tm {
     ($id:ident, $tm:ident{$($tf:item)*}) => {
         #[allow(unused_imports)]
         mod $tm{
@@ -285,7 +286,7 @@ macro_rules! header {
             ($id, $n) => ($item)*
         }
 
-        tm! { $id, $tm { $($tf)* }}
+        __hyper__tm! { $id, $tm { $($tf)* }}
     };
     ($(#[$a:meta])*($id:ident, $n:expr) => ($item:ty)+ $tm:ident{$($tf:item)*}) => {
         header! {
@@ -293,7 +294,7 @@ macro_rules! header {
             ($id, $n) => ($item)+
         }
 
-        tm! { $id, $tm { $($tf)* }}
+        __hyper__tm! { $id, $tm { $($tf)* }}
     };
     ($(#[$a:meta])*($id:ident, $n:expr) => [$item:ty] $tm:ident{$($tf:item)*}) => {
         header! {
@@ -301,7 +302,7 @@ macro_rules! header {
             ($id, $n) => [$item]
         }
 
-        tm! { $id, $tm { $($tf)* }}
+        __hyper__tm! { $id, $tm { $($tf)* }}
     };
     ($(#[$a:meta])*($id:ident, $n:expr) => {Any / ($item:ty)+} $tm:ident{$($tf:item)*}) => {
         header! {
@@ -309,7 +310,7 @@ macro_rules! header {
             ($id, $n) => {Any / ($item)+}
         }
 
-        tm! { $id, $tm { $($tf)* }}
+        __hyper__tm! { $id, $tm { $($tf)* }}
     };
 }
 

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -57,7 +57,7 @@ use cookie::CookieJar;
 #[derive(Clone, PartialEq, Debug)]
 pub struct SetCookie(pub Vec<Cookie>);
 
-deref!(SetCookie => Vec<Cookie>);
+__hyper__deref!(SetCookie => Vec<Cookie>);
 
 impl Header for SetCookie {
     fn header_name() -> &'static str {


### PR DESCRIPTION
The `deref!` macro is largely for internal use, however, it must be exported
because the header! macro uses it. As deref! is also a particularly
general name, this renames it to __hyper__deref! to prevent name
clashes.