### PR TITLE
Add Headers::content_type_charset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "hyper"
-version = "0.7.2"
+version = "0.7.3"
 description = "A modern HTTP library."
 readme = "README.md"
 documentation = "http://hyperium.github.io/hyper/hyper/index.html"


### PR DESCRIPTION
This particular parameter is arguably commonly used, and accessing it through other APIs requires a number of imports.

Do you think this is worth having here?