### PR TITLE
fix(buffer): prevent possible buffer overflow in `grow_zerofill`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -79,7 +79,7 @@ unsafe fn grow_zerofill(buf: &mut Vec<u8>, additional: usize) {
     use std::ptr;
     let len = buf.len();
     buf.set_len(len + additional);
-    ptr::write_bytes(buf.as_mut_ptr().offset(len as isize), 0, buf.len());
+    ptr::write_bytes(buf.as_mut_ptr().offset(len as isize), 0, additional);
 }
 
 impl<R: Read> Read for BufReader<R> {


### PR DESCRIPTION
in `maybe_reserve` we have such code

    let new = self.buf.capacity() - self.buf.len();
    unsafe { grow_zerofill(&mut self.buf, new) }

the original behavior of `grow_zerofill` in such case cause
rewriting the memory behind the allocated vector.