### PR TITLE
Remove now default 'sudo: false'.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
         - rust: stable
           env: FEATURES="--no-default-features"
 
-sudo: false
-
 cache:
     apt: true
     directories:


### PR DESCRIPTION
'sudo: false' is now default on Travis CI.