### PR TITLE
Explain content_type assigned type

### DIFF
--- a/src/header/common/content_type.rs
+++ b/src/header/common/content_type.rs
@@ -3,7 +3,7 @@ use mime::Mime;
 header! {
     /// `Content-Type` header, defined in
     /// [RFC7231](http://tools.ietf.org/html/rfc7231#section-3.1.1.5)
-    /// 
+    ///
     /// The `Content-Type` header field indicates the media type of the
     /// associated representation: either the representation enclosed in the
     /// message payload or the selected representation, as determined by the
@@ -11,22 +11,26 @@ header! {
     /// format and how that data is intended to be processed by a recipient,
     /// within the scope of the received message semantics, after any content
     /// codings indicated by Content-Encoding are decoded.
-    /// 
+    ///
+    /// Although the `mime` crate allows the mime options to be any slice, this crate
+    /// forces the use of Vec. This is to make sure the same header can't have more than 1 type. If
+    /// this is an issue, it's possible to implement `Header` on a custom struct.
+    ///
     /// # ABNF
     /// ```plain
     /// Content-Type = media-type
     /// ```
-    /// 
+    ///
     /// # Example values
     /// * `text/html; charset=ISO-8859-4`
-    /// 
+    ///
     /// # Examples
     /// ```
     /// use hyper::header::{Headers, ContentType};
     /// use hyper::mime::{Mime, TopLevel, SubLevel};
-    /// 
+    ///
     /// let mut headers = Headers::new();
-    /// 
+    ///
     /// headers.set(
     ///     ContentType(Mime(TopLevel::Text, SubLevel::Html, vec![]))
     /// );
@@ -34,9 +38,9 @@ header! {
     /// ```
     /// use hyper::header::{Headers, ContentType};
     /// use hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
-    /// 
+    ///
     /// let mut headers = Headers::new();
-    /// 
+    ///
     /// headers.set(
     ///     ContentType(Mime(TopLevel::Application, SubLevel::Json,
     ///                      vec![(Attr::Charset, Value::Utf8)]))


### PR DESCRIPTION
docs(headers) Explain why content_type doesn't use generic `mime`.

For anyone that follows with the same question. 

Related to #991 