### PR TITLE
fix(benches): adjust to missing `set_ssl_verifier`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ cache:
 script:
   - cargo build --verbose $FEATURES
   - cargo test --verbose $FEATURES
+  - '[ $TRAVIS_RUST_VERSION = nightly ] && cargo bench --no-run || :'
 
 addons:
   apt:

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -1,5 +1,5 @@
 #![deny(warnings)]
-#![feature(collections, test)]
+#![feature(vec_push_all, test)]
 extern crate hyper;
 
 extern crate test;
@@ -8,7 +8,7 @@ use std::fmt;
 use std::io::{self, Read, Write, Cursor};
 use std::net::SocketAddr;
 
-use hyper::net::{self, ContextVerifier};
+use hyper::net;
 
 static README: &'static [u8] = include_bytes!("../README.md");
 
@@ -81,10 +81,6 @@ impl net::NetworkConnector for MockConnector {
     type Stream = MockStream;
     fn connect(&self, _: &str, _: u16, _: &str) -> hyper::Result<MockStream> {
         Ok(MockStream::new())
-    }
-
-    fn set_ssl_verifier(&mut self, _verifier: ContextVerifier) {
-        // pass
     }
 }
 


### PR DESCRIPTION
In 53bba6e , ssl usage was improved. The existing benchmark
implementation wasn't adjusted though.

This commit fixes the client benchmark to work with the latest nightly
rust and instructs travis to try compile the benchmarks
when rustc nightly is used. This should prevent such kind of breakage
in future.