### PR TITLE
perf(headers): use a VecMap, and check name against literals

### DIFF
--- a/src/header/common/access_control_allow_credentials.rs
+++ b/src/header/common/access_control_allow_credentials.rs
@@ -42,7 +42,8 @@ const ACCESS_CONTROL_ALLOW_CREDENTIALS_TRUE: UniCase<&'static str> = UniCase("tr
 
 impl Header for AccessControlAllowCredentials {
     fn header_name() -> &'static str {
-        "Access-Control-Allow-Credentials"
+        static NAME: &'static str = "Access-Control-Allow-Credentials";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<AccessControlAllowCredentials> {

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -73,7 +73,8 @@ impl<S: Scheme> DerefMut for Authorization<S> {
 
 impl<S: Scheme + Any> Header for Authorization<S> where <S as FromStr>::Err: 'static {
     fn header_name() -> &'static str {
-        "Authorization"
+        static NAME: &'static str = "Authorization";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<Authorization<S>> {

--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -51,7 +51,8 @@ __hyper__deref!(CacheControl => Vec<CacheDirective>);
 
 impl Header for CacheControl {
     fn header_name() -> &'static str {
-        "Cache-Control"
+        static NAME: &'static str = "Cache-Control";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<CacheControl> {

--- a/src/header/common/content_disposition.rs
+++ b/src/header/common/content_disposition.rs
@@ -90,7 +90,8 @@ pub struct ContentDisposition {
 
 impl Header for ContentDisposition {
     fn header_name() -> &'static str {
-        "Content-Disposition"
+        static NAME: &'static str = "Content-Disposition";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<ContentDisposition> {

--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -32,10 +32,13 @@ use header::{Header, parsing};
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ContentLength(pub u64);
 
+//static NAME: &'static str = "Content-Length";
+
 impl Header for ContentLength {
     #[inline]
     fn header_name() -> &'static str {
-        "Content-Length"
+        static NAME: &'static str = "Content-Length";
+        NAME
     }
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<ContentLength> {
         // If multiple Content-Length headers were sent, everything can still

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -39,7 +39,8 @@ __hyper__deref!(Cookie => Vec<CookiePair>);
 
 impl Header for Cookie {
     fn header_name() -> &'static str {
-        "Cookie"
+        static NAME: &'static str = "Cookie";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<Cookie> {

--- a/src/header/common/expect.rs
+++ b/src/header/common/expect.rs
@@ -30,7 +30,8 @@ const EXPECT_CONTINUE: UniCase<&'static str> = UniCase("100-continue");
 
 impl Header for Expect {
     fn header_name() -> &'static str {
-        "Expect"
+        static NAME: &'static str = "Expect";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<Expect> {

--- a/src/header/common/host.rs
+++ b/src/header/common/host.rs
@@ -43,7 +43,8 @@ pub struct Host {
 
 impl Header for Host {
     fn header_name() -> &'static str {
-        "Host"
+        static NAME: &'static str = "Host";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<Host> {

--- a/src/header/common/if_range.rs
+++ b/src/header/common/if_range.rs
@@ -55,7 +55,8 @@ pub enum IfRange {
 
 impl Header for IfRange {
     fn header_name() -> &'static str {
-        "If-Range"
+        static NAME: &'static str = "If-Range";
+        NAME
     }
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<IfRange> {
         let etag: ::Result<EntityTag> = header::parsing::from_one_raw_str(raw);

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -217,7 +217,8 @@ macro_rules! header {
         __hyper__deref!($id => Vec<$item>);
         impl $crate::header::Header for $id {
             fn header_name() -> &'static str {
-                $n
+                static NAME: &'static str = $n;
+                NAME
             }
             fn parse_header(raw: &[Vec<u8>]) -> $crate::Result<Self> {
                 $crate::header::parsing::from_comma_delimited(raw).map($id)
@@ -243,7 +244,8 @@ macro_rules! header {
         __hyper__deref!($id => Vec<$item>);
         impl $crate::header::Header for $id {
             fn header_name() -> &'static str {
-                $n
+                static NAME: &'static str = $n;
+                NAME
             }
             fn parse_header(raw: &[Vec<u8>]) -> $crate::Result<Self> {
                 $crate::header::parsing::from_comma_delimited(raw).map($id)
@@ -268,7 +270,8 @@ macro_rules! header {
         __hyper__deref!($id => $value);
         impl $crate::header::Header for $id {
             fn header_name() -> &'static str {
-                $n
+                static NAME: &'static str = $n;
+                NAME
             }
             fn parse_header(raw: &[Vec<u8>]) -> $crate::Result<Self> {
                 $crate::header::parsing::from_one_raw_str(raw).map($id)
@@ -296,7 +299,8 @@ macro_rules! header {
         }
         impl $crate::header::Header for $id {
             fn header_name() -> &'static str {
-                $n
+                static NAME: &'static str = $n;
+                NAME
             }
             fn parse_header(raw: &[Vec<u8>]) -> $crate::Result<Self> {
                 // FIXME: Return None if no item is in $id::Only

--- a/src/header/common/pragma.rs
+++ b/src/header/common/pragma.rs
@@ -40,7 +40,8 @@ pub enum Pragma {
 
 impl Header for Pragma {
     fn header_name() -> &'static str {
-        "Pragma"
+        static NAME: &'static str = "Pragma";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<Pragma> {

--- a/src/header/common/prefer.rs
+++ b/src/header/common/prefer.rs
@@ -52,7 +52,8 @@ __hyper__deref!(Prefer => Vec<Preference>);
 
 impl Header for Prefer {
     fn header_name() -> &'static str {
-        "Prefer"
+        static NAME: &'static str = "Prefer";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<Prefer> {

--- a/src/header/common/preference_applied.rs
+++ b/src/header/common/preference_applied.rs
@@ -50,7 +50,8 @@ __hyper__deref!(PreferenceApplied => Vec<Preference>);
 
 impl Header for PreferenceApplied {
     fn header_name() -> &'static str {
-        "Preference-Applied"
+        static NAME: &'static str = "Preference-Applied";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<PreferenceApplied> {

--- a/src/header/common/range.rs
+++ b/src/header/common/range.rs
@@ -176,7 +176,8 @@ impl FromStr for ByteRangeSpec {
 impl Header for Range {
 
     fn header_name() -> &'static str {
-        "Range"
+        static NAME: &'static str = "Range";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<Range> {

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -84,7 +84,8 @@ __hyper__deref!(SetCookie => Vec<CookiePair>);
 
 impl Header for SetCookie {
     fn header_name() -> &'static str {
-        "Set-Cookie"
+        static NAME: &'static str = "Set-Cookie";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<SetCookie> {

--- a/src/header/common/strict_transport_security.rs
+++ b/src/header/common/strict_transport_security.rs
@@ -121,7 +121,8 @@ impl FromStr for StrictTransportSecurity {
 
 impl Header for StrictTransportSecurity {
     fn header_name() -> &'static str {
-        "Strict-Transport-Security"
+        static NAME: &'static str = "Strict-Transport-Security";
+        NAME
     }
 
     fn parse_header(raw: &[Vec<u8>]) -> ::Result<StrictTransportSecurity> {

--- a/src/header/internals/mod.rs
+++ b/src/header/internals/mod.rs
@@ -1,4 +1,6 @@
 pub use self::item::Item;
+pub use self::vec_map::{VecMap, Entry};
 
 mod cell;
 mod item;
+mod vec_map;

--- a/src/header/internals/vec_map.rs
+++ b/src/header/internals/vec_map.rs
@@ -1,0 +1,89 @@
+#[derive(Clone)]
+pub struct VecMap<K, V> {
+    vec: Vec<(K, V)>,
+}
+
+impl<K: PartialEq, V> VecMap<K, V> {
+    pub fn new() -> VecMap<K, V> {
+        VecMap {
+            vec: Vec::new()
+        }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        match self.find(&key) {
+            Some(pos) => self.vec[pos] = (key, value),
+            None => self.vec.push((key, value))
+        }
+    }
+
+    pub fn entry(&mut self, key: K) -> Entry<K, V> {
+        match self.find(&key) {
+            Some(pos) => Entry::Occupied(OccupiedEntry {
+                vec: self,
+                pos: pos,
+            }),
+            None => Entry::Vacant(VacantEntry {
+                vec: self,
+                key: key,
+            })
+        }
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.find(key).map(move |pos| &self.vec[pos].1)
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.find(key).map(move |pos| &mut self.vec[pos].1)
+    }
+
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.find(key).is_some()
+    }
+
+    pub fn len(&self) -> usize { self.vec.len() }
+    pub fn iter(&self) -> ::std::slice::Iter<(K, V)> {
+        self.vec.iter()
+    }
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        self.find(key).map(|pos| self.vec.remove(pos)).map(|(_, v)| v)
+    }
+    pub fn clear(&mut self) {
+        self.vec.clear();
+    }
+
+    fn find(&self, key: &K) -> Option<usize> {
+        self.vec.iter().position(|entry| key == &entry.0)
+    }
+}
+
+pub enum Entry<'a, K: 'a, V: 'a> {
+    Vacant(VacantEntry<'a, K, V>),
+    Occupied(OccupiedEntry<'a, K, V>)
+}
+
+pub struct VacantEntry<'a, K: 'a, V: 'a> {
+    vec: &'a mut VecMap<K, V>,
+    key: K,
+}
+
+impl<'a, K, V> VacantEntry<'a, K, V> {
+    pub fn insert(self, val: V) -> &'a mut V {
+        let mut vec = self.vec;
+        vec.vec.push((self.key, val));
+        let pos = vec.vec.len() - 1;
+        &mut vec.vec[pos].1
+    }
+}
+
+pub struct OccupiedEntry<'a, K: 'a, V: 'a> {
+    vec: &'a mut VecMap<K, V>,
+    pos: usize,
+}
+
+impl<'a, K, V> OccupiedEntry<'a, K, V> {
+    pub fn into_mut(self) -> &'a mut V {
+        &mut self.vec.vec[self.pos].1
+    }
+}

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -77,8 +77,8 @@
 //! ```
 use std::any::Any;
 use std::borrow::{Cow, ToOwned};
-use std::collections::HashMap;
-use std::collections::hash_map::{Iter, Entry};
+//use std::collections::HashMap;
+//use std::collections::hash_map::{Iter, Entry};
 use std::iter::{FromIterator, IntoIterator};
 use std::ops::{Deref, DerefMut};
 use std::{mem, fmt};
@@ -87,7 +87,7 @@ use {httparse, traitobject};
 use typeable::Typeable;
 use unicase::UniCase;
 
-use self::internals::Item;
+use self::internals::{Item, VecMap, Entry};
 
 #[cfg(feature = "serde-serialization")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -169,7 +169,8 @@ fn header_name<T: Header>() -> &'static str {
 /// A map of header fields on requests and responses.
 #[derive(Clone)]
 pub struct Headers {
-    data: HashMap<HeaderName, Item>
+    //data: HashMap<HeaderName, Item>
+    data: VecMap<HeaderName, Item>,
 }
 
 impl Default for Headers {
@@ -183,7 +184,7 @@ impl Headers {
     /// Creates a new, empty headers map.
     pub fn new() -> Headers {
         Headers {
-            data: HashMap::new()
+            data: VecMap::new()
         }
     }
 
@@ -377,14 +378,14 @@ impl Deserialize for Headers {
 /// An `Iterator` over the fields in a `Headers` map.
 #[allow(missing_debug_implementations)]
 pub struct HeadersItems<'a> {
-    inner: Iter<'a, HeaderName, Item>
+    inner: ::std::slice::Iter<'a, (HeaderName, Item)>
 }
 
 impl<'a> Iterator for HeadersItems<'a> {
     type Item = HeaderView<'a>;
 
     fn next(&mut self) -> Option<HeaderView<'a>> {
-        self.inner.next().map(|(k, v)| HeaderView(k, v))
+        self.inner.next().map(|&(ref k, ref v)| HeaderView(k, v))
     }
 }
 


### PR DESCRIPTION
On (weak machine) consistent small benchmark I've been using to measure impact, these changes caused an increase from ~28k req/s to ~36k req/s.