### PR TITLE
fix(net): Implement `blocked()` for OpensslStream

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -636,6 +636,10 @@ mod openssl {
         fn take_socket_error(&mut self) -> io::Result<()> {
             self.stream.get_mut().take_socket_error()
         }
+
+        fn blocked(&self) -> Option<super::Blocked> {
+            self.blocked
+        }
     }
 }
 


### PR DESCRIPTION
This should fix some busy looping when using OpenSSL. For example, if
the transport was blocked on a read, it wasn't surfaced to the
`http::Conn` and so the wrong interest was registered with the event
loop. Registering for the wrong interest triggered calls to
`http::Conn::ready()` which were unable to make progress.