### PR TITLE
fix(http): Connection checks for spurious timeouts

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -493,8 +493,13 @@ where C: Connect,
                         trace!("connected and writable {:?}", seed.0);
                         rotor::Response::ok(
                             ClientFsm::Socket(
-                                http::Conn::new(seed.0, seed.1, Next::write().timeout(scope.connect_timeout), scope.notifier())
-                                    .keep_alive(scope.keep_alive)
+                                http::Conn::new(
+                                    seed.0,
+                                    seed.1,
+                                    Next::write().timeout(scope.connect_timeout),
+                                    scope.notifier(),
+                                    scope.now()
+                                ).keep_alive(scope.keep_alive)
                             )
                         )
                     } else {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -226,7 +226,7 @@ where A: Accept,
         rotor_try!(scope.register(&seed, EventSet::readable(), PollOpt::level()));
         rotor::Response::ok(
             ServerFsm::Conn(
-                http::Conn::new((), seed, Next::read(), scope.notifier())
+                http::Conn::new((), seed, Next::read(), scope.notifier(), scope.now())
                     .keep_alive(scope.keep_alive)
             )
         )


### PR DESCRIPTION
We've been seeing a strange number of timeouts in our benchmarking.
Handling spurious timeouts as in this patch seems to fix it!

Note that managing the `timeout_start` needs to be done carefully. If
the current time is provided in the wrong place, it's possible requests
would never timeout.