### PR TITLE
accept cert chain files as well as single cert files

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -710,7 +710,7 @@ mod openssl {
         where C: AsRef<Path>, K: AsRef<Path> {
             let mut ctx = try!(SslContext::new(SslMethod::Sslv23));
             try!(ctx.set_cipher_list("DEFAULT"));
-            try!(ctx.set_certificate_file(cert.as_ref(), X509FileType::PEM));
+            try!(ctx.set_certificate_chain_file(cert.as_ref(), X509FileType::PEM));
             try!(ctx.set_private_key_file(key.as_ref(), X509FileType::PEM));
             ctx.set_verify(SSL_VERIFY_NONE, None);
             Ok(Openssl { context: Arc::new(ctx) })


### PR DESCRIPTION
Openssl::with_cert_and_key is often useless in its current form: in most setups, you need to provide the intermediate certificate chain to openssl. One way would be to change with_cert_and_key to allow passing a third file containing the authority chain. But fortunately, we have another option: openssl accepts combined certificates (your certs, then whatever certs you need to link it to the widely distrubuted ones). This is not exotic, both nginx and apache use this setup.

As far as I can tell, this should not break anything, and would fix https support for all libraries relying on with_cert_and_key...