### PR TITLE
test(lib): use public hyper::Url everywhere

### DIFF
--- a/src/client/connect.rs
+++ b/src/client/connect.rs
@@ -7,7 +7,7 @@ use tokio::io::Io;
 use tokio::reactor::Handle;
 use tokio::net::{TcpStream, TcpStreamNew};
 use tokio_service::Service;
-use url::Url;
+use Url;
 
 use super::dns;
 
@@ -185,7 +185,7 @@ impl<S: SslClient> HttpsConnector<S> {
 mod tests {
     use std::io;
     use tokio::reactor::Core;
-    use url::Url;
+    use Url;
     use super::{Connect, HttpConnector};
 
     #[test]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -23,7 +23,7 @@ use header::{Headers, Host};
 use http::{self, TokioBody};
 use method::Method;
 use self::pool::{Pool, Pooled};
-use {Url};
+use Url;
 
 pub use self::connect::{HttpConnector, Connect};
 pub use self::request::Request;
@@ -323,7 +323,7 @@ mod tests {
     use header::Server;
     use super::{Client};
     use super::pool::Pool;
-    use url::Url;
+    use Url;
 
     mock_connector!(Issue640Connector {
         b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\n",

--- a/src/client/request.rs
+++ b/src/client/request.rs
@@ -93,7 +93,7 @@ mod tests {
     /*
     use std::io::Write;
     use std::str::from_utf8;
-    use url::Url;
+    use Url;
     use method::Method::{Get, Head, Post};
     use mock::{MockStream, MockConnector};
     use net::Fresh;

--- a/src/http/h2/mod.rs
+++ b/src/http/h2/mod.rs
@@ -427,7 +427,7 @@ mod tests {
 
     use header::Headers;
     use header;
-    use url::Url;
+    use Url;
     use method;
     use cookie;
     use version;

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::fmt::{Display, self};
 use std::str::FromStr;
-use url::Url;
+use Url;
 use url::ParseError as UrlError;
 
 use Error;


### PR DESCRIPTION
- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
