### PR TITLE
implemented a feature to use native-tls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ optional = true
 version = "0.1.4"
 optional = true
 
+[dependencies.native-tls]
+version = "0.1"
+optional = true
+
 [dependencies.solicit]
 version = "0.4"
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,8 @@ extern crate openssl;
 extern crate openssl_verify;
 #[cfg(feature = "security-framework")]
 extern crate security_framework;
+#[cfg(feature = "native-tls")]
+extern crate native_tls;
 #[cfg(feature = "serde-serialization")]
 extern crate serde;
 extern crate cookie;

--- a/src/net.rs
+++ b/src/net.rs
@@ -11,6 +11,9 @@ pub use self::openssl::{Openssl, OpensslClient};
 #[cfg(feature = "security-framework")]
 pub use self::security_framework::ClientWrapper;
 
+#[cfg(feature = "native-tls")]
+pub use self::native_tls::{ClientWrapper, ServerWrapper};
+
 use std::time::Duration;
 
 use typeable::Typeable;
@@ -603,16 +606,19 @@ impl<S: SslClient, C: NetworkConnector<Stream=HttpStream>> NetworkConnector for 
 }
 
 
-#[cfg(all(not(feature = "openssl"), not(feature = "security-framework")))]
+#[cfg(all(not(feature = "openssl"), not(feature = "security-framework"), not(feature = "native-tls")))]
 #[doc(hidden)]
 pub type DefaultConnector = HttpConnector;
 
-#[cfg(feature = "openssl")]
+#[cfg(all(feature = "openssl", not(feature = "security-framework"), not(feature = "native-tls")))]
 #[doc(hidden)]
 pub type DefaultConnector = HttpsConnector<self::openssl::OpensslClient>;
 
-#[cfg(all(feature = "security-framework", not(feature = "openssl")))]
+#[cfg(all(not(feature = "openssl"), feature = "security-framework", not(feature = "native-tls")))]
 pub type DefaultConnector = HttpsConnector<self::security_framework::ClientWrapper>;
+
+#[cfg(all(not(feature = "openssl"), not(feature = "security-framework"), feature = "native-tls"))]
+pub type DefaultConnector = HttpsConnector<self::native_tls::ClientWrapper>;
 
 #[cfg(feature = "openssl")]
 mod openssl {
@@ -813,6 +819,122 @@ pub mod security_framework {
 
     #[derive(Clone)]
     pub struct Stream(Arc<Mutex<SslStream<HttpStream>>>);
+
+    impl io::Read for Stream {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).read(buf)
+        }
+
+        fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).read_to_end(buf)
+        }
+
+        fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).read_to_string(buf)
+        }
+
+        fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).read_exact(buf)
+        }
+    }
+
+    impl io::Write for Stream {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).flush()
+        }
+
+        fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).write_all(buf)
+        }
+
+        fn write_fmt(&mut self, fmt: fmt::Arguments) -> io::Result<()> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).write_fmt(fmt)
+        }
+    }
+
+    impl NetworkStream for Stream {
+        fn peer_addr(&mut self) -> io::Result<SocketAddr> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).get_mut().peer_addr()
+        }
+
+        fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).get_mut().set_read_timeout(dur)
+        }
+
+        fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).get_mut().set_write_timeout(dur)
+        }
+
+        fn close(&mut self, how: Shutdown) -> io::Result<()> {
+            self.0.lock().unwrap_or_else(|e| e.into_inner()).get_mut().close(how)
+        }
+    }
+}
+
+#[cfg(feature = "native-tls")]
+mod native_tls {
+    use std::io::{self};
+
+    use error::Error;
+    use net::{SslClient, SslServer, NetworkStream, HttpStream};
+    use std::fmt;
+    use std::sync::{Arc, Mutex};
+    use std::net::{Shutdown, SocketAddr};
+    use std::time::Duration;
+
+    use native_tls::{TlsConnector, TlsAcceptor, TlsStream};
+
+    pub struct ClientWrapper(TlsConnector);
+
+    impl Default for ClientWrapper {
+        fn default() -> ClientWrapper {
+            ClientWrapper(TlsConnector::builder().unwrap().build().unwrap())
+        }
+    }
+
+    impl ClientWrapper {
+        pub fn new(builder: TlsConnector) -> ClientWrapper {
+            ClientWrapper(builder)
+        }
+    }
+
+    impl SslClient for ClientWrapper {
+        type Stream = Stream;
+
+        fn wrap_client(&self, stream: HttpStream, host: &str) -> ::Result<Stream> {
+            match self.0.connect(host, stream) {
+                Ok(s) => Ok(Stream(Arc::new(Mutex::new(s)))),
+                Err(e) => Err(Error::Ssl(e.into())),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct ServerWrapper(Arc<TlsAcceptor>);
+
+    impl ServerWrapper {
+        pub fn new(builder: TlsAcceptor) -> ServerWrapper {
+            ServerWrapper(Arc::new(builder))
+        }
+    }
+
+    impl SslServer for ServerWrapper {
+        type Stream = Stream;
+
+        fn wrap_server(&self, stream: HttpStream) -> ::Result<Stream> {
+            match self.0.accept(stream) {
+                Ok(s) => Ok(Stream(Arc::new(Mutex::new(s)))),
+                Err(e) => Err(Error::Ssl(e.into())),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct Stream(Arc<Mutex<TlsStream<HttpStream>>>);
 
     impl io::Read for Stream {
         fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {


### PR DESCRIPTION
Use https://github.com/sfackler/rust-native-tls to provide the TLS stack.

I have only tested this with hyper client, because I only need client side TLS in my application. Also it is based on th 0.9.x branch, not current master. If you think this could actually be merged, I will try to rebase it to master. Right now it is just in the state that works for me . :)