### PR TITLE
feat(client): impl Sync for Client

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -20,7 +20,7 @@ fn main() {
         }
     };
 
-    let mut client = Client::new();
+    let client = Client::new();
 
     let mut res = client.get(&*url)
         .header(Connection::close())

--- a/examples/client_http2.rs
+++ b/examples/client_http2.rs
@@ -21,7 +21,7 @@ fn main() {
         }
     };
 
-    let mut client = Client::with_protocol(h2::new_protocol());
+    let client = Client::with_protocol(h2::new_protocol());
 
     // `Connection: Close` is not a valid header for HTTP/2, but the client handles it gracefully.
     let mut res = client.get(&*url)

--- a/src/http/h1.rs
+++ b/src/http/h1.rs
@@ -275,7 +275,7 @@ impl Http11Protocol {
     /// Creates a new `Http11Protocol` instance that will use the given `NetworkConnector` for
     /// establishing HTTP connections.
     pub fn with_connector<C, S>(c: C) -> Http11Protocol
-            where C: NetworkConnector<Stream=S> + Send + 'static,
+            where C: NetworkConnector<Stream=S> + Send + Sync + 'static,
                   S: NetworkStream + Send {
         Http11Protocol {
             connector: Connector(Box::new(ConnAdapter(c))),
@@ -283,9 +283,9 @@ impl Http11Protocol {
     }
 }
 
-struct ConnAdapter<C: NetworkConnector + Send>(C);
+struct ConnAdapter<C: NetworkConnector + Send + Sync>(C);
 
-impl<C: NetworkConnector<Stream=S> + Send, S: NetworkStream + Send> NetworkConnector for ConnAdapter<C> {
+impl<C: NetworkConnector<Stream=S> + Send + Sync, S: NetworkStream + Send> NetworkConnector for ConnAdapter<C> {
     type Stream = Box<NetworkStream + Send>;
     #[inline]
     fn connect(&self, host: &str, port: u16, scheme: &str)
@@ -298,7 +298,7 @@ impl<C: NetworkConnector<Stream=S> + Send, S: NetworkStream + Send> NetworkConne
     }
 }
 
-struct Connector(Box<NetworkConnector<Stream=Box<NetworkStream + Send>> + Send>);
+struct Connector(Box<NetworkConnector<Stream=Box<NetworkStream + Send>> + Send + Sync>);
 
 impl NetworkConnector for Connector {
     type Stream = Box<NetworkStream + Send>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,3 +198,8 @@ fn _assert_send<T: Send>() {
     _assert_send::<client::Request<net::Fresh>>();
     _assert_send::<client::Response>();
 }
+
+#[allow(unconditional_recursion)]
+fn _assert_sync<T: Sync>() {
+    _assert_sync::<Client>();
+}

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -144,12 +144,12 @@ impl NetworkConnector for MockConnector {
 ///
 /// Otherwise, it behaves the same as `MockConnector`.
 pub struct ChannelMockConnector {
-    calls: Sender<String>,
+    calls: Mutex<Sender<String>>,
 }
 
 impl ChannelMockConnector {
     pub fn new(calls: Sender<String>) -> ChannelMockConnector {
-        ChannelMockConnector { calls: calls }
+        ChannelMockConnector { calls: Mutex::new(calls) }
     }
 }
 
@@ -158,13 +158,13 @@ impl NetworkConnector for ChannelMockConnector {
     #[inline]
     fn connect(&self, _host: &str, _port: u16, _scheme: &str)
             -> ::Result<MockStream> {
-        self.calls.send("connect".into()).unwrap();
+        self.calls.lock().unwrap().send("connect".into()).unwrap();
         Ok(MockStream::new())
     }
 
     #[inline]
     fn set_ssl_verifier(&mut self, _verifier: ContextVerifier) {
-        self.calls.send("set_ssl_verifier".into()).unwrap();
+        self.calls.lock().unwrap().send("set_ssl_verifier".into()).unwrap();
     }
 }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -317,7 +317,7 @@ impl NetworkStream for HttpStream {
 pub struct HttpConnector(pub Option<ContextVerifier>);
 
 /// A method that can set verification methods on an SSL context
-pub type ContextVerifier = Box<Fn(&mut SslContext) -> () + Send>;
+pub type ContextVerifier = Box<Fn(&mut SslContext) -> () + Send + Sync>;
 
 impl NetworkConnector for HttpConnector {
     type Stream = HttpStream;


### PR DESCRIPTION
Connector::connect already used &self, and so would require
synchronization to be handled per connector anyway. Adding Sync to the
Client allows users to setup config for a Client once, such as using a
single connection Pool, and then making requests across multiple
threads.

Closes #254

BREAKING CHANGE: Connectors and Protocols passed to the `Client` must
  now also have a `Sync` bounds, but this shouldn't break default usage.