### PR TITLE
fix(client): use Ssl instance in creation of SslStream

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -444,7 +444,7 @@ mod openssl {
             //}
             let ssl = try!(Ssl::new(&self.context));
             try!(ssl.set_hostname(host));
-            SslStream::new(&self.context, stream).map_err(From::from)
+            SslStream::new_from(ssl, stream).map_err(From::from)
         }
 
         fn wrap_server(&self, stream: HttpStream) -> ::Result<Self::Stream> {


### PR DESCRIPTION
Hi,

I've been having trouble connecting to some SNI-enabled websites, and noticed that the Ssl instance in wrap_client seems to be thrown away after set_hostname is called.  This commit passes the Ssl instance to SslStream and fixed my issue.

Regards,
Stacey Ell