### PR TITLE
Add a license badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # hyper
 
 [![Build Status](https://travis-ci.org/hyperium/hyper.svg?branch=master)](https://travis-ci.org/hyperium/hyper)
-[![crates.io](http://meritbadge.herokuapp.com/hyper)](https://crates.io/crates/hyper)
 [![Coverage Status](https://coveralls.io/repos/hyperium/hyper/badge.svg?branch=master)](https://coveralls.io/r/hyperium/hyper?branch=master)
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+[![crates.io](http://meritbadge.herokuapp.com/hyper)](https://crates.io/crates/hyper)
 
 A Modern HTTP library for Rust.
 
@@ -72,8 +73,3 @@ fn main() {
     println!("Response: {}", body);
 }
 ```
-
-## License
-
-[MIT](./LICENSE)
-


### PR DESCRIPTION
Also, move the crates.io badge beyond the license badge to optimize the badge 
row's utility as a status dashboard as discussed in #525.