### PR TITLE
refactor(headers): use String in Access-Control-Allow-Origin header

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::io::Error as IoError;
 use std::str::Utf8Error;
+use std::string::FromUtf8Error;
 
 use httparse;
 use url;
@@ -124,6 +125,12 @@ impl From<SslError> for Error {
 impl From<Utf8Error> for Error {
     fn from(err: Utf8Error) -> Error {
         Utf8(err)
+    }
+}
+
+impl From<FromUtf8Error> for Error {
+    fn from(err: FromUtf8Error) -> Error {
+        Utf8(err.utf8_error())
     }
 }
 

--- a/src/header/common/access_control_allow_origin.rs
+++ b/src/header/common/access_control_allow_origin.rs
@@ -1,7 +1,5 @@
 use std::fmt::{self, Display};
-use std::str;
 
-use url::Url;
 use header::{Header, HeaderFormat};
 
 /// The `Access-Control-Allow-Origin` response header,
@@ -20,7 +18,7 @@ use header::{Header, HeaderFormat};
 /// * `null`
 /// * `*`
 /// * `http://google.com/`
-/// 
+///
 /// # Examples
 /// ```
 /// use hyper::header::{Headers, AccessControlAllowOrigin};
@@ -40,11 +38,10 @@ use header::{Header, HeaderFormat};
 /// ```
 /// ```
 /// use hyper::header::{Headers, AccessControlAllowOrigin};
-/// use hyper::Url;
 ///
 /// let mut headers = Headers::new();
 /// headers.set(
-///     AccessControlAllowOrigin::Value(Url::parse("http://hyper.rs").unwrap())
+///     AccessControlAllowOrigin::Value("http://hyper.rs".to_owned())
 /// );
 /// ```
 #[derive(Clone, PartialEq, Debug)]
@@ -54,7 +51,7 @@ pub enum AccessControlAllowOrigin {
     /// A hidden origin
     Null,
     /// Allow one particular origin
-    Value(Url),
+    Value(String),
 }
 
 impl Header for AccessControlAllowOrigin {
@@ -63,13 +60,15 @@ impl Header for AccessControlAllowOrigin {
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<AccessControlAllowOrigin> {
-        if raw.len() == 1 {
-            match unsafe { &raw.get_unchecked(0)[..] } {
-                b"*" => Ok(AccessControlAllowOrigin::Any),
-                b"null" => Ok(AccessControlAllowOrigin::Null),
-                r => Ok(AccessControlAllowOrigin::Value(try!(Url::parse(try!(str::from_utf8(r))))))
-            }
-        } else { Err(::Error::Header) }
+        if raw.len() != 1 {
+            return Err(::Error::Header)
+        }
+        let value = unsafe { raw.get_unchecked(0) };
+        Ok(match &value[..] {
+            b"*" => AccessControlAllowOrigin::Any,
+            b"null" => AccessControlAllowOrigin::Null,
+            _ => AccessControlAllowOrigin::Value(try!(String::from_utf8(value.clone())))
+        })
     }
 }
 


### PR DESCRIPTION
Access-Control-Allow-Origin origins are URLs but they do not need to
be valid, they should just be compared as strings. So to support
invalid URLs hyper should use a string instead.

solves #562

BREAKING CHANGE: Access-Control-Allow-Origin does no longer use Url