### PR TITLE
fix(lib): export Origin enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ extern crate test;
 
 
 pub use uri::Uri;
-pub use url::Url;
+pub use url::{Url, Origin};
 pub use client::Client;
 pub use error::{Result, Error};
 pub use header::Headers;


### PR DESCRIPTION
Since the `Url` struct implements an `origin()` method returning an `Origin`, provide the means to use it