### PR TITLE
feat(headers): add bearer token support

### DIFF
--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -18,7 +18,7 @@ pub use self::accept_encoding::AcceptEncoding;
 pub use self::accept_language::AcceptLanguage;
 pub use self::accept_ranges::{AcceptRanges, RangeUnit};
 pub use self::allow::Allow;
-pub use self::authorization::{Authorization, Scheme, Basic};
+pub use self::authorization::{Authorization, Scheme, Basic, Bearer};
 pub use self::cache_control::{CacheControl, CacheDirective};
 pub use self::connection::{Connection, ConnectionOption};
 pub use self::content_length::ContentLength;


### PR DESCRIPTION
this allows servers/clients using bearer tokens
 to work out of the box without having to implement
  their own bearer scheme. while this would be pretty
   easy seems like a more general thing that is useful
    for a lib like this