### PR TITLE
refactor(client): make RequestBuilder non-generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 script:
   - cargo build --verbose $FEATURES
   - cargo test --verbose $FEATURES
-  - '[ $TRAVIS_RUST_VERSION = nightly ] && cargo bench --no-run || :'
+  - 'if [ $TRAVIS_RUST_VERSION = nightly ]; then cargo bench --no-run; fi'
 
 addons:
   apt:

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -7,6 +7,8 @@ extern crate test;
 use std::fmt;
 use std::io::{self, Read, Write, Cursor};
 use std::net::SocketAddr;
+#[cfg(feature = "timeouts")]
+use std::time::Duration;
 
 use hyper::net;
 
@@ -72,6 +74,16 @@ impl hyper::header::HeaderFormat for Foo {
 impl net::NetworkStream for MockStream {
     fn peer_addr(&mut self) -> io::Result<SocketAddr> {
         Ok("127.0.0.1:1337".parse().unwrap())
+    }
+    #[cfg(feature = "timeouts")]
+    fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        // can't time out
+        Ok(())
+    }
+    #[cfg(feature = "timeouts")]
+    fn set_write_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        // can't time out
+        Ok(())
     }
 }
 

--- a/src/server/listener.rs
+++ b/src/server/listener.rs
@@ -27,7 +27,7 @@ impl<A: NetworkListener + Send + 'static> ListenerPool<A> {
         let work = Arc::new(work);
 
         // Begin work.
-        for _ in (0..threads) {
+        for _ in 0..threads {
             spawn_with(super_tx.clone(), work.clone(), self.acceptor.clone())
         }
 


### PR DESCRIPTION
Improve the compile-time of downstream crates that use RequestBuilder,
by not forcing them to remonomorphise and recompile its non-generic
methods when they use it: with this change, they can just call the
precompiled versions in the `hyper` object file(s). The `send` method is
the major culprit here, since it is quite large and complicated.

For an extreme example,

    extern crate hyper;
    fn main() {
        hyper::Client::new().get("x").send().unwrap();
    }

takes ~4s to compile before this patch (i.e. generic RequestBuilder) and
~2s after. (The time spent interacting with LLVM goes from 2.2s to
0.3s.)

BREAKING CHANGE: `RequestBuilder<U>` should be replaced by `RequestBuilder`.