### PR TITLE
refactor(examples): remove use of depricated futures features

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -4,6 +4,8 @@ extern crate futures;
 extern crate pretty_env_logger;
 //extern crate num_cpus;
 
+use futures::future::FutureResult;
+
 use hyper::header::{ContentLength, ContentType};
 use hyper::server::{Http, Service, Request, Response};
 
@@ -16,9 +18,9 @@ impl Service for Hello {
     type Request = Request;
     type Response = Response;
     type Error = hyper::Error;
-    type Future = ::futures::Finished<Response, hyper::Error>;
+    type Future = FutureResult<Response, hyper::Error>;
     fn call(&self, _req: Request) -> Self::Future {
-        ::futures::finished(
+        futures::future::ok(
             Response::new()
                 .with_header(ContentLength(PHRASE.len() as u64))
                 .with_header(ContentType::plaintext())

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -3,6 +3,8 @@ extern crate futures;
 extern crate hyper;
 extern crate pretty_env_logger;
 
+use futures::future::FutureResult;
+
 use hyper::{Get, Post, StatusCode};
 use hyper::header::ContentLength;
 use hyper::server::{Http, Service, Request, Response};
@@ -16,10 +18,10 @@ impl Service for Echo {
     type Request = Request;
     type Response = Response;
     type Error = hyper::Error;
-    type Future = ::futures::Finished<Response, hyper::Error>;
+    type Future = FutureResult<Response, hyper::Error>;
 
     fn call(&self, req: Request) -> Self::Future {
-        ::futures::finished(match (req.method(), req.path()) {
+        futures::future::ok(match (req.method(), req.path()) {
             (&Get, "/") | (&Get, "/echo") => {
                 Response::new()
                     .with_header(ContentLength(INDEX.len() as u64))


### PR DESCRIPTION
The "Finished" struct and "finished" method have been deprecated[0]
and don't show up in the futures docs. Prefer non-deprecated
features for users exploring the examples.

[0] https://github.com/alexcrichton/futures-rs/blob/0.1.10/src/future/mod.rs#L25

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
