### PR TITLE
fix(headers): update dependency language-tags to v0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["http", "hyper", "hyperium"]
 
 [dependencies]
 httparse = "0.1"
-language-tags = "0.0.7"
+language-tags = "0.1.0"
 log = "0.3"
 mime = "0.0.12"
 num_cpus = "0.2"
@@ -48,4 +48,3 @@ default = ["ssl"]
 ssl = ["openssl", "cookie/secure"]
 serde-serialization = ["serde"]
 nightly = []
-


### PR DESCRIPTION
BREAKING CHANGE: `LanguageTag` type changed, see rust-language-tags for
 more information.