### PR TITLE
feat(client): add convenience method 'with_token' to RequestBuilder

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -72,6 +72,8 @@ use net::{HttpConnector, NetworkConnector, NetworkStream, SslClient};
 use Error;
 
 use self::proxy::{Proxy, tunnel};
+use super::header::{Authorization, Bearer};
+
 pub use self::pool::Pool;
 pub use self::request::Request;
 pub use self::response::Response;
@@ -363,6 +365,15 @@ impl<'a> RequestBuilder<'a> {
                 _ => return Ok(res),
             }
         }
+    }
+
+    /// Add an Authorization header with the provided token to the request.
+    pub fn with_token(self, token: &str) -> RequestBuilder<'a> {
+        self.header(Authorization(
+            Bearer {
+                token: token.to_string()
+            }
+        ))
     }
 }
 


### PR DESCRIPTION
may not be necessary, but I found the api for adding an authorization
header a bit clunky and thought this might be the first of many
convenience methods for the RequestBuilder

n/a