### PR TITLE
Evict idle connections when client is full

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,8 @@ pub enum Error {
     Status,
     /// A timeout occurred waiting for an IO event.
     Timeout,
+    /// Event loop is full and cannot process request
+    Full,
     /// An `io::Error` that occurred while trying to read or write to a network stream.
     Io(IoError),
     /// An error from a SSL library.
@@ -90,6 +92,7 @@ impl StdError for Error {
             Status => "Invalid Status provided",
             Incomplete => "Message is incomplete",
             Timeout => "Timeout",
+            Error::Full => "Event loop is full",
             Uri(ref e) => e.description(),
             Io(ref e) => e.description(),
             Ssl(ref e) => e.description(),


### PR DESCRIPTION
In the scenario where a request is started on the `Client`, the client
has a full slab, and sockets for a *different* domain are idling in
keep-alive, the new request would previously cause the client to panic!.

This patch adds a `spawn_error` handler which attempts to evict an idle
connection to make space for the new request. If space cannot be made,
the error handler is run (passed `Error::Full`) and the `Handler` is
dropped.

This is a breaking change because of the new variant of `Error`.

Some inefficient use of `Vec` in the client was replaced with `VecDeque`
to support push/pop from either end.