### PR TITLE
Moved futures/tokio deps to crates where possible to repair build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,17 @@
 [package]
-
-name = "hyper"
-version = "0.10.0-a.0"
-description = "A modern HTTP library."
-readme = "README.md"
-documentation = "http://hyperium.github.io/hyper"
-repository = "https://github.com/hyperium/hyper"
-license = "MIT"
 authors = ["Sean McArthur <sean.monstar@gmail.com>"]
+description = "A modern HTTP library."
+documentation = "http://hyperium.github.io/hyper"
 keywords = ["http", "hyper", "hyperium"]
+license = "MIT"
+name = "hyper"
+readme = "README.md"
+repository = "https://github.com/hyperium/hyper"
+version = "0.10.0-a.0"
 
 [dependencies]
-bytes = {git = "https://github.com/carllerche/bytes"}
-futures = { git = "https://github.com/alexcrichton/futures-rs"}
-futures-cpupool = { git = "https://github.com/alexcrichton/futures-rs"}
+futures = "0.1.6"
+futures-cpupool = "0.1.2"
 httparse = "1.0"
 language-tags = "0.2"
 log = "0.3"
@@ -22,27 +20,35 @@ mio = "0.6"
 rustc-serialize = "0.3"
 spmc = "0.2"
 time = "0.1"
-tokio-core =  {git = "https://github.com/tokio-rs/tokio-core"}
-tokio-proto = {git = "https://github.com/tokio-rs/tokio-proto"}
-tokio-service = {git = "https://github.com/tokio-rs/tokio-service"}
+tokio-core = "0.1.1"
 unicase = "1.0"
 url = "1.0"
 vecio = "0.1"
 
+[dependencies.bytes]
+git = "https://github.com/carllerche/bytes"
+
 [dependencies.cookie]
-version = "0.3"
 default-features = false
+version = "0.3"
 
 [dependencies.serde]
-version = "0.8"
 optional = true
+version = "0.8"
+
+[dependencies.tokio-proto]
+git = "https://github.com/tokio-rs/tokio-proto"
+
+[dependencies.tokio-service]
+git = "https://github.com/tokio-rs/tokio-service"
 
 [dev-dependencies]
 num_cpus = "1.0"
-#env_logger = "0.3"
-pretty_env_logger = { git = "https://github.com/seanmonstar/pretty-env-logger" }
+
+[dev-dependencies.pretty_env_logger]
+git = "https://github.com/seanmonstar/pretty-env-logger"
 
 [features]
 default = []
-serde-serialization = ["serde", "mime/serde"]
 nightly = []
+serde-serialization = ["serde", "mime/serde"]

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -32,10 +32,11 @@ fn main() {
     //env_logger::init().unwrap();
     pretty_env_logger::init();
 
-    println!("Listening on http://127.0.0.1:3000");
-    Server::http(&"127.0.0.1:3000".parse().unwrap()).unwrap()
+    let (listening, server) = Server::http(&"127.0.0.1:3000".parse().unwrap()).unwrap()
         .standalone(|| Ok(Hello)).unwrap();
 
+    println!("Listening on http://{}", listening);
+    server.run();
     /*
     let listener = HttpListener::bind(&"127.0.0.1:3000".parse().unwrap()).unwrap();
     let mut handles = Vec::new();


### PR DESCRIPTION
I wasn't able to build with a fresh checkout of the git-based dependencies.  Moving to the ones available as crates allowed the build to succeed