### PR TITLE
Refactor(uri): Remove usage of Url parse in Uri #1022

### DIFF
--- a/src/uri.rs
+++ b/src/uri.rs
@@ -70,10 +70,13 @@ impl Uri {
                     "blob" | "file" => return Err(Error::Method),
                     _ => return Err(Error::Method),
                 }
-                if let Some(a) = auth {
-                    if (end + 3) == a {
-                        return Err(Error::Method);
-                    }
+                match auth {
+                    Some(a) => {
+                        if (end + 3) == a {
+                            return Err(Error::Method);
+                        }
+                    },
+                    None => return Err(Error::Method),
                 }
             }
             Ok(Uri {
@@ -181,13 +184,13 @@ fn parse_scheme(s: &str) -> Option<usize> {
 
 fn parse_authority(s: &str) -> Option<usize> {
     let v: Vec<&str> = s.split("://").collect();
-    let auth = v.last().unwrap()
-        .split("/")
-        .next()
-        .unwrap_or(s)
-        .len() + if v.len() == 2 { v[0].len() + 3 } else { 0 };
-       
-    return Some(auth);
+    match v.last() {
+        Some(auth) => Some(auth.split("/")
+                           .next()
+                           .unwrap_or(s)
+                           .len() + if v.len() == 2 { v[0].len() + 3 } else { 0 }),
+        None => None,
+    }
 }
 
 fn parse_query(s: &str) -> Option<usize> {

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -88,6 +88,9 @@ impl Uri {
         let end = self.source.len() - if query_len > 0 { query_len + 1 } else { 0 } -
             if fragment_len > 0 { fragment_len + 1 } else { 0 };
         if index >= end {
+            if self.scheme().is_some() {
+                return "/" // absolute-form MUST have path
+            }
             ""
         } else {
             &self.source[index..end]
@@ -317,7 +320,7 @@ test_parse! {
     "http://127.0.0.1:80",
 
     scheme = Some("http"),
-    authority = Some("127.0.0.1"),
+    authority = Some("127.0.0.1:80"),
     path = "/",
     query = None,
     fragment = None,
@@ -328,7 +331,7 @@ test_parse! {
     "https://127.0.0.1:443",
 
     scheme = Some("https"),
-    authority = Some("127.0.0.1"),
+    authority = Some("127.0.0.1:443"),
     path = "/",
     query = None,
     fragment = None,

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -107,6 +107,7 @@ impl Uri {
     pub fn authority(&self) -> Option<&str> {
         if let Some(end) = self.authority_end {
             let index = self.scheme_end.map(|i| i + 3).unwrap_or(0);
+
             Some(&self.source[index..end])
         } else {
             None

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -62,10 +62,24 @@ impl Uri {
                 fragment: parse_fragment(s),
             })
         } else if s.contains("://") {
+            let scheme = parse_scheme(s);
+            let auth = parse_authority(s);
+            if let Some(end) = scheme {
+                match &s[..end] {
+                    "ftp" | "gopher" | "http" | "https" | "ws" | "wss" => {},
+                    "blob" | "file" => return Err(Error::Method),
+                    _ => return Err(Error::Method),
+                }
+                if let Some(a) = auth {
+                    if (end + 3) == a {
+                        return Err(Error::Method);
+                    }
+                }
+            }
             Ok(Uri {
                 source: s.to_owned().into(),
-                scheme_end: parse_scheme(s),
-                authority_end: parse_authority(s),
+                scheme_end: scheme,
+                authority_end: auth,
                 query: parse_query(s),
                 fragment: parse_fragment(s),
             })


### PR DESCRIPTION
Remove usage of Url parse, add basic parse methods. 

Also add minimal error handling, default port/path handling (tests adjusted accordingly). 

https://github.com/hyperium/hyper/issues/1022