### PR TITLE
fix(buffer): check capacity before resizing

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -67,7 +67,7 @@ impl<R: Read> BufReader<R> {
     #[inline]
     fn maybe_reserve(&mut self) {
         let cap = self.buf.capacity();
-        if self.cap == cap {
+        if self.cap == cap && cap < MAX_BUFFER_SIZE {
             self.buf.reserve(cmp::min(cap * 4, MAX_BUFFER_SIZE) - cap);
             let new = self.buf.capacity() - self.buf.len();
             trace!("reserved {}", new);


### PR DESCRIPTION
``cmp::min(cap * 4, MAX_BUFFER_SIZE) - cap'' can underflow when
cap > MAX_BUFFER_SIZE.  cap can exceed MAX_BUFFER_SIZE because
Vec::reserve aligns to powers of two.

Discovered by Matt Howard <themdhoward@gmail.com>

You can trigger this bug by requesting from the "server" implemented here:
perl -e'print "HTTP/1.1 200 OK\r\nServer: " . " "x900000000 . "\r\n"' | nc -l -p 8080

Regards,
Stacey Ell
