### PR TITLE
refactor(http2): move to solicit v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ version = "0.6"
 optional = true
 
 [dependencies.solicit]
-version = "0.3"
+version = "0.4"
 default-features = false
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,9 +202,11 @@ fn _assert_send<T: Send>() {
     _assert_send::<Client>();
     _assert_send::<client::Request<net::Fresh>>();
     _assert_send::<client::Response>();
+    _assert_send::<error::Error>();
 }
 
 #[allow(unconditional_recursion)]
 fn _assert_sync<T: Sync>() {
     _assert_sync::<Client>();
+    _assert_sync::<error::Error>();
 }


### PR DESCRIPTION
This PR moves hyper to use the latest version of solicit, where a few new features were. Only a few minor changes to the internals of the `h2` module were required.

Includes a regression test making sure that `error::Error` remains `Send + Sync`.

Closes #580 