### PR TITLE
fix(server): Switch Ssl to SslServer in bounds

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -532,7 +532,7 @@ pub struct HttpsListener<S: SslServer> {
     ssl: S,
 }
 
-impl<S: Ssl> HttpsListener<S> {
+impl<S: SslServer> HttpsListener<S> {
     /// Start listening to an address over HTTPS.
     pub fn new<To: ToSocketAddrs>(addr: To, ssl: S) -> ::Result<HttpsListener<S>> {
         HttpListener::new(addr).map(|l| HttpsListener {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -125,7 +125,7 @@ use buffer::BufReader;
 use header::{Headers, Expect, Connection};
 use http;
 use method::Method;
-use net::{NetworkListener, NetworkStream, HttpListener, HttpsListener, Ssl};
+use net::{NetworkListener, NetworkStream, HttpListener, HttpsListener, SslServer};
 use status::StatusCode;
 use uri::RequestUri;
 use version::HttpVersion::Http11;
@@ -214,7 +214,7 @@ impl Server<HttpListener> {
     }
 }
 
-impl<S: Ssl + Clone + Send> Server<HttpsListener<S>> {
+impl<S: SslServer + Clone + Send> Server<HttpsListener<S>> {
     /// Creates a new server that will handle `HttpStream`s over SSL.
     ///
     /// You can use any SSL implementation, as long as implements `hyper::net::Ssl`.


### PR DESCRIPTION
An oversight from the original implementation of the Ssl split.