### PR TITLE
refactor(headers):  improve `Range` header adherence to HTTP spec

### DIFF
--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -40,7 +40,7 @@ pub use self::if_range::IfRange;
 pub use self::last_modified::LastModified;
 pub use self::location::Location;
 pub use self::pragma::Pragma;
-pub use self::range::{Range, RangeSpec};
+pub use self::range::{Range, ByteRangeSpec};
 pub use self::referer::Referer;
 pub use self::server::Server;
 pub use self::set_cookie::SetCookie;


### PR DESCRIPTION
I've started working on `Content-Range` header and realized that my previous implementation of `Range` header was wrong. `RangeSpecs` make sense only for byte ranges and all custom range units can have arbitrary strings as their values.

I've modified the code to reflect that, but there is one thing for which I need your feedback:
I've used `Range::Other` for custom ranges, as it IMO matches more closely naming in the RFC (`other-ranges-specifier`). The thing is that `Accept-Ranges` header uses `RangeUnit::Unregistered` for the same purpose, so it would make sense to decide on one them and use it consistently.

This is kinda a breaking change. However since the `Range` header was introduced only a week ago, I'm not sure, if I should mark it as such.