### PR TITLE
chore(cargo): Update url crate to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.1"
 traitobject = "0.0.1"
 typeable = "0.1"
 unicase = "1.0"
-url = "0.2"
+url = "0.5"
 
 [dependencies.cookie]
 version = "0.1"


### PR DESCRIPTION
~~A recent update in url triggered a version split in my application and
broke my build.~~

~~Since hyper is still compatible with 0.2, I think it might make sense to
still allow that version.~~