### PR TITLE
refactor(version): bump version of num_cpus to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ optional = true
 
 [dev-dependencies]
 env_logger = "0.3"
-num_cpus = "0.2"
+num_cpus = "1.0"
 
 [features]
 default = ["ssl"]


### PR DESCRIPTION
In the process of updating the dependencies of another far upstream package that eventually includes hyper, I noticed that `num_cpus` had finally stabilized and made a 1.0 release. There were no code changes in the `1.0` release from `0.2.13` (https://github.com/seanmonstar/num_cpus/commit/7aab1fbc30b9bf39e74b0624dc037af694ce4da3)

The tests for hyper pass on my machine.