### PR TITLE
Fix the server_get_fixed_response test

### DIFF
--- a/src/http/conn.rs
+++ b/src/http/conn.rs
@@ -118,7 +118,11 @@ impl<I: Io, T: Http1Transaction, K: KeepAlive> Conn<I, T, K> {
                 let wants_keep_alive = head.should_keep_alive();
                 self.state.keep_alive &= wants_keep_alive;
                 let (body, reading) = if decoder.is_eof() {
-                    (false, Reading::KeepAlive)
+                    if wants_keep_alive {
+                        (false, Reading::KeepAlive)
+                    } else {
+                        (false, Reading::Closed)
+                    }
                 } else {
                     (true, Reading::Body(decoder))
                 };


### PR DESCRIPTION
I found that when decoding headers the connection would erroneously move itself
to the `Reading::KeepAlive` state even though `wants_keep_alive` is false. This
commit touches up the logic in conn.rs to check this predict the next state
accordingly, fixing a failing server_get_fixed_response locally for me.