### PR TITLE
Don't write a 0-length buffer in flush()

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -145,6 +145,9 @@ impl<T: Write> Write for IoBuf<T> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
+        if self.write_buf.len() == 0 {
+            return Ok(())
+        }
         self.write_buf.write_into(&mut self.transport).and_then(|_n| {
             if self.write_buf.is_empty() {
                 Ok(())


### PR DESCRIPTION
Ends up fixing some cases when the underlying writer doesn't handle a
0-length write well, and also hopefully a nice operation to skip!