### PR TITLE
Client functions don't need a mutable self.

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -25,7 +25,7 @@ fn main() {
     };
 
     let mut core = tokio_core::reactor::Core::new().unwrap();
-    let mut client = Client::new(&core.handle());
+    let client = Client::new(&core.handle());
 
     let work = client.get(url.parse().unwrap()).and_then(|res| {
         println!("Response: {}", res.status());

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -83,13 +83,13 @@ impl<C: Connect> Client<C> {
 
     /// Send a GET Request using this Client.
     #[inline]
-    pub fn get(&mut self, url: Url) -> FutureResponse {
+    pub fn get(&self, url: Url) -> FutureResponse {
         self.request(Request::new(Method::Get, url))
     }
 
     /// Send a constructed Request using this Client.
     #[inline]
-    pub fn request(&mut self, req: Request) -> FutureResponse {
+    pub fn request(&self, req: Request) -> FutureResponse {
         self.call(req)
     }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -49,7 +49,7 @@ macro_rules! test {
             let server = TcpListener::bind("127.0.0.1:0").unwrap();
             let addr = server.local_addr().unwrap();
             let mut core = Core::new().unwrap();
-            let mut client = client(&core.handle());
+            let client = client(&core.handle());
             let mut req = Request::new(Method::$client_method, format!($client_url, addr=addr).parse().unwrap());
             $(
                 req.headers_mut().set($request_headers);
@@ -197,7 +197,7 @@ fn client_keep_alive() {
     let server = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = server.local_addr().unwrap();
     let mut core = Core::new().unwrap();
-    let mut client = client(&core.handle());
+    let client = client(&core.handle());
 
 
     let (tx1, rx1) = oneshot::channel();
@@ -235,7 +235,7 @@ fn client_pooled_socket_disconnected() {
     let server = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = server.local_addr().unwrap();
     let mut core = Core::new().unwrap();
-    let mut client = client(&core.handle());
+    let client = client(&core.handle());
 
 
     let (tx1, rx1) = oneshot::channel();


### PR DESCRIPTION
Hi,

Is there a reason these client functions require a `&mut self`? Makes integrating this to our project much easier if they would be immutable.

Tests seem to pass.