### PR TITLE
[Tokio Branch] Create a `body::Body` struct, exposed as `hyper::Body` that wraps a `tokio_proto`-`Body`.

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -1,0 +1,58 @@
+//! The Hyper Body, which is a wrapper around the tokio_proto Body.
+//! This is used as the Body for a Server Request, Server Response,
+//! and also for a Client Request and Client Response.
+//! It is based on a tokio_proto::streaming::Body for now, but will be
+//! changed to tokio_proto::multiplex::Body int the future for SSL support.
+
+use std::convert::From;
+
+use tokio_proto;
+use http::Chunk;
+use futures::{Poll, Stream};
+use futures::sync::mpsc;
+use futures::StartSend;
+
+pub type TokioBody = tokio_proto::streaming::Body<Chunk, ::Error>;
+
+#[derive(Debug)]
+pub struct Body(TokioBody);
+
+impl Body {
+    /// Return an empty body stream
+    pub fn empty() -> Body {
+        Body(TokioBody::empty())
+    }
+
+    /// Return a body stream with an associated sender half
+    pub fn pair() -> (mpsc::Sender<Result<Chunk, ::Error>>, Body) {
+        let (tx, rx) = TokioBody::pair();
+        let rx = Body(rx);
+        (tx, rx)
+    }
+}
+
+impl Stream for Body {
+    type Item = Chunk;
+    type Error = ::Error;
+
+    fn poll(&mut self) -> Poll<Option<Chunk>, ::Error> {
+        self.0.poll()
+    }
+}
+
+impl From<Body> for tokio_proto::streaming::Body<Chunk, ::Error> {
+    fn from(b: Body) -> tokio_proto::streaming::Body<Chunk, ::Error> {
+        b.0
+    }
+}
+impl From<tokio_proto::streaming::Body<Chunk, ::Error>> for Body {
+    fn from(tokio_body: tokio_proto::streaming::Body<Chunk, ::Error>) -> Body {
+        Body(tokio_body)
+    }
+}
+
+impl From<mpsc::Receiver<Result<Chunk, ::Error>>> for Body {
+    fn from(src: mpsc::Receiver<Result<Chunk, ::Error>>) -> Body {
+        Body(src.into())
+    }
+}

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -1,6 +1,5 @@
 //! Client Requests
 
-use futures::{Future, Sink};
 use Url;
 
 use body::Body;
@@ -9,6 +8,8 @@ use http::{RequestHead, Chunk};
 use method::Method;
 use uri::RequestUri;
 use version::HttpVersion;
+
+type RequestBody = Body;
 
 /// A client request to a remote server.
 #[derive(Debug)]
@@ -64,44 +65,12 @@ impl Request {
 
     /// Set the body of the request.
     #[inline]
-    pub fn set_body<T: IntoBody>(&mut self, body: T) { self.body = Some(body.into()); }
+    pub fn set_body<T: Into<Body>>(&mut self, body: T) { self.body = Some(body.into()); }
 }
 
 
 pub fn split(req: Request) -> (RequestHead, Option<Body>) {
     (req.head, req.body)
-}
-
-pub trait IntoBody {
-    fn into(self) -> Body;
-}
-
-impl IntoBody for Body {
-    fn into(self) -> Self {
-        self
-    }
-}
-
-impl IntoBody for Vec<u8> {
-    fn into(self) -> Body {
-        let (mut tx, rx) = Body::pair();
-        ::futures::lazy(move || tx.start_send(Ok(Chunk::from(self)))).wait().unwrap();
-        rx
-    }
-}
-
-impl IntoBody for &'static [u8] {
-    fn into(self) -> Body {
-        let vec = self.to_vec();
-        IntoBody::into(vec)
-    }
-}
-
-impl IntoBody for &'static str {
-    fn into(self) -> Body {
-        let vec = self.as_bytes().to_vec();
-        IntoBody::into(vec)
-    }
 }
 
 #[cfg(test)]

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -3,13 +3,12 @@
 use futures::{Future, Sink};
 use Url;
 
+use body::Body;
 use header::Headers;
 use http::{RequestHead, Chunk};
 use method::Method;
 use uri::RequestUri;
 use version::HttpVersion;
-
-type Body = ::tokio_proto::streaming::Body<Chunk, ::Error>;
 
 /// A client request to a remote server.
 #[derive(Debug)]

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -1,13 +1,12 @@
 //! Client Responses
 
-use tokio_proto::streaming::Body;
-
+use body::Body;
 use header;
 use http::{self, Chunk, RawStatus};
 use status;
 use version;
 
-pub fn new(incoming: http::ResponseHead, body: Option<Body<Chunk, ::Error>>) -> Response {
+pub fn new(incoming: http::ResponseHead, body: Option<Body>) -> Response {
     trace!("Response::new");
     let status = status::StatusCode::from_u16(incoming.subject.0);
     debug!("version={:?}, status={:?}", incoming.version, status);
@@ -30,7 +29,7 @@ pub struct Response {
     headers: header::Headers,
     version: version::HttpVersion,
     status_raw: RawStatus,
-    body: Option<Body<Chunk, ::Error>>,
+    body: Option<Body>,
 }
 
 impl Response {
@@ -54,7 +53,7 @@ impl Response {
     #[inline]
     pub fn version(&self) -> &version::HttpVersion { &self.version }
 
-    pub fn body(mut self) -> Body<::http::Chunk, ::Error> {
+    pub fn body(mut self) -> Body {
         self.body.take().unwrap_or(Body::empty())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ extern crate test;
 
 
 pub use url::Url;
+pub use body::Body;
 pub use client::Client;
 pub use error::{Result, Error};
 pub use header::Headers;
@@ -67,6 +68,7 @@ macro_rules! unimplemented {
 
 #[cfg(test)]
 mod mock;
+pub mod body;
 pub mod client;
 pub mod error;
 mod method;

--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -5,13 +5,12 @@
 
 use std::fmt;
 
+use body::Body;
 use version::HttpVersion;
 use method::Method;
 use header::Headers;
 use http::{RequestHead, MessageHead, RequestLine, Chunk};
 use uri::RequestUri;
-
-type Body = ::tokio_proto::streaming::Body<Chunk, ::Error>;
 
 /// A request bundles several parts of an incoming `NetworkStream`, given to a `Handler`.
 pub struct Request {

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -5,12 +5,11 @@
 
 use futures::{Future, Sink};
 
+use body::Body;
 use header;
 use http;
 use status::StatusCode;
 use version;
-
-type Body = ::tokio_proto::streaming::Body<http::Chunk, ::Error>;
 
 /// The outgoing half for a Tcp connection, created by a `Server` and given to a `Handler`.
 ///


### PR DESCRIPTION
Create a `body::Body` struct, exposed as `hyper::Body` that wraps a `tokio_proto`-`Body`.

Added `std::From` methods to convert from `tokio_proto`-`Body` to `body::Body` and back.
Made naming of `Body` declarations somewhat consistent across `Server`, `Server Request`, `Server Response`, `Client`, `Client Request`, and `Client Response`.
Impl `Stream` for `body::Body` so that applications can read from the body as if it were a `tokio_proto::streaming`-`Body`

All examples still work and tests are passing (except those that were broken before this modification).

Part 1/2 to close #969 