### PR TITLE
fix(http): Fix commit fac3d70c0b716157ba689ae2b8a0089b6afc9bdc

### DIFF
--- a/src/http/chunk.rs
+++ b/src/http/chunk.rs
@@ -45,7 +45,7 @@ impl From<Bytes> for Chunk {
 
 impl From<Chunk> for Bytes {
     fn from(chunk: Chunk) -> Bytes {
-        match self.0 {
+        match chunk.0 {
             Inner::Shared(bytes) => bytes,
         }
     }


### PR DESCRIPTION
The new From<Chunk> for Bytes uses self instead of chunk in its
implementation of From::from.  Change it to chunk to fix the build.

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
