### PR TITLE
Add 'take_buf' method to BufReader.

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -44,6 +44,24 @@ impl<R: Read> BufReader<R> {
         }
     }
 
+    /// Extracts the buffer from this reader. Return the current cursor position
+    /// and the position of the last valid byte.
+    ///
+    /// This operation does not copy the buffer. Instead, it directly returns
+    /// the internal buffer. As a result, this reader will no longer have any
+    /// buffered contents and any subsequent read from this reader will not
+    /// include the returned buffered contents.
+    #[inline]
+    pub fn take_buf(&mut self) -> (Vec<u8>, usize, usize) {
+        let (pos, cap) = (self.pos, self.cap);
+        self.pos = 0;
+        self.cap = 0;
+
+        let mut output = vec![0; INIT_BUFFER_SIZE];
+        ::std::mem::swap(&mut self.buf, &mut output);
+        (output, pos, cap)
+    }
+
     #[inline]
     pub fn into_inner(self) -> R { self.inner }
 


### PR DESCRIPTION
Hello!

I'm using the latest 0.9.x release on a project I'm working on, and I'm quite in need of this method. As I'd like to release my project on crates.io soon, I was hoping you would merge this in and then release a new version of hyper 0.9.x on crates.io. I understand that 0.9.x has effectively been abandoned in favor of 0.10, so I hope it won't be too much trouble.

Thanks!
Sergio
