### PR TITLE
fix(client): only set Host header when not present

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -303,10 +303,12 @@ impl<'a> RequestBuilder<'a> {
                 }
 
                 let mut h = Headers::new();
-                h.set(Host {
-                    hostname: host.to_owned(),
-                    port: Some(port),
-                });
+                if !h.has::<Host>() {
+                    h.set(Host {
+                        hostname: host.to_owned(),
+                        port: Some(port),
+                    });
+                }
                 if let Some(ref headers) = headers {
                     h.extend(headers.iter());
                 }


### PR DESCRIPTION
This allows the client to override the host header. The feature is
useful for times when an address is provided and the server has a
virtual host mapping.