### PR TITLE
feat(net): add socket timeouts to Server and Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,5 @@ env_logger = "*"
 default = ["ssl"]
 ssl = ["openssl", "cookie/secure"]
 serde-serialization = ["serde"]
-nightly = []
-
+timeouts = []
+nightly = ["timeouts"]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -59,13 +59,16 @@ use std::default::Default;
 use std::io::{self, copy, Read};
 use std::iter::Extend;
 
+#[cfg(feature = "timeouts")]
+use std::time::Duration;
+
 use url::UrlParser;
 use url::ParseError as UrlError;
 
 use header::{Headers, Header, HeaderFormat};
 use header::{ContentLength, Location};
 use method::Method;
-use net::{NetworkConnector, NetworkStream};
+use net::{NetworkConnector, NetworkStream, Fresh};
 use {Url};
 use Error;
 
@@ -87,7 +90,9 @@ pub struct Client {
     protocol: Box<Protocol + Send + Sync>,
     redirect_policy: RedirectPolicy,
     #[cfg(feature = "timeouts")]
-    read_timeout: Option<Duration>
+    read_timeout: Option<Duration>,
+    #[cfg(feature = "timeouts")]
+    write_timeout: Option<Duration>,
 }
 
 impl Client {
@@ -108,11 +113,23 @@ impl Client {
         Client::with_protocol(Http11Protocol::with_connector(connector))
     }
 
+    #[cfg(not(feature = "timeouts"))]
     /// Create a new client with a specific `Protocol`.
     pub fn with_protocol<P: Protocol + Send + Sync + 'static>(protocol: P) -> Client {
         Client {
             protocol: Box::new(protocol),
-            redirect_policy: Default::default()
+            redirect_policy: Default::default(),
+        }
+    }
+
+    #[cfg(feature = "timeouts")]
+    /// Create a new client with a specific `Protocol`.
+    pub fn with_protocol<P: Protocol + Send + Sync + 'static>(protocol: P) -> Client {
+        Client {
+            protocol: Box::new(protocol),
+            redirect_policy: Default::default(),
+            read_timeout: None,
+            write_timeout: None,
         }
     }
 
@@ -125,6 +142,12 @@ impl Client {
     #[cfg(feature = "timeouts")]
     pub fn set_read_timeout(&mut self, dur: Option<Duration>) {
         self.read_timeout = dur;
+    }
+
+    /// Set the write timeout value for all requests.
+    #[cfg(feature = "timeouts")]
+    pub fn set_write_timeout(&mut self, dur: Option<Duration>) {
+        self.write_timeout = dur;
     }
 
     /// Build a Get request.
@@ -235,6 +258,20 @@ impl<'a, U: IntoUrl> RequestBuilder<'a, U> {
             };
             let mut req = try!(Request::with_message(method.clone(), url.clone(), message));
             headers.as_ref().map(|headers| req.headers_mut().extend(headers.iter()));
+
+            #[cfg(not(feature = "timeouts"))]
+            fn set_timeouts(_req: &mut Request<Fresh>, _client: &Client) -> ::Result<()> {
+                Ok(())
+            }
+
+            #[cfg(feature = "timeouts")]
+            fn set_timeouts(req: &mut Request<Fresh>, client: &Client) -> ::Result<()> {
+                try!(req.set_write_timeout(client.write_timeout));
+                try!(req.set_read_timeout(client.read_timeout));
+                Ok(())
+            }
+
+            try!(set_timeouts(&mut req, &client));
 
             match (can_have_body, body.as_ref()) {
                 (true, Some(body)) => match body.size() {

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -5,6 +5,9 @@ use std::io::{self, Read, Write};
 use std::net::{SocketAddr, Shutdown};
 use std::sync::{Arc, Mutex};
 
+#[cfg(feature = "timeouts")]
+use std::time::Duration;
+
 use net::{NetworkConnector, NetworkStream, DefaultConnector};
 
 /// The `NetworkConnector` that behaves as a connection pool used by hyper's `Client`.
@@ -151,6 +154,18 @@ impl<S: NetworkStream> NetworkStream for PooledStream<S> {
     #[inline]
     fn peer_addr(&mut self) -> io::Result<SocketAddr> {
         self.inner.as_mut().unwrap().1.peer_addr()
+    }
+
+    #[cfg(feature = "timeouts")]
+    #[inline]
+    fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.inner.as_ref().unwrap().1.set_read_timeout(dur)
+    }
+
+    #[cfg(feature = "timeouts")]
+    #[inline]
+    fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.inner.as_ref().unwrap().1.set_write_timeout(dur)
     }
 
     #[inline]

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -2,6 +2,9 @@
 use std::marker::PhantomData;
 use std::io::{self, Write};
 
+#[cfg(feature = "timeouts")]
+use std::time::Duration;
+
 use url::Url;
 
 use method::{self, Method};
@@ -39,6 +42,20 @@ impl<W> Request<W> {
     /// Read the Request method.
     #[inline]
     pub fn method(&self) -> method::Method { self.method.clone() }
+
+    /// Set the write timeout.
+    #[cfg(feature = "timeouts")]
+    #[inline]
+    pub fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.message.set_write_timeout(dur)
+    }
+
+    /// Set the read timeout.
+    #[cfg(feature = "timeouts")]
+    #[inline]
+    pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.message.set_read_timeout(dur)
+    }
 }
 
 impl Request<Fresh> {

--- a/src/http/h2.rs
+++ b/src/http/h2.rs
@@ -4,6 +4,8 @@ use std::io::{self, Write, Read, Cursor};
 use std::net::Shutdown;
 use std::ascii::AsciiExt;
 use std::mem;
+#[cfg(feature = "timeouts")]
+use std::time::Duration;
 
 use http::{
     Protocol,
@@ -398,6 +400,19 @@ impl<S> HttpMessage for Http2Message<S> where S: CloneableStream {
         Ok(head)
     }
 
+    #[cfg(feature = "timeouts")]
+    #[inline]
+    fn set_read_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    #[cfg(feature = "timeouts")]
+    #[inline]
+    fn set_write_timeout(&self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    #[inline]
     fn close_connection(&mut self) -> ::Result<()> {
         Ok(())
     }

--- a/src/http/message.rs
+++ b/src/http/message.rs
@@ -1,11 +1,15 @@
 //! Defines the `HttpMessage` trait that serves to encapsulate the operations of a single
 //! request-response cycle on any HTTP connection.
 
-use std::fmt::Debug;
 use std::any::{Any, TypeId};
+use std::fmt::Debug;
 use std::io::{Read, Write};
-
 use std::mem;
+
+#[cfg(feature = "timeouts")]
+use std::io;
+#[cfg(feature = "timeouts")]
+use std::time::Duration;
 
 use typeable::Typeable;
 
@@ -62,7 +66,10 @@ pub trait HttpMessage: Write + Read + Send + Any + Typeable + Debug {
     fn get_incoming(&mut self) -> ::Result<ResponseHead>;
     /// Set the read timeout duration for this message.
     #[cfg(feature = "timeouts")]
-    fn set_read_timeout(&self, dur: Option<Duration>) -> ::Result<()>;
+    fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()>;
+    /// Set the write timeout duration for this message.
+    #[cfg(feature = "timeouts")]
+    fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()>;
     /// Closes the underlying HTTP connection.
     fn close_connection(&mut self) -> ::Result<()>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(test, deny(missing_docs))]
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
+#![cfg_attr(feature = "timeouts", feature(duration, socket_timeout))]
 
 //! # Hyper
 //!

--- a/src/net.rs
+++ b/src/net.rs
@@ -8,6 +8,9 @@ use std::mem;
 #[cfg(feature = "openssl")]
 pub use self::openssl::Openssl;
 
+#[cfg(feature = "timeouts")]
+use std::time::Duration;
+
 use typeable::Typeable;
 use traitobject;
 
@@ -21,17 +24,12 @@ pub enum Streaming {}
 pub trait NetworkListener: Clone {
     /// The stream produced for each connection.
     type Stream: NetworkStream + Send + Clone;
-    /// Listens on a socket.
-    //fn listen<To: ToSocketAddrs>(&mut self, addr: To) -> io::Result<Self::Acceptor>;
 
     /// Returns an iterator of streams.
     fn accept(&mut self) -> ::Result<Self::Stream>;
 
     /// Get the address this Listener ended up listening on.
     fn local_addr(&mut self) -> io::Result<SocketAddr>;
-
-    /// Closes the Acceptor, so no more incoming connections will be handled.
-//    fn close(&mut self) -> io::Result<()>;
 
     /// Returns an iterator over incoming connections.
     fn incoming(&mut self) -> NetworkConnections<Self> {
@@ -53,6 +51,12 @@ impl<'a, N: NetworkListener + 'a> Iterator for NetworkConnections<'a, N> {
 pub trait NetworkStream: Read + Write + Any + Send + Typeable {
     /// Get the remote address of the underlying connection.
     fn peer_addr(&mut self) -> io::Result<SocketAddr>;
+    /// Set the maximum time to wait for a read to complete.
+    #[cfg(feature = "timeouts")]
+    fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()>;
+    /// Set the maximum time to wait for a write to complete.
+    #[cfg(feature = "timeouts")]
+    fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()>;
     /// This will be called when Stream should no longer be kept alive.
     #[inline]
     fn close(&mut self, _how: Shutdown) -> io::Result<()> {
@@ -222,6 +226,18 @@ impl NetworkStream for HttpStream {
             self.0.peer_addr()
     }
 
+    #[cfg(feature = "timeouts")]
+    #[inline]
+    fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.0.set_read_timeout(dur)
+    }
+
+    #[cfg(feature = "timeouts")]
+    #[inline]
+    fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.0.set_write_timeout(dur)
+    }
+
     #[inline]
     fn close(&mut self, how: Shutdown) -> io::Result<()> {
         match self.0.shutdown(how) {
@@ -312,6 +328,24 @@ impl<S: NetworkStream> NetworkStream for HttpsStream<S> {
         }
     }
 
+    #[cfg(feature = "timeouts")]
+    #[inline]
+    fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        match *self {
+            HttpsStream::Http(ref inner) => inner.0.set_read_timeout(dur),
+            HttpsStream::Https(ref inner) => inner.set_read_timeout(dur)
+        }
+    }
+
+    #[cfg(feature = "timeouts")]
+    #[inline]
+    fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        match *self {
+            HttpsStream::Http(ref inner) => inner.0.set_read_timeout(dur),
+            HttpsStream::Https(ref inner) => inner.set_read_timeout(dur)
+        }
+    }
+
     #[inline]
     fn close(&mut self, how: Shutdown) -> io::Result<()> {
         match *self {
@@ -397,6 +431,9 @@ mod openssl {
     use std::net::{SocketAddr, Shutdown};
     use std::path::Path;
     use std::sync::Arc;
+    #[cfg(feature = "timeouts")]
+    use std::time::Duration;
+
     use openssl::ssl::{Ssl, SslContext, SslStream, SslMethod, SSL_VERIFY_NONE};
     use openssl::ssl::error::StreamError as SslIoError;
     use openssl::ssl::error::SslError;
@@ -473,6 +510,18 @@ mod openssl {
         #[inline]
         fn peer_addr(&mut self) -> io::Result<SocketAddr> {
             self.get_mut().peer_addr()
+        }
+
+        #[cfg(feature = "timeouts")]
+        #[inline]
+        fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+            self.get_ref().set_read_timeout(dur)
+        }
+
+        #[cfg(feature = "timeouts")]
+        #[inline]
+        fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+            self.get_ref().set_write_timeout(dur)
         }
 
         fn close(&mut self, how: Shutdown) -> io::Result<()> {


### PR DESCRIPTION
While these methods are marked unstable in libstd, this is behind a
feature flag, `timeouts`. The Client and Server both have
`set_read_timeout` and `set_write_timeout` methods, that will affect all
connections with that entity.

BREAKING CHANGE: Any custom implementation of NetworkStream must now
  implement `set_read_timeout` and `set_write_timeout`, so those will
  break. Most users who only use the provided streams should work with
  no changes needed.

Closes #315 

@reem r?