### PR TITLE
feat(net): update openssl to 0.9 and cookies to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,11 @@ unicase = "1.0"
 url = "1.0"
 
 [dependencies.cookie]
-version = "0.2"
+version = "0.4"
 default-features = false
 
 [dependencies.openssl]
-version = "0.7"
-optional = true
-
-[dependencies.openssl-verify]
-version = "0.1"
+version = "0.9"
 optional = true
 
 [dependencies.security-framework]
@@ -53,6 +49,6 @@ env_logger = "0.3"
 
 [features]
 default = ["ssl"]
-ssl = ["openssl", "openssl-verify", "cookie/secure"]
+ssl = ["openssl", "cookie/secure"]
 serde-serialization = ["serde", "mime/serde"]
 nightly = []

--- a/src/client/proxy.rs
+++ b/src/client/proxy.rs
@@ -7,7 +7,7 @@ use method::Method;
 use net::{NetworkConnector, HttpConnector, NetworkStream, SslClient};
 
 #[cfg(all(feature = "openssl", not(feature = "security-framework")))]
-pub fn tunnel(proxy: (Cow<'static, str>, u16)) -> Proxy<HttpConnector, ::net::Openssl> {
+pub fn tunnel(proxy: (Cow<'static, str>, u16)) -> Proxy<HttpConnector, ::net::OpensslClient> {
     Proxy {
         connector: HttpConnector,
         proxy: proxy,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,6 @@ extern crate time;
 #[macro_use] extern crate url;
 #[cfg(feature = "openssl")]
 extern crate openssl;
-#[cfg(feature = "openssl-verify")]
-extern crate openssl_verify;
 #[cfg(feature = "security-framework")]
 extern crate security_framework;
 #[cfg(feature = "serde-serialization")]

--- a/src/server/listener.rs
+++ b/src/server/listener.rs
@@ -7,7 +7,7 @@ pub struct ListenerPool<A: NetworkListener> {
     acceptor: A
 }
 
-impl<A: NetworkListener + Send + 'static> ListenerPool<A> {
+impl<A: NetworkListener + Send + Clone + 'static> ListenerPool<A> {
     /// Create a thread pool to manage the acceptor.
     pub fn new(acceptor: A) -> ListenerPool<A> {
         ListenerPool { acceptor: acceptor }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -223,7 +223,7 @@ impl<S: SslServer + Clone + Send> Server<HttpsListener<S>> {
     }
 }
 
-impl<L: NetworkListener + Send + 'static> Server<L> {
+impl<L: NetworkListener + Send + Clone + 'static> Server<L> {
     /// Binds to a socket and starts handling connections.
     pub fn handle<H: Handler + 'static>(self, handler: H) -> ::Result<Listening> {
         self.handle_threads(handler, num_cpus::get() * 5 / 4)
@@ -238,7 +238,8 @@ impl<L: NetworkListener + Send + 'static> Server<L> {
 }
 
 fn handle<H, L>(mut server: Server<L>, handler: H, threads: usize) -> ::Result<Listening>
-where H: Handler + 'static, L: NetworkListener + Send + 'static {
+    where H: Handler + 'static, L: NetworkListener + Send + Clone + 'static
+{
     let socket = try!(server.listener.local_addr());
 
     debug!("threads = {:?}", threads);


### PR DESCRIPTION
As the title suggests. This change came about because I want to use the latest version of cookies, which requires the latest version of openssl. Furthermore, this allows for compilation with `ssl` on OS X without messing up the local libraries due to improvements in the `openssl` crate.