### PR TITLE
Make the example client more clear for those learning the crate.

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,13 +1,21 @@
-#![deny(warnings)]
 extern crate hyper;
 
 extern crate env_logger;
 
 use std::env;
-use std::io;
+use std::io::{Read,};  // enables read_to_string
 
 use hyper::Client;
+use hyper::client::response::Response;
 use hyper::header::Connection;
+
+
+// add more parameters here to support adding custom headers
+fn process(client: &Client, url: &str) -> hyper::Result<Response> {
+    client.get(url)
+          .header(Connection::close())
+          .send()
+}
 
 fn main() {
     env_logger::init().unwrap();
@@ -22,11 +30,27 @@ fn main() {
 
     let client = Client::new();
 
-    let mut res = client.get(&*url)
-        .header(Connection::close())
-        .send().unwrap();
+    let mut res = match process(&client, &url) {
+        Ok(res) => res,
+        Err(e) => {
+            // this will be things like name server lookup failure
+            println!("Error: {}", e);
+            return;
+        }
+    };
 
+    /*
+     * the Request was handled by the HTTP server.
+     *
+     * Check res.status to find out if it was successful.
+     * Inspect the headers to see what data type was returned and then
+     * parse the response data stored in `contents`.
+     */
     println!("Response: {}", res.status);
     println!("Headers:\n{}", res.headers);
-    io::copy(&mut res, &mut io::stdout()).unwrap();
+
+    let mut contents = String::new();
+    res.read_to_string(&mut contents).unwrap();
+
+    println!("Contents: {}", contents);
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -42,6 +42,7 @@ fn main() {
     /*
      * the Request was handled by the HTTP server.
      *
+     * Next steps:
      * Check res.status to find out if it was successful.
      * Inspect the headers to see what data type was returned and then
      * parse the response data stored in `contents`.


### PR DESCRIPTION
Add explicit reading of the Response contents into a string.
Add more comments to be more clear for those learning the crate.