### PR TITLE
feat(client): add method to end a chunked body for a Request

### DIFF
--- a/src/http/h1/parse.rs
+++ b/src/http/h1/parse.rs
@@ -188,8 +188,9 @@ impl Http1Message for ClientMessage {
             body = Encoder::chunked();
             let encodings = match head.headers.get_mut::<TransferEncoding>() {
                 Some(encodings) => {
-                    //TODO: check if Chunked already exists
-                    encodings.push(header::Encoding::Chunked);
+                    if !encodings.contains(&header::Encoding::Chunked) {
+                        encodings.push(header::Encoding::Chunked);
+                    }
                     true
                 },
                 None => false


### PR DESCRIPTION
This requires a Handler that uses chunked encoding to call `encoder.close()` when it is done.

Closes #831