### PR TITLE
fix(client): be resilient to invalid response bodies

### DIFF
--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -64,7 +64,6 @@ impl Response {
     pub fn status_raw(&self) -> &RawStatus {
         &self.status_raw
     }
-
 }
 
 impl Read for Response {
@@ -91,11 +90,11 @@ impl Drop for Response {
         //
         // otherwise, the response has been drained. we should check that the
         // server has agreed to keep the connection open
-        trace!("Response.is_drained = {:?}", self.is_drained);
+        trace!("Response.drop is_drained={}", self.is_drained);
         if !(self.is_drained && http::should_keep_alive(self.version, &self.headers)) {
-            trace!("closing connection");
+            trace!("Response.drop closing connection");
             if let Err(e) = self.message.close_connection() {
-                error!("error closing connection: {}", e);
+                error!("Response.drop error closing connection: {}", e);
             }
         }
     }

--- a/src/net.rs
+++ b/src/net.rs
@@ -62,6 +62,17 @@ pub trait NetworkStream: Read + Write + Any + Send + Typeable {
     fn close(&mut self, _how: Shutdown) -> io::Result<()> {
         Ok(())
     }
+
+    // Unsure about name and implementation...
+
+    #[doc(hidden)]
+    fn set_previous_response_expected_no_content(&mut self, _expected: bool) {
+    
+    }
+    #[doc(hidden)]
+    fn previous_response_expected_no_content(&self) -> bool {
+        false
+    }
 }
 
 /// A connector creates a NetworkStream.


### PR DESCRIPTION
When an Http11Message knows that the previous response should not
have included a body per RFC7230, and fails to parse the following
response, the bytes are shuffled along, checking for the start of the
next response.

Closes #640