### PR TITLE
client: Make it clear what the `Read` impl for `Response` does

### DIFF
--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -64,6 +64,7 @@ impl Response {
     }
 }
 
+/// Read the response body.
 impl Read for Response {
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {


### PR DESCRIPTION
In case someone reads the documentation for `client::Response` without
having read the documentation for the `client` module first, they might
wonder what the `Read` impl actually reads.

Let's clarify it by annotating the `Read` impl.