### PR TITLE
feat(client): add url property Response

### DIFF
--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -110,7 +110,7 @@ impl Request<Streaming> {
     ///
     /// Consumes the Request.
     pub fn send(self) -> ::Result<Response> {
-        Response::with_message(self.message)
+        Response::with_message(self.url, self.message)
     }
 }
 


### PR DESCRIPTION
This will always be the last URL that was used by the Request, which is
useful for determining what the final URL was after redirection.

BREAKING CHANGE: Technically a break, since `Response::new()` takes an
  additional argument. In practice, the only place that should have been
  creating Responses directly is inside the Client, so it shouldn't
  break anyone. If you were creating Responses manually, you'll need to
  pass a Url argument.