### PR TITLE
feat(headers): return hyper::Error instead of () from header components

### DIFF
--- a/src/header/shared/charset.rs
+++ b/src/header/shared/charset.rs
@@ -103,8 +103,8 @@ impl Display for Charset {
 }
 
 impl FromStr for Charset {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Charset, ()> {
+    type Err = ::Error;
+    fn from_str(s: &str) -> ::Result<Charset> {
         Ok(match s.to_ascii_uppercase().as_ref() {
             "US-ASCII" => Us_Ascii,
             "ISO-8859-1" => Iso_8859_1,

--- a/src/header/shared/encoding.rs
+++ b/src/header/shared/encoding.rs
@@ -1,5 +1,3 @@
-//! Provides an Encoding enum.
-
 use std::fmt;
 use std::str;
 
@@ -37,8 +35,8 @@ impl fmt::Display for Encoding {
 }
 
 impl str::FromStr for Encoding {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Encoding, ()> {
+    type Err = ::Error;
+    fn from_str(s: &str) -> ::Result<Encoding> {
         match s {
             "chunked" => Ok(Chunked),
             "deflate" => Ok(Deflate),

--- a/src/header/shared/entity.rs
+++ b/src/header/shared/entity.rs
@@ -107,13 +107,13 @@ impl Display for EntityTag {
 }
 
 impl FromStr for EntityTag {
-    type Err = ();
-    fn from_str(s: &str) -> Result<EntityTag, ()> {
+    type Err = ::Error;
+    fn from_str(s: &str) -> ::Result<EntityTag> {
         let length: usize = s.len();
         let slice = &s[..];
         // Early exits if it doesn't terminate in a DQUOTE.
         if !slice.ends_with('"') {
-            return Err(());
+            return Err(::Error::Header);
         }
         // The etag is weak if its first char is not a DQUOTE.
         if slice.starts_with('"') && check_slice_validity(&slice[1..length-1]) {
@@ -123,7 +123,7 @@ impl FromStr for EntityTag {
         } else if slice.starts_with("W/\"") && check_slice_validity(&slice[3..length-1]) {
             return Ok(EntityTag { weak: true, tag: slice[3..length-1].to_owned() });
         }
-        Err(())
+        Err(::Error::Header)
     }
 }
 
@@ -144,12 +144,12 @@ mod tests {
     #[test]
     fn test_etag_parse_failures() {
         // Expected failures
-        assert_eq!("no-dquotes".parse::<EntityTag>(), Err(()));
-        assert_eq!("w/\"the-first-w-is-case-sensitive\"".parse::<EntityTag>(), Err(()));
-        assert_eq!("".parse::<EntityTag>(), Err(()));
-        assert_eq!("\"unmatched-dquotes1".parse::<EntityTag>(), Err(()));
-        assert_eq!("unmatched-dquotes2\"".parse::<EntityTag>(), Err(()));
-        assert_eq!("matched-\"dquotes\"".parse::<EntityTag>(), Err(()));
+        assert!("no-dquotes".parse::<EntityTag>().is_err());
+        assert!("w/\"the-first-w-is-case-sensitive\"".parse::<EntityTag>().is_err());
+        assert!("".parse::<EntityTag>().is_err());
+        assert!("\"unmatched-dquotes1".parse::<EntityTag>().is_err());
+        assert!("unmatched-dquotes2\"".parse::<EntityTag>().is_err());
+        assert!("matched-\"dquotes\"".parse::<EntityTag>().is_err());
     }
 
     #[test]

--- a/src/header/shared/httpdate.rs
+++ b/src/header/shared/httpdate.rs
@@ -31,15 +31,15 @@ use time;
 pub struct HttpDate(pub time::Tm);
 
 impl FromStr for HttpDate {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, ()> {
+    type Err = ::Error;
+    fn from_str(s: &str) -> ::Result<HttpDate> {
         match time::strptime(s, "%a, %d %b %Y %T %Z").or_else(|_| {
             time::strptime(s, "%A, %d-%b-%y %T %Z")
             }).or_else(|_| {
                 time::strptime(s, "%c")
                 }) {
                     Ok(t) => Ok(HttpDate(t)),
-                    Err(_) => Err(()),
+                    Err(_) => Err(::Error::Header),
                     }
     }
 }
@@ -71,21 +71,21 @@ mod tests {
 
     #[test]
     fn test_imf_fixdate() {
-        assert_eq!("Sun, 07 Nov 1994 08:48:37 GMT".parse(), Ok(NOV_07));
+        assert_eq!("Sun, 07 Nov 1994 08:48:37 GMT".parse::<HttpDate>().unwrap(), NOV_07);
     }
 
     #[test]
     fn test_rfc_850() {
-        assert_eq!("Sunday, 07-Nov-94 08:48:37 GMT".parse(), Ok(NOV_07));
+        assert_eq!("Sunday, 07-Nov-94 08:48:37 GMT".parse::<HttpDate>().unwrap(), NOV_07);
     }
 
     #[test]
     fn test_asctime() {
-        assert_eq!("Sun Nov  7 08:48:37 1994".parse(), Ok(NOV_07));
+        assert_eq!("Sun Nov  7 08:48:37 1994".parse::<HttpDate>().unwrap(), NOV_07);
     }
 
     #[test]
     fn test_no_date() {
-        assert_eq!("this-is-no-date".parse(), Err::<HttpDate, ()>(()));
+        assert!("this-is-no-date".parse::<HttpDate>().is_err());
     }
 }

--- a/src/header/shared/language.rs
+++ b/src/header/shared/language.rs
@@ -15,8 +15,8 @@ pub struct Language {
 }
 
 impl FromStr for Language {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Language, ()> {
+    type Err = ::Error;
+    fn from_str(s: &str) -> ::Result<Language> {
         let mut i = s.split("-");
         let p = i.next();
         let s = i.next();
@@ -29,7 +29,7 @@ impl FromStr for Language {
                 primary: p.to_owned(),
                 sub: None
                 }),
-            _ => Err(())
+            _ => Err(::Error::Header)
         }
     }
 }


### PR DESCRIPTION
This allows more precise errors in the future and makes it easier to use
the try!() macro in some cases.

BREAKING CHANGE: Error enum extended. Return type of header/shared/
types changed.