### PR TITLE
docs(server): fix Response::set_status() documentation

### DIFF
--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -35,7 +35,7 @@ impl<'a> Response<'a> {
     #[inline]
     pub fn headers_mut(&mut self) -> &mut header::Headers { &mut self.head.headers }
 
-    /// Get a mutable reference to the status.
+    /// Set the status of this response.
     #[inline]
     pub fn set_status(&mut self, status: StatusCode) {
         self.head.subject = status;


### PR DESCRIPTION
`Response::set_status(&mut self, status: StatusCode)` sets the status of the response and does not return a mutable reference.