### PR TITLE
style(headers): use regular doc-comments inside macros

### DIFF
--- a/src/header/common/accept.rs
+++ b/src/header/common/accept.rs
@@ -3,79 +3,79 @@ use mime::Mime;
 use header::QualityItem;
 
 header! {
-    #[doc="`Accept` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.2)"]
-    #[doc=""]
-    #[doc="The `Accept` header field can be used by user agents to specify"]
-    #[doc="response media types that are acceptable.  Accept header fields can"]
-    #[doc="be used to indicate that the request is specifically limited to a"]
-    #[doc="small set of desired types, as in the case of a request for an"]
-    #[doc="in-line image"]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Accept = #( media-range [ accept-params ] )"]
-    #[doc=""]
-    #[doc="media-range    = ( \"*/*\""]
-    #[doc="                 / ( type \"/\" \"*\" )"]
-    #[doc="                 / ( type \"/\" subtype )"]
-    #[doc="                 ) *( OWS \";\" OWS parameter )"]
-    #[doc="accept-params  = weight *( accept-ext )"]
-    #[doc="accept-ext = OWS \";\" OWS token [ \"=\" ( token / quoted-string ) ]"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `audio/*; q=0.2, audio/basic` (`*` value won't parse correctly)"]
-    #[doc="* `text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Accept, qitem};"]
-    #[doc="use hyper::mime::{Mime, TopLevel, SubLevel};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc=""]
-    #[doc="headers.set("]
-    #[doc="    Accept(vec!["]
-    #[doc="        qitem(Mime(TopLevel::Text, SubLevel::Html, vec![])),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Accept, qitem};"]
-    #[doc="use hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    Accept(vec!["]
-    #[doc="        qitem(Mime(TopLevel::Application, SubLevel::Json,"]
-    #[doc="                   vec![(Attr::Charset, Value::Utf8)])),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Accept, QualityItem, Quality, qitem};"]
-    #[doc="use hyper::mime::{Mime, TopLevel, SubLevel};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc=""]
-    #[doc="headers.set("]
-    #[doc="    Accept(vec!["]
-    #[doc="        qitem(Mime(TopLevel::Text, SubLevel::Html, vec![])),"]
-    #[doc="        qitem(Mime(TopLevel::Application,"]
-    #[doc="                   SubLevel::Ext(\"xhtml+xml\".to_owned()), vec![])),"]
-    #[doc="        QualityItem::new(Mime(TopLevel::Application, SubLevel::Xml, vec![]),"]
-    #[doc="                         Quality(900)),"]
-    #[doc="                         qitem(Mime(TopLevel::Image,"]
-    #[doc="                                    SubLevel::Ext(\"webp\".to_owned()), vec![])),"]
-    #[doc="                         QualityItem::new(Mime(TopLevel::Star, SubLevel::Star, vec![]),"]
-    #[doc="                                          Quality(800))"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Notes"]
-    #[doc="* Using always Mime types to represent `media-range` differs from the ABNF."]
-    #[doc="* **FIXME**: `accept-ext` is not supported."]
+    /// `Accept` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.2)
+    ///
+    /// The `Accept` header field can be used by user agents to specify
+    /// response media types that are acceptable.  Accept header fields can
+    /// be used to indicate that the request is specifically limited to a
+    /// small set of desired types, as in the case of a request for an
+    /// in-line image
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Accept = #( media-range [ accept-params ] )
+    ///
+    /// media-range    = ( "*/*"
+    ///                  / ( type "/" "*" )
+    ///                  / ( type "/" subtype )
+    ///                  ) *( OWS ";" OWS parameter )
+    /// accept-params  = weight *( accept-ext )
+    /// accept-ext = OWS ";" OWS token [ "=" ( token / quoted-string ) ]
+    /// ```
+    ///
+    /// # Example values
+    /// * `audio/*; q=0.2, audio/basic` (`*` value won't parse correctly)
+    /// * `text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c`
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, Accept, qitem};
+    /// use hyper::mime::{Mime, TopLevel, SubLevel};
+    ///
+    /// let mut headers = Headers::new();
+    ///
+    /// headers.set(
+    ///     Accept(vec![
+    ///         qitem(Mime(TopLevel::Text, SubLevel::Html, vec![])),
+    ///     ])
+    /// );
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, Accept, qitem};
+    /// use hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     Accept(vec![
+    ///         qitem(Mime(TopLevel::Application, SubLevel::Json,
+    ///                    vec![(Attr::Charset, Value::Utf8)])),
+    ///     ])
+    /// );
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, Accept, QualityItem, Quality, qitem};
+    /// use hyper::mime::{Mime, TopLevel, SubLevel};
+    ///
+    /// let mut headers = Headers::new();
+    ///
+    /// headers.set(
+    ///     Accept(vec![
+    ///         qitem(Mime(TopLevel::Text, SubLevel::Html, vec![])),
+    ///         qitem(Mime(TopLevel::Application,
+    ///                    SubLevel::Ext("xhtml+xml".to_owned()), vec![])),
+    ///         QualityItem::new(Mime(TopLevel::Application, SubLevel::Xml, vec![]),
+    ///                          Quality(900)),
+    ///                          qitem(Mime(TopLevel::Image,
+    ///                                     SubLevel::Ext("webp".to_owned()), vec![])),
+    ///                          QualityItem::new(Mime(TopLevel::Star, SubLevel::Star, vec![]),
+    ///                                           Quality(800))
+    ///     ])
+    /// );
+    /// ```
+    ///
+    /// # Notes
+    /// * Using always Mime types to represent `media-range` differs from the ABNF.
+    /// * **FIXME**: `accept-ext` is not supported.
     (Accept, "Accept") => (QualityItem<Mime>)+
 
     test_accept {

--- a/src/header/common/accept_charset.rs
+++ b/src/header/common/accept_charset.rs
@@ -1,52 +1,52 @@
 use header::{Charset, QualityItem};
 
 header! {
-    #[doc="`Accept-Charset` header, defined in"]
-    #[doc="[RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.3)"]
-    #[doc=""]
-    #[doc="The `Accept-Charset` header field can be sent by a user agent to"]
-    #[doc="indicate what charsets are acceptable in textual response content."]
-    #[doc="This field allows user agents capable of understanding more"]
-    #[doc="comprehensive or special-purpose charsets to signal that capability"]
-    #[doc="to an origin server that is capable of representing information in"]
-    #[doc="those charsets."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Accept-Charset = 1#( ( charset / \"*\" ) [ weight ] )"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `iso-8859-5, unicode-1-1;q=0.8`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AcceptCharset, Charset, qitem};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AcceptCharset(vec![qitem(Charset::Us_Ascii)])"]
-    #[doc=");"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AcceptCharset, Charset, Quality, QualityItem};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AcceptCharset(vec!["]
-    #[doc="        QualityItem::new(Charset::Us_Ascii, Quality(900)),"]
-    #[doc="        QualityItem::new(Charset::Iso_8859_10, Quality(200)),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AcceptCharset, Charset, qitem};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AcceptCharset(vec![qitem(Charset::Ext(\"utf-8\".to_owned()))])"]
-    #[doc=");"]
-    #[doc="```"]
+    /// `Accept-Charset` header, defined in
+    /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.3)
+    ///
+    /// The `Accept-Charset` header field can be sent by a user agent to
+    /// indicate what charsets are acceptable in textual response content.
+    /// This field allows user agents capable of understanding more
+    /// comprehensive or special-purpose charsets to signal that capability
+    /// to an origin server that is capable of representing information in
+    /// those charsets.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Accept-Charset = 1#( ( charset / "*" ) [ weight ] )
+    /// ```
+    ///
+    /// # Example values
+    /// * `iso-8859-5, unicode-1-1;q=0.8`
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, AcceptCharset, Charset, qitem};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AcceptCharset(vec![qitem(Charset::Us_Ascii)])
+    /// );
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, AcceptCharset, Charset, Quality, QualityItem};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AcceptCharset(vec![
+    ///         QualityItem::new(Charset::Us_Ascii, Quality(900)),
+    ///         QualityItem::new(Charset::Iso_8859_10, Quality(200)),
+    ///     ])
+    /// );
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, AcceptCharset, Charset, qitem};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AcceptCharset(vec![qitem(Charset::Ext("utf-8".to_owned()))])
+    /// );
+    /// ```
     (AcceptCharset, "Accept-Charset") => (QualityItem<Charset>)+
 
     test_accept_charset {

--- a/src/header/common/accept_encoding.rs
+++ b/src/header/common/accept_encoding.rs
@@ -1,61 +1,61 @@
 use header::{Encoding, QualityItem};
 
 header! {
-    #[doc="`Accept-Encoding` header, defined in"]
-    #[doc="[RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.4)"]
-    #[doc=""]
-    #[doc="The `Accept-Encoding` header field can be used by user agents to"]
-    #[doc="indicate what response content-codings are"]
-    #[doc="acceptable in the response.  An  `identity` token is used as a synonym"]
-    #[doc="for \"no encoding\" in order to communicate when no encoding is"]
-    #[doc="preferred."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Accept-Encoding  = #( codings [ weight ] )"]
-    #[doc="codings          = content-coding / \"identity\" / \"*\""]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `compress, gzip`"]
-    #[doc="* ``"]
-    #[doc="* `*`"]
-    #[doc="* `compress;q=0.5, gzip;q=1`"]
-    #[doc="* `gzip;q=1.0, identity; q=0.5, *;q=0`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AcceptEncoding, Encoding, qitem};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AcceptEncoding(vec![qitem(Encoding::Chunked)])"]
-    #[doc=");"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AcceptEncoding, Encoding, qitem};"]
-    #[doc=" "]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AcceptEncoding(vec!["]
-    #[doc="        qitem(Encoding::Chunked),"]
-    #[doc="        qitem(Encoding::Gzip),"]
-    #[doc="        qitem(Encoding::Deflate),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AcceptEncoding, Encoding, QualityItem, Quality, qitem};"]
-    #[doc=" "]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AcceptEncoding(vec!["]
-    #[doc="        qitem(Encoding::Chunked),"]
-    #[doc="        QualityItem::new(Encoding::Gzip, Quality(600)),"]
-    #[doc="        QualityItem::new(Encoding::EncodingExt(\"*\".to_owned()), Quality(0)),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
+    /// `Accept-Encoding` header, defined in
+    /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.4)
+    ///
+    /// The `Accept-Encoding` header field can be used by user agents to
+    /// indicate what response content-codings are
+    /// acceptable in the response.  An  `identity` token is used as a synonym
+    /// for "no encoding" in order to communicate when no encoding is
+    /// preferred.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Accept-Encoding  = #( codings [ weight ] )
+    /// codings          = content-coding / "identity" / "*"
+    /// ```
+    ///
+    /// # Example values
+    /// * `compress, gzip`
+    /// * ``
+    /// * `*`
+    /// * `compress;q=0.5, gzip;q=1`
+    /// * `gzip;q=1.0, identity; q=0.5, *;q=0`
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, AcceptEncoding, Encoding, qitem};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AcceptEncoding(vec![qitem(Encoding::Chunked)])
+    /// );
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, AcceptEncoding, Encoding, qitem};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AcceptEncoding(vec![
+    ///         qitem(Encoding::Chunked),
+    ///         qitem(Encoding::Gzip),
+    ///         qitem(Encoding::Deflate),
+    ///     ])
+    /// );
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, AcceptEncoding, Encoding, QualityItem, Quality, qitem};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AcceptEncoding(vec![
+    ///         qitem(Encoding::Chunked),
+    ///         QualityItem::new(Encoding::Gzip, Quality(600)),
+    ///         QualityItem::new(Encoding::EncodingExt("*".to_owned()), Quality(0)),
+    ///     ])
+    /// );
+    /// ```
     (AcceptEncoding, "Accept-Encoding") => (QualityItem<Encoding>)*
 
     test_accept_encoding {

--- a/src/header/common/accept_language.rs
+++ b/src/header/common/accept_language.rs
@@ -2,54 +2,54 @@ use language_tags::LanguageTag;
 use header::QualityItem;
 
 header! {
-    #[doc="`Accept-Language` header, defined in"]
-    #[doc="[RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.5)"]
-    #[doc=""]
-    #[doc="The `Accept-Language` header field can be used by user agents to"]
-    #[doc="indicate the set of natural languages that are preferred in the"]
-    #[doc="response."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Accept-Language = 1#( language-range [ weight ] )"]
-    #[doc="language-range  = <language-range, see [RFC4647], Section 2.1>"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `da, en-gb;q=0.8, en;q=0.7`"]
-    #[doc="* `en-us;q=1.0, en;q=0.5, fr`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::LanguageTag;"]
-    #[doc="use hyper::header::{Headers, AcceptLanguage, qitem};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="let mut langtag: LanguageTag = Default::default();"]
-    #[doc="langtag.language = Some(\"en\".to_owned());"]
-    #[doc="langtag.region = Some(\"US\".to_owned());"]
-    #[doc="headers.set("]
-    #[doc="    AcceptLanguage(vec!["]
-    #[doc="        qitem(langtag),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# #[macro_use] extern crate language_tags;"]
-    #[doc="# use hyper::header::{Headers, AcceptLanguage, QualityItem, Quality, qitem};"]
-    #[doc="# "]
-    #[doc="# fn main() {"]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AcceptLanguage(vec!["]
-    #[doc="        qitem(langtag!(da)),"]
-    #[doc="        QualityItem::new(langtag!(en;;;GB), Quality(800)),"]
-    #[doc="        QualityItem::new(langtag!(en), Quality(700)),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="# }"]
-    #[doc="```"]
+    /// `Accept-Language` header, defined in
+    /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.3.5)
+    ///
+    /// The `Accept-Language` header field can be used by user agents to
+    /// indicate the set of natural languages that are preferred in the
+    /// response.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Accept-Language = 1#( language-range [ weight ] )
+    /// language-range  = <language-range, see [RFC4647], Section 2.1>
+    /// ```
+    ///
+    /// # Example values
+    /// * `da, en-gb;q=0.8, en;q=0.7`
+    /// * `en-us;q=1.0, en;q=0.5, fr`
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::LanguageTag;
+    /// use hyper::header::{Headers, AcceptLanguage, qitem};
+    ///
+    /// let mut headers = Headers::new();
+    /// let mut langtag: LanguageTag = Default::default();
+    /// langtag.language = Some("en".to_owned());
+    /// langtag.region = Some("US".to_owned());
+    /// headers.set(
+    ///     AcceptLanguage(vec![
+    ///         qitem(langtag),
+    ///     ])
+    /// );
+    /// ```
+    /// ```
+    /// # extern crate hyper;
+    /// # #[macro_use] extern crate language_tags;
+    /// # use hyper::header::{Headers, AcceptLanguage, QualityItem, Quality, qitem};
+    /// #
+    /// # fn main() {
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AcceptLanguage(vec![
+    ///         qitem(langtag!(da)),
+    ///         QualityItem::new(langtag!(en;;;GB), Quality(800)),
+    ///         QualityItem::new(langtag!(en), Quality(700)),
+    ///     ])
+    /// );
+    /// # }
+    /// ```
     (AcceptLanguage, "Accept-Language") => (QualityItem<LanguageTag>)+
 
     test_accept_language {

--- a/src/header/common/accept_ranges.rs
+++ b/src/header/common/accept_ranges.rs
@@ -2,49 +2,49 @@ use std::fmt::{self, Display};
 use std::str::FromStr;
 
 header! {
-    #[doc="`Accept-Ranges` header, defined in"]
-    #[doc="[RFC7233](http://tools.ietf.org/html/rfc7233#section-2.3)"]
-    #[doc=""]
-    #[doc="The `Accept-Ranges` header field allows a server to indicate that it"]
-    #[doc="supports range requests for the target resource."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Accept-Ranges     = acceptable-ranges"]
-    #[doc="acceptable-ranges = 1#range-unit / \"none\""]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `bytes`"]
-    #[doc="* `none`"]
-    #[doc="* `unknown-unit`"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AcceptRanges, RangeUnit};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(AcceptRanges(vec![RangeUnit::Bytes]));"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AcceptRanges, RangeUnit};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(AcceptRanges(vec![RangeUnit::None]));"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AcceptRanges, RangeUnit};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AcceptRanges(vec!["]
-    #[doc="        RangeUnit::Unregistered(\"nibbles\".to_owned()),"]
-    #[doc="        RangeUnit::Bytes,"]
-    #[doc="        RangeUnit::Unregistered(\"doublets\".to_owned()),"]
-    #[doc="        RangeUnit::Unregistered(\"quadlets\".to_owned()),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
+    /// `Accept-Ranges` header, defined in
+    /// [RFC7233](http://tools.ietf.org/html/rfc7233#section-2.3)
+    ///
+    /// The `Accept-Ranges` header field allows a server to indicate that it
+    /// supports range requests for the target resource.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Accept-Ranges     = acceptable-ranges
+    /// acceptable-ranges = 1#range-unit / \"none\"
+    ///
+    /// # Example values
+    /// * `bytes`
+    /// * `none`
+    /// * `unknown-unit`
+    /// ```
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, AcceptRanges, RangeUnit};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(AcceptRanges(vec![RangeUnit::Bytes]));
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, AcceptRanges, RangeUnit};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(AcceptRanges(vec![RangeUnit::None]));
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, AcceptRanges, RangeUnit};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AcceptRanges(vec![
+    ///         RangeUnit::Unregistered("nibbles".to_owned()),
+    ///         RangeUnit::Bytes,
+    ///         RangeUnit::Unregistered("doublets".to_owned()),
+    ///         RangeUnit::Unregistered("quadlets".to_owned()),
+    ///     ])
+    /// );
+    /// ```
     (AcceptRanges, "Accept-Ranges") => (RangeUnit)+
 
     test_acccept_ranges {

--- a/src/header/common/access_control_allow_headers.rs
+++ b/src/header/common/access_control_allow_headers.rs
@@ -1,55 +1,55 @@
 use unicase::UniCase;
 
 header! {
-    #[doc="`Access-Control-Allow-Headers` header, part of"]
-    #[doc="[CORS](http://www.w3.org/TR/cors/#access-control-allow-headers-response-header)"]
-    #[doc=""]
-    #[doc="The `Access-Control-Allow-Headers` header indicates, as part of the"]
-    #[doc="response to a preflight request, which header field names can be used"]
-    #[doc="during the actual request."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Access-Control-Allow-Headers: \"Access-Control-Allow-Headers\" \":\" #field-name"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `accept-language, date`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# extern crate unicase;"]
-    #[doc="# fn main() {"]
-    #[doc="// extern crate unicase;"]
-    #[doc=""]
-    #[doc="use hyper::header::{Headers, AccessControlAllowHeaders};"]
-    #[doc="use unicase::UniCase;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AccessControlAllowHeaders(vec![UniCase(\"date\".to_owned())])"]
-    #[doc=");"]
-    #[doc="# }"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# extern crate unicase;"]
-    #[doc="# fn main() {"]
-    #[doc="// extern crate unicase;"]
-    #[doc=""]
-    #[doc="use hyper::header::{Headers, AccessControlAllowHeaders};"]
-    #[doc="use unicase::UniCase;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AccessControlAllowHeaders(vec!["]
-    #[doc="        UniCase(\"accept-language\".to_owned()),"]
-    #[doc="        UniCase(\"date\".to_owned()),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="# }"]
-    #[doc="```"]
+    /// `Access-Control-Allow-Headers` header, part of
+    /// [CORS](http://www.w3.org/TR/cors/#access-control-allow-headers-response-header)
+    ///
+    /// The `Access-Control-Allow-Headers` header indicates, as part of the
+    /// response to a preflight request, which header field names can be used
+    /// during the actual request.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Access-Control-Allow-Headers: "Access-Control-Allow-Headers" ":" #field-name
+    /// ```
+    ///
+    /// # Example values
+    /// * `accept-language, date`
+    ///
+    /// # Examples
+    /// ```
+    /// # extern crate hyper;
+    /// # extern crate unicase;
+    /// # fn main() {
+    /// // extern crate unicase;
+    ///
+    /// use hyper::header::{Headers, AccessControlAllowHeaders};
+    /// use unicase::UniCase;
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AccessControlAllowHeaders(vec![UniCase("date".to_owned())])
+    /// );
+    /// # }
+    /// ```
+    /// ```
+    /// # extern crate hyper;
+    /// # extern crate unicase;
+    /// # fn main() {
+    /// // extern crate unicase;
+    ///
+    /// use hyper::header::{Headers, AccessControlAllowHeaders};
+    /// use unicase::UniCase;
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AccessControlAllowHeaders(vec![
+    ///         UniCase("accept-language".to_owned()),
+    ///         UniCase("date".to_owned()),
+    ///     ])
+    /// );
+    /// # }
+    /// ```
     (AccessControlAllowHeaders, "Access-Control-Allow-Headers") => (UniCase<String>)*
 
     test_access_control_allow_headers {

--- a/src/header/common/access_control_allow_methods.rs
+++ b/src/header/common/access_control_allow_methods.rs
@@ -1,45 +1,45 @@
 use method::Method;
 
 header! {
-    #[doc="`Access-Control-Allow-Methods` header, part of"]
-    #[doc="[CORS](http://www.w3.org/TR/cors/#access-control-allow-methods-response-header)"]
-    #[doc=""]
-    #[doc="The `Access-Control-Allow-Methods` header indicates, as part of the"]
-    #[doc="response to a preflight request, which methods can be used during the"]
-    #[doc="actual request."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Access-Control-Allow-Methods: \"Access-Control-Allow-Methods\" \":\" #Method"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `PUT, DELETE, XMODIFY`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AccessControlAllowMethods};"]
-    #[doc="use hyper::method::Method;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AccessControlAllowMethods(vec![Method::Get])"]
-    #[doc=");"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AccessControlAllowMethods};"]
-    #[doc="use hyper::method::Method;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AccessControlAllowMethods(vec!["]
-    #[doc="        Method::Get,"]
-    #[doc="        Method::Post,"]
-    #[doc="        Method::Patch,"]
-    #[doc="        Method::Extension(\"COPY\".to_owned()),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
+    /// `Access-Control-Allow-Methods` header, part of
+    /// [CORS](http://www.w3.org/TR/cors/#access-control-allow-methods-response-header)
+    ///
+    /// The `Access-Control-Allow-Methods` header indicates, as part of the
+    /// response to a preflight request, which methods can be used during the
+    /// actual request.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Access-Control-Allow-Methods: "Access-Control-Allow-Methods" ":" #Method
+    /// ```
+    ///
+    /// # Example values
+    /// * `PUT, DELETE, XMODIFY`
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, AccessControlAllowMethods};
+    /// use hyper::method::Method;
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AccessControlAllowMethods(vec![Method::Get])
+    /// );
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, AccessControlAllowMethods};
+    /// use hyper::method::Method;
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AccessControlAllowMethods(vec![
+    ///         Method::Get,
+    ///         Method::Post,
+    ///         Method::Patch,
+    ///         Method::Extension("COPY".to_owned()),
+    ///     ])
+    /// );
+    /// ```
     (AccessControlAllowMethods, "Access-Control-Allow-Methods") => (Method)*
 
     test_access_control_allow_methods {

--- a/src/header/common/access_control_max_age.rs
+++ b/src/header/common/access_control_max_age.rs
@@ -1,25 +1,25 @@
 header! {
-    #[doc="`Access-Control-Max-Age` header, part of"]
-    #[doc="[CORS](http://www.w3.org/TR/cors/#access-control-max-age-response-header)"]
-    #[doc=""]
-    #[doc="The `Access-Control-Max-Age` header indicates how long the results of a"]
-    #[doc="preflight request can be cached in a preflight result cache."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Access-Control-Max-Age = \"Access-Control-Max-Age\" \":\" delta-seconds"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `531`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AccessControlMaxAge};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(AccessControlMaxAge(1728000u32));"]
-    #[doc="```"]
+    /// `Access-Control-Max-Age` header, part of
+    /// [CORS](http://www.w3.org/TR/cors/#access-control-max-age-response-header)
+    ///
+    /// The `Access-Control-Max-Age` header indicates how long the results of a
+    /// preflight request can be cached in a preflight result cache.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Access-Control-Max-Age = \"Access-Control-Max-Age\" \":\" delta-seconds
+    /// ```
+    ///
+    /// # Example values
+    /// * `531`
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, AccessControlMaxAge};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(AccessControlMaxAge(1728000u32));
+    /// ```
     (AccessControlMaxAge, "Access-Control-Max-Age") => [u32]
 
     test_access_control_max_age {

--- a/src/header/common/access_control_request_headers.rs
+++ b/src/header/common/access_control_request_headers.rs
@@ -1,55 +1,55 @@
 use unicase::UniCase;
 
 header! {
-    #[doc="`Access-Control-Request-Headers` header, part of"]
-    #[doc="[CORS](http://www.w3.org/TR/cors/#access-control-request-headers-request-header)"]
-    #[doc=""]
-    #[doc="The `Access-Control-Request-Headers` header indicates which headers will"]
-    #[doc="be used in the actual request as part of the preflight request."]
-    #[doc="during the actual request."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Access-Control-Allow-Headers: \"Access-Control-Allow-Headers\" \":\" #field-name"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `accept-language, date`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# extern crate unicase;"]
-    #[doc="# fn main() {"]
-    #[doc="// extern crate unicase;"]
-    #[doc=""]
-    #[doc="use hyper::header::{Headers, AccessControlRequestHeaders};"]
-    #[doc="use unicase::UniCase;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AccessControlRequestHeaders(vec![UniCase(\"date\".to_owned())])"]
-    #[doc=");"]
-    #[doc="# }"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# extern crate unicase;"]
-    #[doc="# fn main() {"]
-    #[doc="// extern crate unicase;"]
-    #[doc=""]
-    #[doc="use hyper::header::{Headers, AccessControlRequestHeaders};"]
-    #[doc="use unicase::UniCase;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    AccessControlRequestHeaders(vec!["]
-    #[doc="        UniCase(\"accept-language\".to_owned()),"]
-    #[doc="        UniCase(\"date\".to_owned()),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="# }"]
-    #[doc="```"]
+    /// `Access-Control-Request-Headers` header, part of
+    /// [CORS](http://www.w3.org/TR/cors/#access-control-request-headers-request-header)
+    ///
+    /// The `Access-Control-Request-Headers` header indicates which headers will
+    /// be used in the actual request as part of the preflight request.
+    /// during the actual request.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Access-Control-Allow-Headers: "Access-Control-Allow-Headers" ":" #field-name
+    /// ```
+    ///
+    /// # Example values
+    /// * `accept-language, date`
+    ///
+    /// # Examples
+    /// ```
+    /// # extern crate hyper;
+    /// # extern crate unicase;
+    /// # fn main() {
+    /// // extern crate unicase;
+    ///
+    /// use hyper::header::{Headers, AccessControlRequestHeaders};
+    /// use unicase::UniCase;
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AccessControlRequestHeaders(vec![UniCase("date".to_owned())])
+    /// );
+    /// # }
+    /// ```
+    /// ```
+    /// # extern crate hyper;
+    /// # extern crate unicase;
+    /// # fn main() {
+    /// // extern crate unicase;
+    ///
+    /// use hyper::header::{Headers, AccessControlRequestHeaders};
+    /// use unicase::UniCase;
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     AccessControlRequestHeaders(vec![
+    ///         UniCase("accept-language".to_owned()),
+    ///         UniCase("date".to_owned()),
+    ///     ])
+    /// );
+    /// # }
+    /// ```
     (AccessControlRequestHeaders, "Access-Control-Request-Headers") => (UniCase<String>)*
 
     test_access_control_request_headers {

--- a/src/header/common/access_control_request_method.rs
+++ b/src/header/common/access_control_request_method.rs
@@ -1,27 +1,27 @@
 use method::Method;
 
 header! {
-    #[doc="`Access-Control-Request-Method` header, part of"]
-    #[doc="[CORS](http://www.w3.org/TR/cors/#access-control-request-method-request-header)"]
-    #[doc=""]
-    #[doc="The `Access-Control-Request-Method` header indicates which method will be"]
-    #[doc="used in the actual request as part of the preflight request."]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Access-Control-Request-Method: \"Access-Control-Request-Method\" \":\" Method"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `GET`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, AccessControlRequestMethod};"]
-    #[doc="use hyper::method::Method;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(AccessControlRequestMethod(Method::Get));"]
-    #[doc="```"]
+    /// `Access-Control-Request-Method` header, part of
+    /// [CORS](http://www.w3.org/TR/cors/#access-control-request-method-request-header)
+    /// 
+    /// The `Access-Control-Request-Method` header indicates which method will be
+    /// used in the actual request as part of the preflight request.
+    /// # ABNF
+    /// ```plain
+    /// Access-Control-Request-Method: \"Access-Control-Request-Method\" \":\" Method
+    /// ```
+    /// 
+    /// # Example values
+    /// * `GET`
+    /// 
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, AccessControlRequestMethod};
+    /// use hyper::method::Method;
+    /// 
+    /// let mut headers = Headers::new();
+    /// headers.set(AccessControlRequestMethod(Method::Get));
+    /// ```
     (AccessControlRequestMethod, "Access-Control-Request-Method") => [Method]
 
     test_access_control_request_method {

--- a/src/header/common/allow.rs
+++ b/src/header/common/allow.rs
@@ -1,47 +1,47 @@
 use method::Method;
 
 header! {
-    #[doc="`Allow` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.4.1)"]
-    #[doc=""]
-    #[doc="The `Allow` header field lists the set of methods advertised as"]
-    #[doc="supported by the target resource.  The purpose of this field is"]
-    #[doc="strictly to inform the recipient of valid request methods associated"]
-    #[doc="with the resource."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Allow = #method"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `GET, HEAD, PUT`"]
-    #[doc="* `OPTIONS, GET, PUT, POST, DELETE, HEAD, TRACE, CONNECT, PATCH, fOObAr`"]
-    #[doc="* ``"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Allow};"]
-    #[doc="use hyper::method::Method;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    Allow(vec![Method::Get])"]
-    #[doc=");"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Allow};"]
-    #[doc="use hyper::method::Method;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    Allow(vec!["]
-    #[doc="        Method::Get,"]
-    #[doc="        Method::Post,"]
-    #[doc="        Method::Patch,"]
-    #[doc="        Method::Extension(\"COPY\".to_owned()),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
+    /// `Allow` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.4.1)
+    ///
+    /// The `Allow` header field lists the set of methods advertised as
+    /// supported by the target resource.  The purpose of this field is
+    /// strictly to inform the recipient of valid request methods associated
+    /// with the resource.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Allow = #method
+    /// ```
+    ///
+    /// # Example values
+    /// * `GET, HEAD, PUT`
+    /// * `OPTIONS, GET, PUT, POST, DELETE, HEAD, TRACE, CONNECT, PATCH, fOObAr`
+    /// * ``
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, Allow};
+    /// use hyper::method::Method;
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     Allow(vec![Method::Get])
+    /// );
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, Allow};
+    /// use hyper::method::Method;
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     Allow(vec![
+    ///         Method::Get,
+    ///         Method::Post,
+    ///         Method::Patch,
+    ///         Method::Extension("COPY".to_owned()),
+    ///     ])
+    /// );
+    /// ```
     (Allow, "Allow") => (Method)*
 
     test_allow {

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -49,50 +49,50 @@ impl Display for ConnectionOption {
 }
 
 header! {
-    #[doc="`Connection` header, defined in"]
-    #[doc="[RFC7230](http://tools.ietf.org/html/rfc7230#section-6.1)"]
-    #[doc=""]
-    #[doc="The `Connection` header field allows the sender to indicate desired"]
-    #[doc="control options for the current connection.  In order to avoid"]
-    #[doc="confusing downstream recipients, a proxy or gateway MUST remove or"]
-    #[doc="replace any received connection options before forwarding the"]
-    #[doc="message."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Connection        = 1#connection-option"]
-    #[doc="connection-option = token"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `close`"]
-    #[doc="* `keep-alive`"]
-    #[doc="* `upgrade`"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Connection};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(Connection::keep_alive());"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# extern crate unicase;"]
-    #[doc="# fn main() {"]
-    #[doc="// extern crate unicase;"]
-    #[doc=""]
-    #[doc="use hyper::header::{Headers, Connection, ConnectionOption};"]
-    #[doc="use unicase::UniCase;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    Connection(vec!["]
-    #[doc="        ConnectionOption::ConnectionHeader(UniCase(\"upgrade\".to_owned())),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="# }"]
-    #[doc="```"]
+    /// `Connection` header, defined in
+    /// [RFC7230](http://tools.ietf.org/html/rfc7230#section-6.1)
+    ///
+    /// The `Connection` header field allows the sender to indicate desired
+    /// control options for the current connection.  In order to avoid
+    /// confusing downstream recipients, a proxy or gateway MUST remove or
+    /// replace any received connection options before forwarding the
+    /// message.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Connection        = 1#connection-option
+    /// connection-option = token
+    ///
+    /// # Example values
+    /// * `close`
+    /// * `keep-alive`
+    /// * `upgrade`
+    /// ```
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, Connection};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(Connection::keep_alive());
+    /// ```
+    /// ```
+    /// # extern crate hyper;
+    /// # extern crate unicase;
+    /// # fn main() {
+    /// // extern crate unicase;
+    ///
+    /// use hyper::header::{Headers, Connection, ConnectionOption};
+    /// use unicase::UniCase;
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     Connection(vec![
+    ///         ConnectionOption::ConnectionHeader(UniCase("upgrade".to_owned())),
+    ///     ])
+    /// );
+    /// # }
+    /// ```
     (Connection, "Connection") => (ConnectionOption)+
 
     test_connection {

--- a/src/header/common/content_encoding.rs
+++ b/src/header/common/content_encoding.rs
@@ -1,43 +1,43 @@
 use header::Encoding;
 
 header! {
-    #[doc="`Content-Encoding` header, defined in"]
-    #[doc="[RFC7231](http://tools.ietf.org/html/rfc7231#section-3.1.2.2)"]
-    #[doc=""]
-    #[doc="The `Content-Encoding` header field indicates what content codings"]
-    #[doc="have been applied to the representation, beyond those inherent in the"]
-    #[doc="media type, and thus what decoding mechanisms have to be applied in"]
-    #[doc="order to obtain data in the media type referenced by the Content-Type"]
-    #[doc="header field.  Content-Encoding is primarily used to allow a"]
-    #[doc="representation's data to be compressed without losing the identity of"]
-    #[doc="its underlying media type."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Content-Encoding = 1#content-coding"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `gzip`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, ContentEncoding, Encoding};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(ContentEncoding(vec![Encoding::Chunked]));"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, ContentEncoding, Encoding};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    ContentEncoding(vec!["]
-    #[doc="        Encoding::Gzip,"]
-    #[doc="        Encoding::Chunked,"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
+    /// `Content-Encoding` header, defined in
+    /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-3.1.2.2)
+    /// 
+    /// The `Content-Encoding` header field indicates what content codings
+    /// have been applied to the representation, beyond those inherent in the
+    /// media type, and thus what decoding mechanisms have to be applied in
+    /// order to obtain data in the media type referenced by the Content-Type
+    /// header field.  Content-Encoding is primarily used to allow a
+    /// representation's data to be compressed without losing the identity of
+    /// its underlying media type.
+    /// 
+    /// # ABNF
+    /// ```plain
+    /// Content-Encoding = 1#content-coding
+    /// ```
+    /// 
+    /// # Example values
+    /// * `gzip`
+    /// 
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, ContentEncoding, Encoding};
+    /// 
+    /// let mut headers = Headers::new();
+    /// headers.set(ContentEncoding(vec![Encoding::Chunked]));
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, ContentEncoding, Encoding};
+    /// 
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     ContentEncoding(vec![
+    ///         Encoding::Gzip,
+    ///         Encoding::Chunked,
+    ///     ])
+    /// );
+    /// ```
     (ContentEncoding, "Content-Encoding") => (Encoding)+
 
     test_content_encoding {

--- a/src/header/common/content_language.rs
+++ b/src/header/common/content_language.rs
@@ -2,54 +2,54 @@ use language_tags::LanguageTag;
 use header::QualityItem;
 
 header! {
-    #[doc="`Content-Language` header, defined in"]
-    #[doc="[RFC7231](https://tools.ietf.org/html/rfc7231#section-3.1.3.2)"]
-    #[doc=""]
-    #[doc="The `Content-Language` header field describes the natural language(s)"]
-    #[doc="of the intended audience for the representation.  Note that this"]
-    #[doc="might not be equivalent to all the languages used within the"]
-    #[doc="representation."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Content-Language = 1#language-tag"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `da`"]
-    #[doc="* `mi, en`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# #[macro_use] extern crate language_tags;"]
-    #[doc="# use hyper::header::{Headers, ContentLanguage, qitem};"]
-    #[doc="# "]
-    #[doc="# fn main() {"]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    ContentLanguage(vec!["]
-    #[doc="        qitem(langtag!(en)),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="# }"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# #[macro_use] extern crate language_tags;"]
-    #[doc="# use hyper::header::{Headers, ContentLanguage, qitem};"]
-    #[doc="# "]
-    #[doc="# fn main() {"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    ContentLanguage(vec!["]
-    #[doc="        qitem(langtag!(da)),"]
-    #[doc="        qitem(langtag!(en;;;GB)),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="# }"]
-    #[doc="```"]
+    /// `Content-Language` header, defined in
+    /// [RFC7231](https://tools.ietf.org/html/rfc7231#section-3.1.3.2)
+    /// 
+    /// The `Content-Language` header field describes the natural language(s)
+    /// of the intended audience for the representation.  Note that this
+    /// might not be equivalent to all the languages used within the
+    /// representation.
+    /// 
+    /// # ABNF
+    /// ```plain
+    /// Content-Language = 1#language-tag
+    /// ```
+    /// 
+    /// # Example values
+    /// * `da`
+    /// * `mi, en`
+    /// 
+    /// # Examples
+    /// ```
+    /// # extern crate hyper;
+    /// # #[macro_use] extern crate language_tags;
+    /// # use hyper::header::{Headers, ContentLanguage, qitem};
+    /// # 
+    /// # fn main() {
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     ContentLanguage(vec![
+    ///         qitem(langtag!(en)),
+    ///     ])
+    /// );
+    /// # }
+    /// ```
+    /// ```
+    /// # extern crate hyper;
+    /// # #[macro_use] extern crate language_tags;
+    /// # use hyper::header::{Headers, ContentLanguage, qitem};
+    /// # 
+    /// # fn main() {
+    /// 
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     ContentLanguage(vec![
+    ///         qitem(langtag!(da)),
+    ///         qitem(langtag!(en;;;GB)),
+    ///     ])
+    /// );
+    /// # }
+    /// ```
     (ContentLanguage, "Content-Language") => (QualityItem<LanguageTag>)+
 
     test_content_language {

--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -2,33 +2,33 @@ use std::fmt;
 
 use header::{HeaderFormat, Header, parsing};
 
-#[doc="`Content-Length` header, defined in"]
-#[doc="[RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.2)"]
-#[doc=""]
-#[doc="When a message does not have a `Transfer-Encoding` header field, a"]
-#[doc="Content-Length header field can provide the anticipated size, as a"]
-#[doc="decimal number of octets, for a potential payload body.  For messages"]
-#[doc="that do include a payload body, the Content-Length field-value"]
-#[doc="provides the framing information necessary for determining where the"]
-#[doc="body (and message) ends.  For messages that do not include a payload"]
-#[doc="body, the Content-Length indicates the size of the selected"]
-#[doc="representation."]
-#[doc=""]
-#[doc="# ABNF"]
-#[doc="```plain"]
-#[doc="Content-Length = 1*DIGIT"]
-#[doc="```"]
-#[doc=""]
-#[doc="# Example values"]
-#[doc="* `3495`"]
-#[doc=""]
-#[doc="# Example"]
-#[doc="```"]
-#[doc="use hyper::header::{Headers, ContentLength};"]
-#[doc=""]
-#[doc="let mut headers = Headers::new();"]
-#[doc="headers.set(ContentLength(1024u64));"]
-#[doc="```"]
+/// `Content-Length` header, defined in
+/// [RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.2)
+/// 
+/// When a message does not have a `Transfer-Encoding` header field, a
+/// Content-Length header field can provide the anticipated size, as a
+/// decimal number of octets, for a potential payload body.  For messages
+/// that do include a payload body, the Content-Length field-value
+/// provides the framing information necessary for determining where the
+/// body (and message) ends.  For messages that do not include a payload
+/// body, the Content-Length indicates the size of the selected
+/// representation.
+/// 
+/// # ABNF
+/// ```plain
+/// Content-Length = 1*DIGIT
+/// ```
+/// 
+/// # Example values
+/// * `3495`
+/// 
+/// # Example
+/// ```
+/// use hyper::header::{Headers, ContentLength};
+/// 
+/// let mut headers = Headers::new();
+/// headers.set(ContentLength(1024u64));
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ContentLength(pub u64);
 

--- a/src/header/common/content_range.rs
+++ b/src/header/common/content_range.rs
@@ -2,8 +2,8 @@ use std::fmt::{self, Display};
 use std::str::FromStr;
 
 header! {
-    #[doc="`Content-Range` header, defined in"]
-    #[doc="[RFC7233](http://tools.ietf.org/html/rfc7233#section-4.2)"]
+    /// `Content-Range` header, defined in
+    /// [RFC7233](http://tools.ietf.org/html/rfc7233#section-4.2)
     (ContentRange, "Content-Range") => [ContentRangeSpec]
 
     test_content_range {

--- a/src/header/common/content_type.rs
+++ b/src/header/common/content_type.rs
@@ -1,47 +1,47 @@
 use mime::Mime;
 
 header! {
-    #[doc="`Content-Type` header, defined in"]
-    #[doc="[RFC7231](http://tools.ietf.org/html/rfc7231#section-3.1.1.5)"]
-    #[doc=""]
-    #[doc="The `Content-Type` header field indicates the media type of the"]
-    #[doc="associated representation: either the representation enclosed in the"]
-    #[doc="message payload or the selected representation, as determined by the"]
-    #[doc="message semantics.  The indicated media type defines both the data"]
-    #[doc="format and how that data is intended to be processed by a recipient,"]
-    #[doc="within the scope of the received message semantics, after any content"]
-    #[doc="codings indicated by Content-Encoding are decoded."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Content-Type = media-type"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `text/html; charset=ISO-8859-4`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, ContentType};"]
-    #[doc="use hyper::mime::{Mime, TopLevel, SubLevel};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc=""]
-    #[doc="headers.set("]
-    #[doc="    ContentType(Mime(TopLevel::Text, SubLevel::Html, vec![]))"]
-    #[doc=");"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, ContentType};"]
-    #[doc="use hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc=""]
-    #[doc="headers.set("]
-    #[doc="    ContentType(Mime(TopLevel::Application, SubLevel::Json,"]
-    #[doc="                     vec![(Attr::Charset, Value::Utf8)]))"]
-    #[doc=");"]
-    #[doc="```"]
+    /// `Content-Type` header, defined in
+    /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-3.1.1.5)
+    /// 
+    /// The `Content-Type` header field indicates the media type of the
+    /// associated representation: either the representation enclosed in the
+    /// message payload or the selected representation, as determined by the
+    /// message semantics.  The indicated media type defines both the data
+    /// format and how that data is intended to be processed by a recipient,
+    /// within the scope of the received message semantics, after any content
+    /// codings indicated by Content-Encoding are decoded.
+    /// 
+    /// # ABNF
+    /// ```plain
+    /// Content-Type = media-type
+    /// ```
+    /// 
+    /// # Example values
+    /// * `text/html; charset=ISO-8859-4`
+    /// 
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, ContentType};
+    /// use hyper::mime::{Mime, TopLevel, SubLevel};
+    /// 
+    /// let mut headers = Headers::new();
+    /// 
+    /// headers.set(
+    ///     ContentType(Mime(TopLevel::Text, SubLevel::Html, vec![]))
+    /// );
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, ContentType};
+    /// use hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
+    /// 
+    /// let mut headers = Headers::new();
+    /// 
+    /// headers.set(
+    ///     ContentType(Mime(TopLevel::Application, SubLevel::Json,
+    ///                      vec![(Attr::Charset, Value::Utf8)]))
+    /// );
+    /// ```
     (ContentType, "Content-Type") => [Mime]
 
     test_content_type {

--- a/src/header/common/date.rs
+++ b/src/header/common/date.rs
@@ -1,33 +1,33 @@
 use header::HttpDate;
 
 header! {
-    #[doc="`Date` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.1.1.2)"]
-    #[doc=""]
-    #[doc="The `Date` header field represents the date and time at which the"]
-    #[doc="message was originated."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Date = HTTP-date"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `Tue, 15 Nov 1994 08:12:31 GMT`"]
-    #[doc=""]
-    #[doc="# Example"]
-    #[doc="```"]
-    #[doc="# extern crate time;"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# fn main() {"]
-    #[doc="// extern crate time;"]
-    #[doc=""]
-    #[doc="use hyper::header::{Headers, Date, HttpDate};"]
-    #[doc="use time;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(Date(HttpDate(time::now())));"]
-    #[doc="# }"]
-    #[doc="```"]
+    /// `Date` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.1.1.2)
+    /// 
+    /// The `Date` header field represents the date and time at which the
+    /// message was originated.
+    /// 
+    /// # ABNF
+    /// ```plain
+    /// Date = HTTP-date
+    /// ```
+    /// 
+    /// # Example values
+    /// * `Tue, 15 Nov 1994 08:12:31 GMT`
+    /// 
+    /// # Example
+    /// ```
+    /// # extern crate time;
+    /// # extern crate hyper;
+    /// # fn main() {
+    /// // extern crate time;
+    /// 
+    /// use hyper::header::{Headers, Date, HttpDate};
+    /// use time;
+    /// 
+    /// let mut headers = Headers::new();
+    /// headers.set(Date(HttpDate(time::now())));
+    /// # }
+    /// ```
     (Date, "Date") => [HttpDate]
 
     test_date {

--- a/src/header/common/etag.rs
+++ b/src/header/common/etag.rs
@@ -1,41 +1,41 @@
 use header::EntityTag;
 
 header! {
-    #[doc="`ETag` header, defined in [RFC7232](http://tools.ietf.org/html/rfc7232#section-2.3)"]
-    #[doc=""]
-    #[doc="The `ETag` header field in a response provides the current entity-tag"]
-    #[doc="for the selected representation, as determined at the conclusion of"]
-    #[doc="handling the request.  An entity-tag is an opaque validator for"]
-    #[doc="differentiating between multiple representations of the same"]
-    #[doc="resource, regardless of whether those multiple representations are"]
-    #[doc="due to resource state changes over time, content negotiation"]
-    #[doc="resulting in multiple representations being valid at the same time,"]
-    #[doc="or both.  An entity-tag consists of an opaque quoted string, possibly"]
-    #[doc="prefixed by a weakness indicator."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="ETag       = entity-tag"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `\"xyzzy\"`"]
-    #[doc="* `W/\"xyzzy\"`"]
-    #[doc="* `\"\"`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, ETag, EntityTag};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(ETag(EntityTag::new(false, \"xyzzy\".to_owned())));"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, ETag, EntityTag};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(ETag(EntityTag::new(true, \"xyzzy\".to_owned())));"]
-    #[doc="```"]
+    /// `ETag` header, defined in [RFC7232](http://tools.ietf.org/html/rfc7232#section-2.3)
+    ///
+    /// The `ETag` header field in a response provides the current entity-tag
+    /// for the selected representation, as determined at the conclusion of
+    /// handling the request.  An entity-tag is an opaque validator for
+    /// differentiating between multiple representations of the same
+    /// resource, regardless of whether those multiple representations are
+    /// due to resource state changes over time, content negotiation
+    /// resulting in multiple representations being valid at the same time,
+    /// or both.  An entity-tag consists of an opaque quoted string, possibly
+    /// prefixed by a weakness indicator.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// ETag       = entity-tag
+    /// ```
+    ///
+    /// # Example values
+    /// * `"xyzzy"`
+    /// * `W/"xyzzy"`
+    /// * `""`
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, ETag, EntityTag};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(ETag(EntityTag::new(false, "xyzzy".to_owned())));
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, ETag, EntityTag};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(ETag(EntityTag::new(true, "xyzzy".to_owned())));
+    /// ```
     (ETag, "ETag") => [EntityTag]
 
     test_etag {

--- a/src/header/common/expires.rs
+++ b/src/header/common/expires.rs
@@ -1,37 +1,37 @@
 use header::HttpDate;
 
 header! {
-    #[doc="`Expires` header, defined in [RFC7234](http://tools.ietf.org/html/rfc7234#section-5.3)"]
-    #[doc=""]
-    #[doc="The `Expires` header field gives the date/time after which the"]
-    #[doc="response is considered stale."]
-    #[doc=""]
-    #[doc="The presence of an Expires field does not imply that the original"]
-    #[doc="resource will change or cease to exist at, before, or after that"]
-    #[doc="time."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Expires = HTTP-date"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `Thu, 01 Dec 1994 16:00:00 GMT`"]
-    #[doc=""]
-    #[doc="# Example"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# extern crate time;"]
-    #[doc="# fn main() {"]
-    #[doc="// extern crate time;"]
-    #[doc=""]
-    #[doc="use hyper::header::{Headers, Expires, HttpDate};"]
-    #[doc="use time::{self, Duration};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(Expires(HttpDate(time::now() + Duration::days(1))));"]
-    #[doc="# }"]
-    #[doc="```"]
+    /// `Expires` header, defined in [RFC7234](http://tools.ietf.org/html/rfc7234#section-5.3)
+    /// 
+    /// The `Expires` header field gives the date/time after which the
+    /// response is considered stale.
+    /// 
+    /// The presence of an Expires field does not imply that the original
+    /// resource will change or cease to exist at, before, or after that
+    /// time.
+    /// 
+    /// # ABNF
+    /// ```plain
+    /// Expires = HTTP-date
+    /// ```
+    /// 
+    /// # Example values
+    /// * `Thu, 01 Dec 1994 16:00:00 GMT`
+    /// 
+    /// # Example
+    /// ```
+    /// # extern crate hyper;
+    /// # extern crate time;
+    /// # fn main() {
+    /// // extern crate time;
+    /// 
+    /// use hyper::header::{Headers, Expires, HttpDate};
+    /// use time::{self, Duration};
+    /// 
+    /// let mut headers = Headers::new();
+    /// headers.set(Expires(HttpDate(time::now() + Duration::days(1))));
+    /// # }
+    /// ```
     (Expires, "Expires") => [HttpDate]
 
     test_expires {

--- a/src/header/common/from.rs
+++ b/src/header/common/from.rs
@@ -1,22 +1,22 @@
 header! {
-    #[doc="`From` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.5.1)"]
-    #[doc=""]
-    #[doc="The `From` header field contains an Internet email address for a"]
-    #[doc="human user who controls the requesting user agent.  The address ought"]
-    #[doc="to be machine-usable."]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="From    = mailbox"]
-    #[doc="mailbox = <mailbox, see [RFC5322], Section 3.4>"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, From};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(From(\"webmaster@example.org\".to_owned()));"]
-    #[doc="```"]
+    /// `From` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.5.1)
+    ///
+    /// The `From` header field contains an Internet email address for a
+    /// human user who controls the requesting user agent.  The address ought
+    /// to be machine-usable.
+    /// # ABNF
+    /// ```plain
+    /// From    = mailbox
+    /// mailbox = <mailbox, see [RFC5322], Section 3.4>
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use hyper::header::{Headers, From};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(From("webmaster@example.org".to_owned()));
+    /// ```
     // FIXME: Maybe use mailbox?
     (From, "From") => [String]
 

--- a/src/header/common/if_match.rs
+++ b/src/header/common/if_match.rs
@@ -1,49 +1,49 @@
 use header::EntityTag;
 
 header! {
-    #[doc="`If-Match` header, defined in"]
-    #[doc="[RFC7232](https://tools.ietf.org/html/rfc7232#section-3.1)"]
-    #[doc=""]
-    #[doc="The `If-Match` header field makes the request method conditional on"]
-    #[doc="the recipient origin server either having at least one current"]
-    #[doc="representation of the target resource, when the field-value is \"*\","]
-    #[doc="or having a current representation of the target resource that has an"]
-    #[doc="entity-tag matching a member of the list of entity-tags provided in"]
-    #[doc="the field-value."]
-    #[doc=""]
-    #[doc="An origin server MUST use the strong comparison function when"]
-    #[doc="comparing entity-tags for `If-Match`, since the client"]
-    #[doc="intends this precondition to prevent the method from being applied if"]
-    #[doc="there have been any changes to the representation data."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="If-Match = \"*\" / 1#entity-tag"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `\"xyzzy\"`"]
-    #[doc="* \"xyzzy\", \"r2d2xxxx\", \"c3piozzzz\""]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, IfMatch};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(IfMatch::Any);"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, IfMatch, EntityTag};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    IfMatch::Items(vec!["]
-    #[doc="        EntityTag::new(false, \"xyzzy\".to_owned()),"]
-    #[doc="        EntityTag::new(false, \"foobar\".to_owned()),"]
-    #[doc="        EntityTag::new(false, \"bazquux\".to_owned()),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
+    /// `If-Match` header, defined in
+    /// [RFC7232](https://tools.ietf.org/html/rfc7232#section-3.1)
+    ///
+    /// The `If-Match` header field makes the request method conditional on
+    /// the recipient origin server either having at least one current
+    /// representation of the target resource, when the field-value is "*",
+    /// or having a current representation of the target resource that has an
+    /// entity-tag matching a member of the list of entity-tags provided in
+    /// the field-value.
+    ///
+    /// An origin server MUST use the strong comparison function when
+    /// comparing entity-tags for `If-Match`, since the client
+    /// intends this precondition to prevent the method from being applied if
+    /// there have been any changes to the representation data.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// If-Match = "*" / 1#entity-tag
+    /// ```
+    ///
+    /// # Example values
+    /// * `"xyzzy"`
+    /// * "xyzzy", "r2d2xxxx", "c3piozzzz"
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, IfMatch};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(IfMatch::Any);
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, IfMatch, EntityTag};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     IfMatch::Items(vec![
+    ///         EntityTag::new(false, "xyzzy".to_owned()),
+    ///         EntityTag::new(false, "foobar".to_owned()),
+    ///         EntityTag::new(false, "bazquux".to_owned()),
+    ///     ])
+    /// );
+    /// ```
     (IfMatch, "If-Match") => {Any / (EntityTag)+}
 
     test_if_match {

--- a/src/header/common/if_modified_since.rs
+++ b/src/header/common/if_modified_since.rs
@@ -1,37 +1,37 @@
 use header::HttpDate;
 
 header! {
-    #[doc="`If-Modified-Since` header, defined in"]
-    #[doc="[RFC7232](http://tools.ietf.org/html/rfc7232#section-3.3)"]
-    #[doc=""]
-    #[doc="The `If-Modified-Since` header field makes a GET or HEAD request"]
-    #[doc="method conditional on the selected representation's modification date"]
-    #[doc="being more recent than the date provided in the field-value."]
-    #[doc="Transfer of the selected representation's data is avoided if that"]
-    #[doc="data has not changed."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="If-Unmodified-Since = HTTP-date"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `Sat, 29 Oct 1994 19:43:31 GMT`"]
-    #[doc=""]
-    #[doc="# Example"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# extern crate time;"]
-    #[doc="# fn main() {"]
-    #[doc="// extern crate time;"]
-    #[doc=""]
-    #[doc="use hyper::header::{Headers, IfModifiedSince, HttpDate};"]
-    #[doc="use time::{self, Duration};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(IfModifiedSince(HttpDate(time::now() - Duration::days(1))));"]
-    #[doc="# }"]
-    #[doc="```"]
+    /// `If-Modified-Since` header, defined in
+    /// [RFC7232](http://tools.ietf.org/html/rfc7232#section-3.3)
+    /// 
+    /// The `If-Modified-Since` header field makes a GET or HEAD request
+    /// method conditional on the selected representation's modification date
+    /// being more recent than the date provided in the field-value.
+    /// Transfer of the selected representation's data is avoided if that
+    /// data has not changed.
+    /// 
+    /// # ABNF
+    /// ```plain
+    /// If-Unmodified-Since = HTTP-date
+    /// ```
+    /// 
+    /// # Example values
+    /// * `Sat, 29 Oct 1994 19:43:31 GMT`
+    /// 
+    /// # Example
+    /// ```
+    /// # extern crate hyper;
+    /// # extern crate time;
+    /// # fn main() {
+    /// // extern crate time;
+    /// 
+    /// use hyper::header::{Headers, IfModifiedSince, HttpDate};
+    /// use time::{self, Duration};
+    /// 
+    /// let mut headers = Headers::new();
+    /// headers.set(IfModifiedSince(HttpDate(time::now() - Duration::days(1))));
+    /// # }
+    /// ```
     (IfModifiedSince, "If-Modified-Since") => [HttpDate]
 
     test_if_modified_since {

--- a/src/header/common/if_none_match.rs
+++ b/src/header/common/if_none_match.rs
@@ -1,51 +1,51 @@
 use header::EntityTag;
 
 header! {
-    #[doc="`If-None-Match` header, defined in"]
-    #[doc="[RFC7232](https://tools.ietf.org/html/rfc7232#section-3.2)"]
-    #[doc=""]
-    #[doc="The `If-None-Match` header field makes the request method conditional"]
-    #[doc="on a recipient cache or origin server either not having any current"]
-    #[doc="representation of the target resource, when the field-value is \"*\","]
-    #[doc="or having a selected representation with an entity-tag that does not"]
-    #[doc="match any of those listed in the field-value."]
-    #[doc=""]
-    #[doc="A recipient MUST use the weak comparison function when comparing"]
-    #[doc="entity-tags for If-None-Match (Section 2.3.2), since weak entity-tags"]
-    #[doc="can be used for cache validation even if there have been changes to"]
-    #[doc="the representation data."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="If-None-Match = \"*\" / 1#entity-tag"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `\"xyzzy\"`"]
-    #[doc="* `W/\"xyzzy\"`"]
-    #[doc="* `\"xyzzy\", \"r2d2xxxx\", \"c3piozzzz\"`"]
-    #[doc="* `W/\"xyzzy\", W/\"r2d2xxxx\", W/\"c3piozzzz\"`"]
-    #[doc="* `*`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, IfNoneMatch};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(IfNoneMatch::Any);"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, IfNoneMatch, EntityTag};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    IfNoneMatch::Items(vec!["]
-    #[doc="        EntityTag::new(false, \"xyzzy\".to_owned()),"]
-    #[doc="        EntityTag::new(false, \"foobar\".to_owned()),"]
-    #[doc="        EntityTag::new(false, \"bazquux\".to_owned()),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
+    /// `If-None-Match` header, defined in
+    /// [RFC7232](https://tools.ietf.org/html/rfc7232#section-3.2)
+    ///
+    /// The `If-None-Match` header field makes the request method conditional
+    /// on a recipient cache or origin server either not having any current
+    /// representation of the target resource, when the field-value is "*",
+    /// or having a selected representation with an entity-tag that does not
+    /// match any of those listed in the field-value.
+    ///
+    /// A recipient MUST use the weak comparison function when comparing
+    /// entity-tags for If-None-Match (Section 2.3.2), since weak entity-tags
+    /// can be used for cache validation even if there have been changes to
+    /// the representation data.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// If-None-Match = "*" / 1#entity-tag
+    /// ```
+    ///
+    /// # Example values
+    /// * `"xyzzy"`
+    /// * `W/"xyzzy"`
+    /// * `"xyzzy", "r2d2xxxx", "c3piozzzz"`
+    /// * `W/"xyzzy", W/"r2d2xxxx", W/"c3piozzzz"`
+    /// * `*`
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, IfNoneMatch};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(IfNoneMatch::Any);
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, IfNoneMatch, EntityTag};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     IfNoneMatch::Items(vec![
+    ///         EntityTag::new(false, "xyzzy".to_owned()),
+    ///         EntityTag::new(false, "foobar".to_owned()),
+    ///         EntityTag::new(false, "bazquux".to_owned()),
+    ///     ])
+    /// );
+    /// ```
     (IfNoneMatch, "If-None-Match") => {Any / (EntityTag)+}
 
     test_if_none_match {

--- a/src/header/common/if_unmodified_since.rs
+++ b/src/header/common/if_unmodified_since.rs
@@ -1,37 +1,37 @@
 use header::HttpDate;
 
 header! {
-    #[doc="`If-Unmodified-Since` header, defined in"]
-    #[doc="[RFC7232](http://tools.ietf.org/html/rfc7232#section-3.4)"]
-    #[doc=""]
-    #[doc="The `If-Unmodified-Since` header field makes the request method"]
-    #[doc="conditional on the selected representation's last modification date"]
-    #[doc="being earlier than or equal to the date provided in the field-value."]
-    #[doc="This field accomplishes the same purpose as If-Match for cases where"]
-    #[doc="the user agent does not have an entity-tag for the representation."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="If-Unmodified-Since = HTTP-date"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `Sat, 29 Oct 1994 19:43:31 GMT`"]
-    #[doc=""]
-    #[doc="# Example"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# extern crate time;"]
-    #[doc="# fn main() {"]
-    #[doc="// extern crate time;"]
-    #[doc=""]
-    #[doc="use hyper::header::{Headers, IfUnmodifiedSince, HttpDate};"]
-    #[doc="use time::{self, Duration};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(IfUnmodifiedSince(HttpDate(time::now() - Duration::days(1))));"]
-    #[doc="# }"]
-    #[doc="```"]
+    /// `If-Unmodified-Since` header, defined in
+    /// [RFC7232](http://tools.ietf.org/html/rfc7232#section-3.4)
+    /// 
+    /// The `If-Unmodified-Since` header field makes the request method
+    /// conditional on the selected representation's last modification date
+    /// being earlier than or equal to the date provided in the field-value.
+    /// This field accomplishes the same purpose as If-Match for cases where
+    /// the user agent does not have an entity-tag for the representation.
+    /// 
+    /// # ABNF
+    /// ```plain
+    /// If-Unmodified-Since = HTTP-date
+    /// ```
+    /// 
+    /// # Example values
+    /// * `Sat, 29 Oct 1994 19:43:31 GMT`
+    /// 
+    /// # Example
+    /// ```
+    /// # extern crate hyper;
+    /// # extern crate time;
+    /// # fn main() {
+    /// // extern crate time;
+    /// 
+    /// use hyper::header::{Headers, IfUnmodifiedSince, HttpDate};
+    /// use time::{self, Duration};
+    /// 
+    /// let mut headers = Headers::new();
+    /// headers.set(IfUnmodifiedSince(HttpDate(time::now() - Duration::days(1))));
+    /// # }
+    /// ```
     (IfUnmodifiedSince, "If-Unmodified-Since") => [HttpDate]
 
     test_if_unmodified_since {

--- a/src/header/common/last_modified.rs
+++ b/src/header/common/last_modified.rs
@@ -1,36 +1,36 @@
 use header::HttpDate;
 
 header! {
-    #[doc="`Last-Modified` header, defined in"]
-    #[doc="[RFC7232](http://tools.ietf.org/html/rfc7232#section-2.2)"]
-    #[doc=""]
-    #[doc="The `Last-Modified` header field in a response provides a timestamp"]
-    #[doc="indicating the date and time at which the origin server believes the"]
-    #[doc="selected representation was last modified, as determined at the"]
-    #[doc="conclusion of handling the request."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Expires = HTTP-date"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `Sat, 29 Oct 1994 19:43:31 GMT`"]
-    #[doc=""]
-    #[doc="# Example"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# extern crate time;"]
-    #[doc="# fn main() {"]
-    #[doc="// extern crate time;"]
-    #[doc=""]
-    #[doc="use hyper::header::{Headers, LastModified, HttpDate};"]
-    #[doc="use time::{self, Duration};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(LastModified(HttpDate(time::now() - Duration::days(1))));"]
-    #[doc="# }"]
-    #[doc="```"]
+    /// `Last-Modified` header, defined in
+    /// [RFC7232](http://tools.ietf.org/html/rfc7232#section-2.2)
+    /// 
+    /// The `Last-Modified` header field in a response provides a timestamp
+    /// indicating the date and time at which the origin server believes the
+    /// selected representation was last modified, as determined at the
+    /// conclusion of handling the request.
+    /// 
+    /// # ABNF
+    /// ```plain
+    /// Expires = HTTP-date
+    /// ```
+    /// 
+    /// # Example values
+    /// * `Sat, 29 Oct 1994 19:43:31 GMT`
+    /// 
+    /// # Example
+    /// ```
+    /// # extern crate hyper;
+    /// # extern crate time;
+    /// # fn main() {
+    /// // extern crate time;
+    /// 
+    /// use hyper::header::{Headers, LastModified, HttpDate};
+    /// use time::{self, Duration};
+    /// 
+    /// let mut headers = Headers::new();
+    /// headers.set(LastModified(HttpDate(time::now() - Duration::days(1))));
+    /// # }
+    /// ```
     (LastModified, "Last-Modified") => [HttpDate]
 
     test_last_modified {

--- a/src/header/common/location.rs
+++ b/src/header/common/location.rs
@@ -1,34 +1,34 @@
 header! {
-    #[doc="`Location` header, defined in"]
-    #[doc="[RFC7231](http://tools.ietf.org/html/rfc7231#section-7.1.2)"]
-    #[doc=""]
-    #[doc="The `Location` header field is used in some responses to refer to a"]
-    #[doc="specific resource in relation to the response.  The type of"]
-    #[doc="relationship is defined by the combination of request method and"]
-    #[doc="status code semantics."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Location = URI-reference"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `/People.html#tim`"]
-    #[doc="* `http://www.example.net/index.html`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Location};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(Location(\"/People.html#tim\".to_owned()));"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Location};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(Location(\"http://www.example.com/index.html\".to_owned()));"]
-    #[doc="```"]
+    /// `Location` header, defined in
+    /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.1.2)
+    ///
+    /// The `Location` header field is used in some responses to refer to a
+    /// specific resource in relation to the response.  The type of
+    /// relationship is defined by the combination of request method and
+    /// status code semantics.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Location = URI-reference
+    /// ```
+    ///
+    /// # Example values
+    /// * `/People.html#tim`
+    /// * `http://www.example.net/index.html`
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, Location};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(Location("/People.html#tim".to_owned()));
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, Location};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(Location("http://www.example.com/index.html".to_owned()));
+    /// ```
     // TODO: Use URL
     (Location, "Location") => [String]
 

--- a/src/header/common/referer.rs
+++ b/src/header/common/referer.rs
@@ -1,34 +1,34 @@
 header! {
-    #[doc="`Referer` header, defined in"]
-    #[doc="[RFC7231](http://tools.ietf.org/html/rfc7231#section-5.5.2)"]
-    #[doc=""]
-    #[doc="The `Referer` [sic] header field allows the user agent to specify a"]
-    #[doc="URI reference for the resource from which the target URI was obtained"]
-    #[doc="(i.e., the \"referrer\", though the field name is misspelled).  A user"]
-    #[doc="agent MUST NOT include the fragment and userinfo components of the"]
-    #[doc="URI reference, if any, when generating the Referer field value."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Referer = absolute-URI / partial-URI"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `http://www.example.org/hypertext/Overview.html`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Referer};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(Referer(\"/People.html#tim\".to_owned()));"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Referer};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(Referer(\"http://www.example.com/index.html\".to_owned()));"]
-    #[doc="```"]
+    /// `Referer` header, defined in
+    /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.5.2)
+    ///
+    /// The `Referer` [sic] header field allows the user agent to specify a
+    /// URI reference for the resource from which the target URI was obtained
+    /// (i.e., the "referrer", though the field name is misspelled).  A user
+    /// agent MUST NOT include the fragment and userinfo components of the
+    /// URI reference, if any, when generating the Referer field value.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Referer = absolute-URI / partial-URI
+    /// ```
+    ///
+    /// # Example values
+    /// * `http://www.example.org/hypertext/Overview.html`
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, Referer};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(Referer("/People.html#tim".to_owned()));
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, Referer};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(Referer("http://www.example.com/index.html".to_owned()));
+    /// ```
     // TODO Use URL
     (Referer, "Referer") => [String]
 

--- a/src/header/common/server.rs
+++ b/src/header/common/server.rs
@@ -1,29 +1,29 @@
 header! {
-    #[doc="`Server` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.4.2)"]
-    #[doc=""]
-    #[doc="The `Server` header field contains information about the software"]
-    #[doc="used by the origin server to handle the request, which is often used"]
-    #[doc="by clients to help identify the scope of reported interoperability"]
-    #[doc="problems, to work around or tailor requests to avoid particular"]
-    #[doc="server limitations, and for analytics regarding server or operating"]
-    #[doc="system use.  An origin server MAY generate a Server field in its"]
-    #[doc="responses."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Server = product *( RWS ( product / comment ) )"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `CERN/3.0 libwww/2.17`"]
-    #[doc=""]
-    #[doc="# Example"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Server};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(Server(\"hyper/0.5.2\".to_owned()));"]
-    #[doc="```"]
+    /// `Server` header, defined in [RFC7231](http://tools.ietf.org/html/rfc7231#section-7.4.2)
+    ///
+    /// The `Server` header field contains information about the software
+    /// used by the origin server to handle the request, which is often used
+    /// by clients to help identify the scope of reported interoperability
+    /// problems, to work around or tailor requests to avoid particular
+    /// server limitations, and for analytics regarding server or operating
+    /// system use.  An origin server MAY generate a Server field in its
+    /// responses.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Server = product *( RWS ( product / comment ) )
+    /// ```
+    ///
+    /// # Example values
+    /// * `CERN/3.0 libwww/2.17`
+    ///
+    /// # Example
+    /// ```
+    /// use hyper::header::{Headers, Server};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(Server("hyper/0.5.2".to_owned()));
+    /// ```
     // TODO: Maybe parse as defined in the spec?
     (Server, "Server") => [String]
 

--- a/src/header/common/transfer_encoding.rs
+++ b/src/header/common/transfer_encoding.rs
@@ -1,34 +1,34 @@
 use header::Encoding;
 
 header! {
-    #[doc="`Transfer-Encoding` header, defined in"]
-    #[doc="[RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.1)"]
-    #[doc=""]
-    #[doc="The `Transfer-Encoding` header field lists the transfer coding names"]
-    #[doc="corresponding to the sequence of transfer codings that have been (or"]
-    #[doc="will be) applied to the payload body in order to form the message"]
-    #[doc="body."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Transfer-Encoding = 1#transfer-coding"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `gzip, chunked`"]
-    #[doc=""]
-    #[doc="# Example"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, TransferEncoding, Encoding};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    TransferEncoding(vec!["]
-    #[doc="        Encoding::Gzip,"]
-    #[doc="        Encoding::Chunked,"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
+    /// `Transfer-Encoding` header, defined in
+    /// [RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.1)
+    /// 
+    /// The `Transfer-Encoding` header field lists the transfer coding names
+    /// corresponding to the sequence of transfer codings that have been (or
+    /// will be) applied to the payload body in order to form the message
+    /// body.
+    /// 
+    /// # ABNF
+    /// ```plain
+    /// Transfer-Encoding = 1#transfer-coding
+    /// ```
+    /// 
+    /// # Example values
+    /// * `gzip, chunked`
+    /// 
+    /// # Example
+    /// ```
+    /// use hyper::header::{Headers, TransferEncoding, Encoding};
+    /// 
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     TransferEncoding(vec![
+    ///         Encoding::Gzip,
+    ///         Encoding::Chunked,
+    ///     ])
+    /// );
+    /// ```
     (TransferEncoding, "Transfer-Encoding") => (Encoding)+
 
     transfer_encoding {

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -3,51 +3,51 @@ use std::str::FromStr;
 use unicase::UniCase;
 
 header! {
-    #[doc="`Upgrade` header, defined in [RFC7230](http://tools.ietf.org/html/rfc7230#section-6.7)"]
-    #[doc=""]
-    #[doc="The `Upgrade` header field is intended to provide a simple mechanism"]
-    #[doc="for transitioning from HTTP/1.1 to some other protocol on the same"]
-    #[doc="connection.  A client MAY send a list of protocols in the Upgrade"]
-    #[doc="header field of a request to invite the server to switch to one or"]
-    #[doc="more of those protocols, in order of descending preference, before"]
-    #[doc="sending the final response.  A server MAY ignore a received Upgrade"]
-    #[doc="header field if it wishes to continue using the current protocol on"]
-    #[doc="that connection.  Upgrade cannot be used to insist on a protocol"]
-    #[doc="change."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Upgrade          = 1#protocol"]
-    #[doc=""]
-    #[doc="protocol         = protocol-name [\"/\" protocol-version]"]
-    #[doc="protocol-name    = token"]
-    #[doc="protocol-version = token"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `HTTP/2.0, SHTTP/1.3, IRC/6.9, RTA/x11`"]
-    #[doc=""]
-    #[doc="# Examples"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Upgrade, Protocol, ProtocolName};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(Upgrade(vec![Protocol::new(ProtocolName::WebSocket, None)]));"]
-    #[doc="```"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Upgrade, Protocol, ProtocolName};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    Upgrade(vec!["]
-    #[doc="        Protocol::new(ProtocolName::Http, Some(\"2.0\".to_owned())),"]
-    #[doc="        Protocol::new(ProtocolName::Unregistered(\"SHTTP\".to_owned()),"]
-    #[doc="            Some(\"1.3\".to_owned())),"]
-    #[doc="        Protocol::new(ProtocolName::Unregistered(\"IRC\".to_owned()),"]
-    #[doc="            Some(\"6.9\".to_owned())),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="```"]
+    /// `Upgrade` header, defined in [RFC7230](http://tools.ietf.org/html/rfc7230#section-6.7)
+    ///
+    /// The `Upgrade` header field is intended to provide a simple mechanism
+    /// for transitioning from HTTP/1.1 to some other protocol on the same
+    /// connection.  A client MAY send a list of protocols in the Upgrade
+    /// header field of a request to invite the server to switch to one or
+    /// more of those protocols, in order of descending preference, before
+    /// sending the final response.  A server MAY ignore a received Upgrade
+    /// header field if it wishes to continue using the current protocol on
+    /// that connection.  Upgrade cannot be used to insist on a protocol
+    /// change.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Upgrade          = 1#protocol
+    ///
+    /// protocol         = protocol-name ["/" protocol-version]
+    /// protocol-name    = token
+    /// protocol-version = token
+    /// ```
+    ///
+    /// # Example values
+    /// * `HTTP/2.0, SHTTP/1.3, IRC/6.9, RTA/x11`
+    ///
+    /// # Examples
+    /// ```
+    /// use hyper::header::{Headers, Upgrade, Protocol, ProtocolName};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(Upgrade(vec![Protocol::new(ProtocolName::WebSocket, None)]));
+    /// ```
+    /// ```
+    /// use hyper::header::{Headers, Upgrade, Protocol, ProtocolName};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     Upgrade(vec![
+    ///         Protocol::new(ProtocolName::Http, Some("2.0".to_owned())),
+    ///         Protocol::new(ProtocolName::Unregistered("SHTTP".to_owned()),
+    ///             Some("1.3".to_owned())),
+    ///         Protocol::new(ProtocolName::Unregistered("IRC".to_owned()),
+    ///             Some("6.9".to_owned())),
+    ///     ])
+    /// );
+    /// ```
     (Upgrade, "Upgrade") => (Protocol)+
 
     test_upgrade {

--- a/src/header/common/user_agent.rs
+++ b/src/header/common/user_agent.rs
@@ -1,36 +1,36 @@
 header! {
-    #[doc="`User-Agent` header, defined in"]
-    #[doc="[RFC7231](http://tools.ietf.org/html/rfc7231#section-5.5.3)"]
-    #[doc=""]
-    #[doc="The `User-Agent` header field contains information about the user"]
-    #[doc="agent originating the request, which is often used by servers to help"]
-    #[doc="identify the scope of reported interoperability problems, to work"]
-    #[doc="around or tailor responses to avoid particular user agent"]
-    #[doc="limitations, and for analytics regarding browser or operating system"]
-    #[doc="use.  A user agent SHOULD send a User-Agent field in each request"]
-    #[doc="unless specifically configured not to do so."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="User-Agent = product *( RWS ( product / comment ) )"]
-    #[doc="product         = token [\"/\" product-version]"]
-    #[doc="product-version = token"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `CERN-LineMode/2.15 libwww/2.17b3`"]
-    #[doc="* `Bunnies`"]
-    #[doc=""]
-    #[doc="# Notes"]
-    #[doc="* The parser does not split the value"]
-    #[doc=""]
-    #[doc="# Example"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, UserAgent};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(UserAgent(\"hyper/0.5.2\".to_owned()));"]
-    #[doc="```"]
+    /// `User-Agent` header, defined in
+    /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-5.5.3)
+    ///
+    /// The `User-Agent` header field contains information about the user
+    /// agent originating the request, which is often used by servers to help
+    /// identify the scope of reported interoperability problems, to work
+    /// around or tailor responses to avoid particular user agent
+    /// limitations, and for analytics regarding browser or operating system
+    /// use.  A user agent SHOULD send a User-Agent field in each request
+    /// unless specifically configured not to do so.
+    ///
+    /// # ABNF
+    /// ```plain
+    /// User-Agent = product *( RWS ( product / comment ) )
+    /// product         = token ["/" product-version]
+    /// product-version = token
+    /// ```
+    ///
+    /// # Example values
+    /// * `CERN-LineMode/2.15 libwww/2.17b3`
+    /// * `Bunnies`
+    ///
+    /// # Notes
+    /// * The parser does not split the value
+    ///
+    /// # Example
+    /// ```
+    /// use hyper::header::{Headers, UserAgent};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(UserAgent("hyper/0.5.2".to_owned()));
+    /// ```
     (UserAgent, "User-Agent") => [String]
 
     test_user_agent {

--- a/src/header/common/vary.rs
+++ b/src/header/common/vary.rs
@@ -1,50 +1,50 @@
 use unicase::UniCase;
 
 header! {
-    #[doc="`Vary` header, defined in [RFC7231](https://tools.ietf.org/html/rfc7231#section-7.1.4)"]
-    #[doc=""]
-    #[doc="The \"Vary\" header field in a response describes what parts of a"]
-    #[doc="request message, aside from the method, Host header field, and"]
-    #[doc="request target, might influence the origin server's process for"]
-    #[doc="selecting and representing this response.  The value consists of"]
-    #[doc="either a single asterisk (\"*\") or a list of header field names"]
-    #[doc="(case-insensitive)."]
-    #[doc=""]
-    #[doc="# ABNF"]
-    #[doc="```plain"]
-    #[doc="Vary = \"*\" / 1#field-name"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example values"]
-    #[doc="* `accept-encoding, accept-language`"]
-    #[doc=""]
-    #[doc="# Example"]
-    #[doc="```"]
-    #[doc="use hyper::header::{Headers, Vary};"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set(Vary::Any);"]
-    #[doc="```"]
-    #[doc=""]
-    #[doc="# Example"]
-    #[doc="```"]
-    #[doc="# extern crate hyper;"]
-    #[doc="# extern crate unicase;"]
-    #[doc="# fn main() {"]
-    #[doc="// extern crate unicase;"]
-    #[doc=""]
-    #[doc="use hyper::header::{Headers, Vary};"]
-    #[doc="use unicase::UniCase;"]
-    #[doc=""]
-    #[doc="let mut headers = Headers::new();"]
-    #[doc="headers.set("]
-    #[doc="    Vary::Items(vec!["]
-    #[doc="        UniCase(\"accept-encoding\".to_owned()),"]
-    #[doc="        UniCase(\"accept-language\".to_owned()),"]
-    #[doc="    ])"]
-    #[doc=");"]
-    #[doc="# }"]
-    #[doc="```"]
+    /// `Vary` header, defined in [RFC7231](https://tools.ietf.org/html/rfc7231#section-7.1.4)
+    ///
+    /// The "Vary" header field in a response describes what parts of a
+    /// request message, aside from the method, Host header field, and
+    /// request target, might influence the origin server's process for
+    /// selecting and representing this response.  The value consists of
+    /// either a single asterisk ("*") or a list of header field names
+    /// (case-insensitive).
+    ///
+    /// # ABNF
+    /// ```plain
+    /// Vary = "*" / 1#field-name
+    /// ```
+    ///
+    /// # Example values
+    /// * `accept-encoding, accept-language`
+    ///
+    /// # Example
+    /// ```
+    /// use hyper::header::{Headers, Vary};
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(Vary::Any);
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// # extern crate hyper;
+    /// # extern crate unicase;
+    /// # fn main() {
+    /// // extern crate unicase;
+    ///
+    /// use hyper::header::{Headers, Vary};
+    /// use unicase::UniCase;
+    ///
+    /// let mut headers = Headers::new();
+    /// headers.set(
+    ///     Vary::Items(vec![
+    ///         UniCase("accept-encoding".to_owned()),
+    ///         UniCase("accept-language".to_owned()),
+    ///     ])
+    /// );
+    /// # }
+    /// ```
     (Vary, "Vary") => {Any / (UniCase<String>)+}
 
     test_vary {


### PR DESCRIPTION
A bug (rust-lang/rust#23812) in rustc prevented the use of normal
comments inside macros but this has been fixed.