### PR TITLE
feat(client): add Proxy support

### DIFF
--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -102,22 +102,21 @@ impl<C: NetworkConnector<Stream=S>, S: NetworkStream + Send> NetworkConnector fo
     type Stream = PooledStream<S>;
     fn connect(&self, host: &str, port: u16, scheme: &str) -> ::Result<PooledStream<S>> {
         let key = key(host, port, scheme);
-        let mut locked = self.inner.lock().unwrap();
         let mut should_remove = false;
-        let inner = match locked.conns.get_mut(&key) {
+        let inner = match self.inner.lock().unwrap().conns.get_mut(&key) {
             Some(ref mut vec) => {
                 trace!("Pool had connection, using");
                 should_remove = vec.len() == 1;
                 vec.pop().unwrap()
             }
-            _ => PooledStreamInner {
+            None => PooledStreamInner {
                 key: key.clone(),
                 stream: try!(self.connector.connect(host, port, scheme)),
                 previous_response_expected_no_content: false,
             }
         };
         if should_remove {
-            locked.conns.remove(&key);
+            self.inner.lock().unwrap().conns.remove(&key);
         }
         Ok(PooledStream {
             inner: Some(inner),

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -133,6 +133,13 @@ pub struct PooledStream<S> {
     pool: Arc<Mutex<PoolImpl<S>>>,
 }
 
+impl<S: NetworkStream> PooledStream<S> {
+    /// Take the wrapped stream out of the pool completely.
+    pub fn into_inner(mut self) -> S {
+        self.inner.take().expect("PooledStream lost its inner stream").stream
+    }
+}
+
 #[derive(Debug)]
 struct PooledStreamInner<S> {
     key: Key,


### PR DESCRIPTION
This works by configuring proxy options on a `Client`, such as `client.set_proxy("http", "127.0.0.1", "8018")`.

Closes #531 