### PR TITLE
Fix README example so that it compiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ fn hello(_: Request, res: Response) {
     res.send(b"Hello World!").unwrap();
 }
 
+#[allow(unused_must_use)]
 fn main() {
     Server::http("127.0.0.1:3000").unwrap().handle(hello);
 }


### PR DESCRIPTION
I feel a little bad disabling warnings in example code, so suggestions welcome for improvement!

Without this, the error is:

```
src/main.rs:12:5: 12:59 warning: unused result which must be used, #[warn(unused_must_use)] on by default
src/main.rs:12     Server::http("127.0.0.1:3000").unwrap().handle(hello);
```