### PR TITLE
Without this semicolon, multiple threads didn't spawn properly

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -42,7 +42,7 @@ fn main() {
         let listener = listener.try_clone().unwrap();
         handles.push(::std::thread::spawn(move || {
             Server::new(listener)
-                .handle(|_| Hello).unwrap()
+                .handle(|_| Hello).unwrap();
         }));
     }
     println!("Listening on http://127.0.0.1:3000");


### PR DESCRIPTION
I'm not exactly sure of the reason, but without this semicolon, the example only used one thread.
After adding the semicolon, threads spawned up as expected.

```
$ rustc --version
rustc 1.9.0 (e4e8b6668 2016-05-18)
```
Checked the threads in `htop` command.
And I'm using ubuntu. Please let me know if you need more details.