### PR TITLE
chore(cargo): set stricter versions for dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,18 @@ authors = ["Sean McArthur <sean.monstar@gmail.com>",
 keywords = ["http", "hyper", "hyperium"]
 
 [dependencies]
-cookie = "*"
-httparse = "*"
-log = ">= 0.2.0"
-mime = "*"
-num_cpus = "*"
-openssl = "*"
-rustc-serialize = "*"
-time = "*"
-unicase = "*"
-url = "*"
-traitobject = "*"
-typeable = "*"
+cookie = "0.1"
+httparse = "0.1"
+log = "0.3"
+mime = "0.0.11"
+num_cpus = "0.2"
+openssl = "0.6"
+rustc-serialize = "0.3"
+time = "0.1"
+unicase = "0.1"
+url = "0.2"
+traitobject = "0.0.1"
+typeable = "0.1"
 
 [dev-dependencies]
 env_logger = "*"


### PR DESCRIPTION
Coming into Rust 1.0, I hope crates will behave well (semver) when making breaking changes. So, we should be stricter about what versions we know work, instead of just telling users "Set DepA's version to 0.X in your Cargo.lock to fix that".

Bumping versions dependencies is easy, and can save people headaches.