### PR TITLE
* most certifactes has chains of certifactes, so we should

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -531,7 +531,7 @@ mod openssl {
         where C: AsRef<Path>, K: AsRef<Path> {
             let mut ctx = try!(SslContext::new(SslMethod::Sslv23));
             try!(ctx.set_cipher_list("ALL!EXPORT!EXPORT40!EXPORT56!aNULL!LOW!RC4@STRENGTH"));
-            try!(ctx.set_certificate_file(cert.as_ref(), X509FileType::PEM));
+            try!(ctx.set_certificate_chain_file(cert.as_ref(), X509FileType::PEM));
             try!(ctx.set_private_key_file(key.as_ref(), X509FileType::PEM));
             Ok(Openssl { context: ctx })
         }


### PR DESCRIPTION
  also read them by default