### PR TITLE
Add hooks for HttpListener and HttpsListener to be started from existing listeners.

### DIFF
--- a/src/server/listener.rs
+++ b/src/server/listener.rs
@@ -42,7 +42,6 @@ impl<A: NetworkListener + Send + 'static> ListenerPool<A> {
 fn spawn_with<A, F>(supervisor: mpsc::Sender<()>, work: Arc<F>, mut acceptor: A)
 where A: NetworkListener + Send + 'static,
       F: Fn(<A as NetworkListener>::Stream) + Send + Sync + 'static {
-
     thread::spawn(move || {
         let _sentinel = Sentinel::new(supervisor, ());
 
@@ -77,3 +76,4 @@ impl<T: Send + 'static> Drop for Sentinel<T> {
         let _ = self.supervisor.send(self.value.take().unwrap());
     }
 }
+

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -194,8 +194,6 @@ impl<L: NetworkListener> Server<L> {
     pub fn set_write_timeout(&mut self, dur: Option<Duration>) {
         self.timeouts.write = dur;
     }
-
-
 }
 
 impl Server<HttpListener> {
@@ -219,6 +217,7 @@ impl<L: NetworkListener + Send + 'static> Server<L> {
     pub fn handle<H: Handler + 'static>(self, handler: H) -> ::Result<Listening> {
         self.handle_threads(handler, num_cpus::get() * 5 / 4)
     }
+
     /// Binds to a socket and starts handling connections with the provided
     /// number of threads.
     pub fn handle_threads<H: Handler + 'static>(self, handler: H,
@@ -228,8 +227,7 @@ impl<L: NetworkListener + Send + 'static> Server<L> {
 }
 
 fn handle<H, L>(mut server: Server<L>, handler: H, threads: usize) -> ::Result<Listening>
-where H: Handler + 'static,
-L: NetworkListener + Send + 'static {
+where H: Handler + 'static, L: NetworkListener + Send + 'static {
     let socket = try!(server.listener.local_addr());
 
     debug!("threads = {:?}", threads);
@@ -251,7 +249,6 @@ struct Worker<H: Handler + 'static> {
 }
 
 impl<H: Handler + 'static> Worker<H> {
-
     fn new(handler: H, timeouts: Timeouts) -> Worker<H> {
         Worker {
             handler: handler,
@@ -299,7 +296,6 @@ impl<H: Handler + 'static> Worker<H> {
         self.set_write_timeout(s, self.timeouts.write)
     }
 
-
     #[cfg(not(feature = "timeouts"))]
     fn set_write_timeout(&self, _s: &NetworkStream, _timeout: Option<Duration>) -> io::Result<()> {
         Ok(())
@@ -338,7 +334,6 @@ impl<H: Handler + 'static> Worker<H> {
                 return false;
             }
         };
-
 
         if !self.handle_expect(&req, wrt) {
             return false;


### PR DESCRIPTION
This allows Servers to be started on existing TcpListeners.

Progress towards iron/iron#386