### PR TITLE
fix(cargo): fix linking on OSX 10.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,5 +41,5 @@ env_logger = "*"
 
 [features]
 default = ["ssl"]
-ssl = ["openssl", "cookie/secure", "solicit/openssl"]
+ssl = ["openssl", "cookie/secure"]
 nightly = []


### PR DESCRIPTION
On OSX 10.10, attempting to run `cargo test` will yield a
[linker error](https://gist.github.com/Byron/b7a50cdcf7c60234335d).

Just removing the feature fixes the issue, even though I am not
sure if it is breaking something further down the line.