### PR TITLE
chore(nightly): remove ()'s and fix benchmarks for nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 script:
   - cargo build --verbose $FEATURES
   - cargo test --verbose $FEATURES
-  - '[ $TRAVIS_RUST_VERSION = nightly ] && cargo bench --no-run || :'
+  - 'if [ $TRAVIS_RUST_VERSION = nightly ]; then cargo bench --no-run; fi'
 
 addons:
   apt:

--- a/benches/client.rs
+++ b/benches/client.rs
@@ -7,6 +7,8 @@ extern crate test;
 use std::fmt;
 use std::io::{self, Read, Write, Cursor};
 use std::net::SocketAddr;
+#[cfg(feature = "timeouts")]
+use std::time::Duration;
 
 use hyper::net;
 
@@ -72,6 +74,16 @@ impl hyper::header::HeaderFormat for Foo {
 impl net::NetworkStream for MockStream {
     fn peer_addr(&mut self) -> io::Result<SocketAddr> {
         Ok("127.0.0.1:1337".parse().unwrap())
+    }
+    #[cfg(feature = "timeouts")]
+    fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        // can't time out
+        Ok(())
+    }
+    #[cfg(feature = "timeouts")]
+    fn set_write_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        // can't time out
+        Ok(())
     }
 }
 

--- a/src/server/listener.rs
+++ b/src/server/listener.rs
@@ -27,7 +27,7 @@ impl<A: NetworkListener + Send + 'static> ListenerPool<A> {
         let work = Arc::new(work);
 
         // Begin work.
-        for _ in (0..threads) {
+        for _ in 0..threads {
             spawn_with(super_tx.clone(), work.clone(), self.acceptor.clone())
         }
 


### PR DESCRIPTION
Also ensure that `cargo bench` runs successfully on travis; the old
`cargo bench ... || :` has the effect of ignoring any errors in it.