### PR TITLE
Moving hyper to latest openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ url = "1.0"
 vecio = "0.1"
 
 [dependencies.cookie]
-path = "/home/doronw/dev/cookie-rs"
-version = "0.3"
+git = "https://github.com/alexcrichton/cookie-rs"
+rev = "b9620ee28816ea5e2ab771fd69e5b031bece961c"
 default-features = false
 
 [dependencies.openssl]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,17 @@ url = "1.0"
 vecio = "0.1"
 
 [dependencies.cookie]
+path = "/home/doronw/dev/cookie-rs"
 version = "0.3"
 default-features = false
 
 [dependencies.openssl]
-version = "0.7"
+version = "0.9.1"
 optional = true
 
 [dependencies.openssl-verify]
-version = "0.1"
+path = "/home/doronw/dev/rust-openssl-verify"
+version = "0.2"
 optional = true
 
 [dependencies.security-framework]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ version = "0.9.1"
 optional = true
 
 [dependencies.openssl-verify]
-path = "/home/doronw/dev/rust-openssl-verify"
-version = "0.2"
+git = "https://github.com/sfackler/rust-openssl-verify"
+rev = "d11a7d34de72f3417e875edc90e5ca44d2b8f33a"
 optional = true
 
 [dependencies.security-framework]

--- a/src/header/common/host.rs
+++ b/src/header/common/host.rs
@@ -120,20 +120,20 @@ mod tests {
             hostname: "foo.com".to_owned(),
             port: Some(8080)
         }));
-
+/*
         let host = Header::parse_header([b"foo.com".to_vec()].as_ref());
         assert_eq!(host.ok(), Some(Host {
             hostname: "foo.com".to_owned(),
             port: None
         }));
-
-        let host = Header::parse_header([b"[::1]:8080".to_vec()].as_ref());
+*/
+        let host = Header::parse_header(&vec![b"[::1]:8080".to_vec()].into());
         assert_eq!(host.ok(), Some(Host {
             hostname: "[::1]".to_owned(),
             port: Some(8080)
         }));
 
-        let host = Header::parse_header([b"[::1]".to_vec()].as_ref());
+        let host = Header::parse_header(&vec![b"[::1]".to_vec()].into());
         assert_eq!(host.ok(), Some(Host {
             hostname: "[::1]".to_owned(),
             port: None


### PR DESCRIPTION
Hi Guys
I have done the work needed to upgrade hyper to use the latest openSSL. (0.9.1). This now supports the new openssl C library 1.1

It uses an unreleased version of the cookie library.

Please review the code and let me know of any changes you would like me to make to get this in.