### PR TITLE
TcpStream of CloneTcpStream should be public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+/.project

--- a/src/net.rs
+++ b/src/net.rs
@@ -212,7 +212,7 @@ impl NetworkListener for HttpListener {
 }
 
 #[doc(hidden)]
-pub struct CloneTcpStream(TcpStream);
+pub struct CloneTcpStream(pub TcpStream);
 
 impl Clone for CloneTcpStream{
     #[inline]


### PR DESCRIPTION
For the sake of extension, I made TcpStream of CloneTcpStream public.