### PR TITLE
feat(headers): send headers back in set methods

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -263,10 +263,14 @@ impl<'a> RequestBuilder<'a> {
 
             match (can_have_body, body.as_ref()) {
                 (true, Some(body)) => match body.size() {
-                    Some(size) => req.headers_mut().set(ContentLength(size)),
+                    Some(size) => {
+                        req.headers_mut().set(ContentLength(size));
+                    },
                     None => (), // chunked, Request will add it automatically
                 },
-                (true, None) => req.headers_mut().set(ContentLength(0)),
+                (true, None) => {
+                    req.headers_mut().set(ContentLength(0));
+                },
                 _ => () // neither
             }
             let mut streaming = try!(req.start());

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -795,7 +795,7 @@ mod tests {
     #[bench]
     fn bench_headers_set(b: &mut Bencher) {
         let mut headers = Headers::new();
-        b.iter(|| headers.set(ContentLength(12)))
+        b.iter(|| { headers.set(ContentLength(12)); })
     }
 
     #[cfg(feature = "nightly")]

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -27,7 +27,7 @@
 //! fn main () {
 //!     let mut headers = Headers::new();
 //!
-//!     headers.set(XRequestGuid("a proper guid".to_owned()))
+//!     headers.set(XRequestGuid("a proper guid".to_owned()));
 //! }
 //! ```
 //!
@@ -212,10 +212,11 @@ impl Headers {
     /// Set a header field to the corresponding value.
     ///
     /// The field is determined by the type of the value being set.
-    pub fn set<H: Header + HeaderFormat>(&mut self, value: H) {
+    pub fn set<H: Header + HeaderFormat>(&mut self, value: H) -> &mut Headers {
         trace!("Headers.set( {:?}, {:?} )", header_name::<H>(), value);
         self.data.insert(UniCase(CowStr(Cow::Borrowed(header_name::<H>()))),
                          Item::new_typed(Box::new(value)));
+        self
     }
 
     /// Access the raw value of a header.
@@ -245,9 +246,10 @@ impl Headers {
     /// headers.set_raw("content-length", vec![b"5".to_vec()]);
     /// ```
     pub fn set_raw<K: Into<Cow<'static, str>> + fmt::Debug>(&mut self, name: K,
-            value: Vec<Vec<u8>>) {
+            value: Vec<Vec<u8>>) -> &mut Headers {
         trace!("Headers.set_raw( {:?}, {:?} )", name, value);
         self.data.insert(UniCase(CowStr(name.into())), Item::new_raw(value));
+        self
     }
 
     /// Remove a header set by set_raw
@@ -665,6 +667,22 @@ mod tests {
         let mut headers = Headers::new();
         headers.set(ContentLength(10));
         headers.set_raw("content-LENGTH", vec![b"20".to_vec()]);
+        assert_eq!(headers.get_raw("Content-length").unwrap(), &[b"20".to_vec()][..]);
+        assert_eq!(headers.get(), Some(&ContentLength(20)));
+    }
+
+    #[test]
+    fn test_chained_set_raw() {
+        let mut headers = Headers::new();
+        headers.set(ContentLength(10)).set_raw("content-LENGTH", vec![b"20".to_vec()]);
+        assert_eq!(headers.get_raw("Content-length").unwrap(), &[b"20".to_vec()][..]);
+        assert_eq!(headers.get(), Some(&ContentLength(20)));
+    }
+
+    #[test]
+    fn test_chained_set() {
+        let mut headers = Headers::new();
+        headers.set(ContentLength(10)).set(ContentLength(20));
         assert_eq!(headers.get_raw("Content-length").unwrap(), &[b"20".to_vec()][..]);
         assert_eq!(headers.get(), Some(&ContentLength(20)));
     }

--- a/src/http/h1.rs
+++ b/src/http/h1.rs
@@ -207,7 +207,7 @@ impl HttpMessage for Http11Message {
 
                             if encodings {
                                 head.headers.set(
-                                    header::TransferEncoding(vec![header::Encoding::Chunked]))
+                                    header::TransferEncoding(vec![header::Encoding::Chunked]));
                             }
                         }
 

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -112,7 +112,7 @@ impl<'a, W: Any> Response<'a, W> {
 
             if encodings {
                 self.headers.set::<header::TransferEncoding>(
-                    header::TransferEncoding(vec![header::Encoding::Chunked]))
+                    header::TransferEncoding(vec![header::Encoding::Chunked]));
             }
         }
 


### PR DESCRIPTION
Following #716 suggestion, allow the `set()` and `set_raw()` methods to be used in chain.

BREAKING CHANGE: This enforces the use of a semicolon after `set()` and set_raw() methods.

The needed changes in hyper do reflect the possible impact this can have.