### PR TITLE
fix(http): no longer keep alive for Http1.0 if no Connection header

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -22,8 +22,25 @@ pub struct RawStatus(pub u16, pub Cow<'static, str>);
 pub fn should_keep_alive(version: HttpVersion, headers: &Headers) -> bool {
     trace!("should_keep_alive( {:?}, {:?} )", version, headers.get::<Connection>());
     match (version, headers.get::<Connection>()) {
+        (Http10, None) => false,
         (Http10, Some(conn)) if !conn.contains(&KeepAlive) => false,
         (Http11, Some(conn)) if conn.contains(&Close)  => false,
         _ => true
     }
+}
+
+#[test]
+fn test_should_keep_alive() {
+    let mut headers = Headers::new();
+
+    assert!(!should_keep_alive(Http10, &headers));
+    assert!(should_keep_alive(Http11, &headers));
+
+    headers.set(Connection::close());
+    assert!(!should_keep_alive(Http10, &headers));
+    assert!(!should_keep_alive(Http11, &headers));
+
+    headers.set(Connection::keep_alive());
+    assert!(should_keep_alive(Http10, &headers));
+    assert!(should_keep_alive(Http11, &headers));
 }


### PR DESCRIPTION
Closes #596