### PR TITLE
feat(ssl): make OpenSSL an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,10 @@ authors = ["Sean McArthur <sean.monstar@gmail.com>",
 keywords = ["http", "hyper", "hyperium"]
 
 [dependencies]
-cookie = "0.1"
 httparse = "0.1"
 log = "0.3"
 mime = "0.0.11"
 num_cpus = "0.2"
-openssl = "0.6"
 rustc-serialize = "0.3"
 time = "0.1"
 unicase = "0.1"
@@ -29,4 +27,17 @@ typeable = "0.1"
 env_logger = "*"
 
 [features]
+default = ["ssl"]
+# These are grouped together b/c it doesn't really make sense to
+# enable one w/o the other
+ssl = ["openssl", "cookie"]
 nightly = []
+
+
+[dependencies.cookie]
+version = "0.1"
+optional = true
+
+[dependencies.openssl]
+version = "0.6"
+optional = true

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -41,7 +41,9 @@ use url::ParseError as UrlError;
 use header::{Headers, Header, HeaderFormat};
 use header::{ContentLength, Location};
 use method::Method;
-use net::{NetworkConnector, NetworkStream, ContextVerifier};
+use net::{NetworkConnector, NetworkStream};
+#[cfg(feature = "openssl")]
+use net::ContextVerifier;
 use status::StatusClass::Redirection;
 use {Url};
 use Error;
@@ -84,6 +86,7 @@ impl Client {
     }
 
     /// Set the SSL verifier callback for use with OpenSSL.
+    #[cfg(feature = "openssl")]
     pub fn set_ssl_verifier(&mut self, verifier: ContextVerifier) {
         self.connector.set_ssl_verifier(verifier);
     }
@@ -149,6 +152,7 @@ impl<C: NetworkConnector<Stream=S> + Send, S: NetworkStream + Send> NetworkConne
         Ok(try!(self.0.connect(host, port, scheme)).into())
     }
     #[inline]
+    #[cfg(feature = "openssl")]
     fn set_ssl_verifier(&mut self, verifier: ContextVerifier) {
         self.0.set_ssl_verifier(verifier);
     }
@@ -164,6 +168,7 @@ impl NetworkConnector for Connector {
         Ok(try!(self.0.connect(host, port, scheme)).into())
     }
     #[inline]
+    #[cfg(feature = "openssl")]
     fn set_ssl_verifier(&mut self, verifier: ContextVerifier) {
         self.0.set_ssl_verifier(verifier);
     }

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -5,7 +5,9 @@ use std::io::{self, Read, Write};
 use std::net::{SocketAddr, Shutdown};
 use std::sync::{Arc, Mutex};
 
-use net::{NetworkConnector, NetworkStream, HttpConnector, ContextVerifier};
+use net::{NetworkConnector, NetworkStream, HttpConnector};
+#[cfg(feature = "openssl")]
+use net::ContextVerifier;
 
 /// The `NetworkConnector` that behaves as a connection pool used by hyper's `Client`.
 pub struct Pool<C: NetworkConnector> {
@@ -121,6 +123,7 @@ impl<C: NetworkConnector<Stream=S>, S: NetworkStream + Send> NetworkConnector fo
         })
     }
     #[inline]
+    #[cfg(feature = "openssl")]
     fn set_ssl_verifier(&mut self, verifier: ContextVerifier) {
         self.connector.set_ssl_verifier(verifier);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,19 +4,11 @@ use std::fmt;
 use std::io::Error as IoError;
 
 use httparse;
+#[cfg(feature = "openssl")]
 use openssl::ssl::error::SslError;
 use url;
 
-use self::Error::{
-    Method,
-    Uri,
-    Version,
-    Header,
-    Status,
-    Io,
-    Ssl,
-    TooLarge
-};
+use self::Error::*;
 
 
 /// Result type often returned from methods that can have hyper `Error`s.
@@ -40,6 +32,7 @@ pub enum Error {
     /// An `io::Error` that occurred while trying to read or write to a network stream.
     Io(IoError),
     /// An error from the `openssl` library.
+    #[cfg(feature = "openssl")]
     Ssl(SslError)
 }
 
@@ -59,6 +52,7 @@ impl StdError for Error {
             Status => "Invalid Status provided",
             Uri(ref e) => e.description(),
             Io(ref e) => e.description(),
+            #[cfg(feature = "openssl")]
             Ssl(ref e) => e.description(),
         }
     }
@@ -66,6 +60,7 @@ impl StdError for Error {
     fn cause(&self) -> Option<&StdError> {
         match *self {
             Io(ref error) => Some(error),
+            #[cfg(feature = "openssl")]
             Ssl(ref error) => Some(error),
             Uri(ref error) => Some(error),
             _ => None,
@@ -85,6 +80,7 @@ impl From<url::ParseError> for Error {
     }
 }
 
+#[cfg(feature = "openssl")]
 impl From<SslError> for Error {
     fn from(err: SslError) -> Error {
         match err {

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -25,6 +25,7 @@ pub use self::content_length::ContentLength;
 pub use self::content_encoding::ContentEncoding;
 pub use self::content_language::ContentLanguage;
 pub use self::content_type::ContentType;
+#[cfg(feature = "cookie")]
 pub use self::cookie::Cookie;
 pub use self::date::Date;
 pub use self::etag::ETag;
@@ -42,6 +43,7 @@ pub use self::location::Location;
 pub use self::pragma::Pragma;
 pub use self::referer::Referer;
 pub use self::server::Server;
+#[cfg(feature = "cookie")]
 pub use self::set_cookie::SetCookie;
 pub use self::transfer_encoding::TransferEncoding;
 pub use self::upgrade::{Upgrade, Protocol, ProtocolName};
@@ -329,6 +331,7 @@ mod accept_ranges;
 mod allow;
 mod authorization;
 mod cache_control;
+#[cfg(feature = "cookie")]
 mod cookie;
 mod connection;
 mod content_encoding;
@@ -351,6 +354,7 @@ mod location;
 mod pragma;
 mod referer;
 mod server;
+#[cfg(feature = "cookie")]
 mod set_cookie;
 mod transfer_encoding;
 mod upgrade;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,9 @@
 extern crate rustc_serialize as serialize;
 extern crate time;
 extern crate url;
+#[cfg(feature = "openssl")]
 extern crate openssl;
+#[cfg(feature = "cookie")]
 extern crate cookie;
 extern crate unicase;
 extern crate httparse;


### PR DESCRIPTION
Compiling with default_features=false will now omit SSL support.

This introduces a ton of `cfg` annotations, but I don't know how to avoid them :(. It's quite ugly, but it seems to work.

BTW, I hope I got the title format correct.

Fixes #541 