### PR TITLE
feat(ssl): enable hostname verification by default for OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ default-features = false
 version = "0.7"
 optional = true
 
+[dependencies.openssl-verify]
+version = "0.1"
+optional = true
+
 [dependencies.security-framework]
 version = "0.1.4"
 optional = true
@@ -49,6 +53,6 @@ env_logger = "0.3"
 
 [features]
 default = ["ssl"]
-ssl = ["openssl", "cookie/secure"]
+ssl = ["openssl", "openssl-verify", "cookie/secure"]
 serde-serialization = ["serde", "mime/serde"]
 nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,8 @@ extern crate time;
 #[macro_use] extern crate url;
 #[cfg(feature = "openssl")]
 extern crate openssl;
+#[cfg(feature = "openssl-verify")]
+extern crate openssl_verify;
 #[cfg(feature = "security-framework")]
 extern crate security_framework;
 #[cfg(feature = "serde-serialization")]


### PR DESCRIPTION
Additionally disables SSLv2 and SSLv3, as those are universally considered
unsafe.

Closes #472