### PR TITLE
refactor(client): remove unused client type aliases

### DIFF
--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -30,9 +30,6 @@ pub trait Connect {
     fn register(&mut self, Registration);
 }
 
-type Scheme = String;
-type Port = u16;
-
 /// A connector for the `http` scheme.
 pub struct HttpConnector {
     dns: Option<Dns>,


### PR DESCRIPTION
These type aliases cause test build to fail due to strict LINT settings

If these types should be preserved (used outside the test suite), please let me know and I can instead disable the LINT for these types.