### PR TITLE
Fix guide example to save receiver for later use by response handler.

### DIFF
--- a/doc/guide/server.md
+++ b/doc/guide/server.md
@@ -314,7 +314,9 @@ impl Handler<Http> for Text {
             "/question" => {
                 let (tx, rx) = mpsc::channel();
                 // queue work on our worker
-                self.worker_tx.send((self.control.take().unwrap(), tx));
+                self.worker_tx.send((self.control.take().unwrap(), tx)).unwrap();
+                // save receive channel for response handling
+                self.worker_rx = Some(rx);
                 // tell hyper we need to wait until we can continue
                 return Next::wait();
             }


### PR DESCRIPTION
The `on_response` function requires the struct `Text` to have had `worker_rx` set, for the `question` path.
