### PR TITLE
Forcing OpenSSL to 0.8 -- discussion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ authors = ["Sean McArthur <sean.monstar@gmail.com>",
 keywords = ["http", "hyper", "hyperium"]
 
 [dependencies]
+openssl-sys="*"
+openssl="*"
 httparse = "1.0"
 language-tags = "0.2"
 log = "0.3"
@@ -28,16 +30,12 @@ vecio = "0.1"
 version = "0.3"
 default-features = false
 
-[dependencies.openssl]
-version = "0.7"
-optional = true
-
 [dependencies.openssl-verify]
-version = "0.1"
+version = "*"
 optional = true
 
 [dependencies.security-framework]
-version = "0.1.4"
+version = "*"
 optional = true
 
 [dependencies.serde]
@@ -49,7 +47,5 @@ env_logger = "0.3"
 num_cpus = "1.0"
 
 [features]
-default = ["ssl"]
-ssl = ["openssl", "openssl-verify", "cookie/secure"]
 serde-serialization = ["serde", "mime/serde"]
 nightly = []


### PR DESCRIPTION
Hi.

The current master of hyper isn't building for me under Windows, due to a `fatal error C1083: Cannot open include file: 'openssl/ssl.h': No such file or directory` issue.
I have a 64-bit OpenSSL install, and the environment variables set: `OPENSSL_DIR`, `OPENSSL_LIB_DIR` and `OPENSSL_INCLUDE_DIR`.

A little bit of experimentation shows that the `openssl v0.7.14` package fails, but the `openssl v0.8.3` package builds OK.

Running the tests with OpenSSL 0.8 results in a few failures against the test server -- but I can't compare to 0.7.


Would it be possible to move from 0.7 to 0.8?

My OpenSSL install is `1.1.0b` x64 from http://slproweb.com/products/Win32OpenSSL.html
Rust version is `rustc 1.12.1 (d4f39402a 2016-10-19)` with cargo `cargo 0.13.0-nightly (109cb7c 2016-08-19)`
Running under Win 7 64-bit.

Thanks.