### PR TITLE
fix(headers): Remove raw part when getting mutable reference to typed header

### DIFF
--- a/src/header/internals/item.rs
+++ b/src/header/internals/item.rs
@@ -78,6 +78,9 @@ impl Item {
                 Err(_) => ()
             }
         }
+        if self.raw.is_some() && self.typed.get_mut(tid).is_some() {
+            self.raw = OptCell::new(None);
+        }
         self.typed.get_mut(tid).map(|typed| unsafe { typed.downcast_mut_unchecked() })
     }
 }

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -670,6 +670,7 @@ mod tests {
     fn test_get_mutable() {
         let mut headers = Headers::from_raw(&raw!(b"Content-Length: 10")).unwrap();
         *headers.get_mut::<ContentLength>().unwrap() = ContentLength(20);
+        assert_eq!(headers.get_raw("content-length").unwrap(), &[b"20".to_vec()][..]);
         assert_eq!(*headers.get::<ContentLength>().unwrap(), ContentLength(20));
     }
 


### PR DESCRIPTION
> If you get a mutable reference to a typed header it is possible to make
the two representations be out of sync. To avoid this, after parsing the
raw part it should be removed.
>
> Closes #821 

Rebase with a test added.
Closes #833 