### PR TITLE
Auto-set auth header if URL contains credentials

### DIFF
--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -4,6 +4,7 @@ use std::str::{FromStr, from_utf8};
 use std::ops::{Deref, DerefMut};
 use serialize::base64::{ToBase64, FromBase64, Standard, Config, Newline};
 use header::{Header, HeaderFormat};
+use url::Url;
 
 /// `Authorization` header, defined in [RFC7235](https://tools.ietf.org/html/rfc7235#section-4.2)
 ///
@@ -191,6 +192,20 @@ impl FromStr for Basic {
                 Err(::Error::Header)
             }
         }
+    }
+}
+
+impl Basic {
+    pub fn from_url(url: &Url) -> Option<Basic> {
+        if let Some(scheme) = url.relative_scheme_data() {
+            if scheme.username != "" {
+                return Some(Basic {
+                    username: scheme.username.clone(),
+                    password: scheme.password.clone(),
+                });
+            }
+        }
+        None
     }
 }
 

--- a/src/http/h1.rs
+++ b/src/http/h1.rs
@@ -129,6 +129,10 @@ impl HttpMessage for Http11Message {
         let mut res = Err(Error::from(io::Error::new(
                             io::ErrorKind::Other,
                             "")));
+        // Set basic authentication headers if the url contains credentials
+        if let Some(basic) = header::Basic::from_url(&head.url) {
+            head.headers.set(header::Authorization(basic));
+        }
         let mut method = None;
         self.stream.map_in_place(|stream: Stream| -> Stream {
             let stream = match stream {


### PR DESCRIPTION
The [URL spec](https://url.spec.whatwg.org/#concept-url-username)
has a concept of a URL's "username" and "password". Since rust-url implements
this spec, we should probably autoconvert instances of this username/password to
a `Basic` auth header.

Blocks https://github.com/servo/servo/pull/9625


Example to try out locally:

 
```rust
extern crate hyper;
extern crate url;
use std::io::Read;

use hyper::Client;
use hyper::header::Connection;
use url::Url;
fn main() {
    // Create a client.
    let mut client = Client::new();

    // Creating an outgoing request.
    let mut url = Url::parse("http://localhost:8000/").unwrap();
    if let Some(scheme_data) = url.relative_scheme_data_mut() {
        scheme_data.username = "manish".into();
        scheme_data.password= Some("hasanawesomepassword".into());
    }
    let mut res = client.get(url)
        // set a header
        .header(Connection::close())
        // let 'er go!
        .send().unwrap();

    // Read the Response.
    let mut body = String::new();
    res.read_to_string(&mut body).unwrap();

    println!("Response: {}", body);
}
```

r? @seanmonstar