### PR TITLE
fix(url): fix panic when questionmark is in fragment

### DIFF
--- a/src/uri.rs
+++ b/src/uri.rs
@@ -201,7 +201,11 @@ fn parse_query(s: &str) -> Option<usize> {
         Some(i) => {
             let frag_pos = s.find('#').unwrap_or(s.len());
 
-            return Some(frag_pos - i - 1);
+            if frag_pos < i + 1 {
+                None
+            } else {
+                Some(frag_pos - i - 1)
+            }
         },
         None => None,
     }
@@ -411,6 +415,18 @@ test_parse! {
     query = None,
     fragment = None,
     port = Some(443),
+}
+
+test_parse! {
+    test_uri_parse_fragment_questionmark,
+    "http://127.0.0.1/#?",
+
+    scheme = Some("http"),
+    authority = Some("127.0.0.1"),
+    path = "/",
+    query = None,
+    fragment = Some("?"),
+    port = None,
 }
 
 #[test]


### PR DESCRIPTION
- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines

`Url::parse` panicked if a questionmark is in the fragment part:

```
panicked at 'attempt to subtract with overflow', src/uri.rs:207
```

This was found by [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz)