### PR TITLE
[Tokio Branch] Fix examples failing in `cargo test`

### DIFF
--- a/src/header/common/access_control_allow_methods.rs
+++ b/src/header/common/access_control_allow_methods.rs
@@ -19,7 +19,7 @@ header! {
     /// # Examples
     /// ```
     /// use hyper::header::{Headers, AccessControlAllowMethods};
-    /// use hyper::method::Method;
+    /// use hyper::Method;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(
@@ -28,7 +28,7 @@ header! {
     /// ```
     /// ```
     /// use hyper::header::{Headers, AccessControlAllowMethods};
-    /// use hyper::method::Method;
+    /// use hyper::Method;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(

--- a/src/header/common/access_control_request_method.rs
+++ b/src/header/common/access_control_request_method.rs
@@ -17,7 +17,7 @@ header! {
     /// # Examples
     /// ```
     /// use hyper::header::{Headers, AccessControlRequestMethod};
-    /// use hyper::method::Method;
+    /// use hyper::Method;
     /// 
     /// let mut headers = Headers::new();
     /// headers.set(AccessControlRequestMethod(Method::Get));

--- a/src/header/common/allow.rs
+++ b/src/header/common/allow.rs
@@ -21,7 +21,7 @@ header! {
     /// # Examples
     /// ```
     /// use hyper::header::{Headers, Allow};
-    /// use hyper::method::Method;
+    /// use hyper::Method;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(
@@ -30,7 +30,7 @@ header! {
     /// ```
     /// ```
     /// use hyper::header::{Headers, Allow};
-    /// use hyper::method::Method;
+    /// use hyper::Method;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(


### PR DESCRIPTION
`hyper::method::Method` is no longer accessible by users of hyper.
Must use `hyper::Method` instead.

All tests and examples now pass.