### PR TITLE
docs(hyper): fix html root url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://hyperium.github.io/hyper/hyper/index.html")]
+#![doc(html_root_url = "https://hyperium.github.io/hyper/")]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]


### PR DESCRIPTION
The HTML root URL is not supposed to point at the index resource, but
represent the path that can be used to construct the full URL of the
crate's components.