### PR TITLE
Add optional serialization of common types via `serde`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,16 @@ optional = true
 version = "0.4"
 default-features = false
 
+[dependencies.serde]
+version = "*"
+optional = true
+
 [dev-dependencies]
 env_logger = "*"
 
 [features]
 default = ["ssl"]
 ssl = ["openssl", "cookie/secure"]
+serde-serialization = ["serde"]
 nightly = []
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,8 @@ extern crate time;
 extern crate url;
 #[cfg(feature = "openssl")]
 extern crate openssl;
+#[cfg(feature = "serde-serialization")]
+extern crate serde;
 extern crate cookie;
 extern crate unicase;
 extern crate httparse;

--- a/src/method.rs
+++ b/src/method.rs
@@ -7,6 +7,9 @@ use error::Error;
 use self::Method::{Options, Get, Post, Put, Delete, Head, Trace, Connect, Patch,
                    Extension};
 
+#[cfg(feature = "serde-serialization")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 /// The Request Method (VERB)
 ///
 /// Currently includes 8 variants representing the 8 methods defined in
@@ -124,6 +127,21 @@ impl fmt::Display for Method {
         })
     }
 }
+
+#[cfg(feature = "serde-serialization")]
+impl Serialize for Method {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+        format!("{}", self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde-serialization")]
+impl Deserialize for Method {
+    fn deserialize<D>(deserializer: &mut D) -> Result<Method, D::Error> where D: Deserializer {
+        let string_representation: String = try!(Deserialize::deserialize(deserializer));
+        Ok(FromStr::from_str(&string_representation[..]).unwrap())
+    }
+} 
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This is behind a Cargo feature to avoid forcing downstream users to
depend on `serde`. It is needed for Servo IPC to work.