### PR TITLE
Set timeouts immediately after accepting a connection

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -198,11 +198,13 @@ impl<L: NetworkListener> Server<L> {
 
     /// Sets the read timeout for all Request reads.
     pub fn set_read_timeout(&mut self, dur: Option<Duration>) {
+        self.listener.set_read_timeout(dur);
         self.timeouts.read = dur;
     }
 
     /// Sets the write timeout for all Response writes.
     pub fn set_write_timeout(&mut self, dur: Option<Duration>) {
+        self.listener.set_write_timeout(dur);
         self.timeouts.write = dur;
     }
 }


### PR DESCRIPTION
This is a possible solution for #950. I'm not running this in production yet, and thus could not confirm whether it really solves the problem. I thought I'd submit it anyway, so it can get some review. Whether or not this really is a solution for #950, I believe it fixes a real problem and should be merged in any case.

I've struggled and failed to come up with an automated test to verify that this does what it intends to do. Since there doesn't seem to be a test for timeout behavior currently, and this is a relatively straight-forward change, I decided to submit it without an automated test.

Please note that this only affects the server-side code. I haven't checked whether the same problem is present client-side.

Another note: This pull request sets the default read and write timeouts to `None`, which I believe preserves the current behavior. This might not be a good default for a server-side application, so some thought should be put into whether to change this.

A reminder to me, or in case I forgot, anyone else who might read this: This pull request adds default implementations of trait methods that should be removed in the next release which includes breaking changes (see comments in code). It would probably be a good idea to open an issue as a reminder, in case this pull request is merged.