### PR TITLE
fix(http): stackoverflow in Conn::ready

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -17,7 +17,7 @@ use version::HttpVersion::{Http10, Http11};
 #[cfg(feature = "serde-serialization")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-pub use self::conn::{Conn, MessageHandler, MessageHandlerFactory, Seed, Key};
+pub use self::conn::{Conn, MessageHandler, MessageHandlerFactory, Seed, Key, ReadyResult};
 
 mod buffer;
 pub mod channel;


### PR DESCRIPTION
I've had a couple of instances during stress testing now where
Conn::ready would overflow its stack due to recursing on itself. This
moves subsequent calls to ready() into a loop outside the function.

`Conn::ready()` takes `mut self` so the loop needs to do an ownership dance to keep trying. Would love to hear a better way to achieve this.