### PR TITLE
feat(client): add patch method to Client builder interface

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -160,6 +160,11 @@ impl Client {
         self.request(Method::Head, url)
     }
 
+    /// Build a Patch request.
+    pub fn patch<U: IntoUrl>(&self, url: U) -> RequestBuilder<U> {
+        self.request(Method::Patch, url)
+    }
+
     /// Build a Post request.
     pub fn post<U: IntoUrl>(&self, url: U) -> RequestBuilder<U> {
         self.request(Method::Post, url)


### PR DESCRIPTION
I'm building a client interface on top of hyper for an rest API that makes use of the HTTP PATCH method. It felt a little awkward that there were methods for `get` `post` and `delete` but not `patch` so I wanted to make it less awkward for others.