### PR TITLE
[WIP] fix bugs in header field parsers

### DIFF
--- a/src/header/common/accept.rs
+++ b/src/header/common/accept.rs
@@ -114,6 +114,11 @@ header! {
                     SubLevel::Plain, vec![(Attr::Charset, Value::Utf8)]),
                     Quality(500)),
             ])));
+        test_header!(
+            test_fuzzing1,
+            vec![b"chunk#;e"],
+            None
+        );
     }
 }
 

--- a/src/header/common/accept.rs
+++ b/src/header/common/accept.rs
@@ -114,11 +114,13 @@ header! {
                     SubLevel::Plain, vec![(Attr::Charset, Value::Utf8)]),
                     Quality(500)),
             ])));
-        test_header!(
-            test_fuzzing1,
-            vec![b"chunk#;e"],
-            None
-        );
+
+        #[test]
+        fn test_fuzzing1() {
+            let raw: Raw = "chunk#;e".into();
+            let header = Accept::parse_header(&raw);
+            assert!(header.is_ok());
+        }
     }
 }
 

--- a/src/header/common/etag.rs
+++ b/src/header/common/etag.rs
@@ -83,6 +83,9 @@ header! {
         test_header!(test14,
             vec![b"matched-\"dquotes\""],
             None::<ETag>);
+        test_header!(test15,
+            vec![b"\""],
+            None::<ETag>);
     }
 }
 

--- a/src/header/shared/entity.rs
+++ b/src/header/shared/entity.rs
@@ -123,15 +123,17 @@ impl FromStr for EntityTag {
         let length: usize = s.len();
         let slice = &s[..];
         // Early exits if it doesn't terminate in a DQUOTE.
-        if !slice.ends_with('"') {
+        if !slice.ends_with('"') || slice.len() < 2 {
             return Err(::Error::Header);
         }
         // The etag is weak if its first char is not a DQUOTE.
-        if slice.starts_with('"') && check_slice_validity(&slice[1..length-1]) {
+        if slice.len() >= 2 && slice.starts_with('"')
+                && check_slice_validity(&slice[1..length-1]) {
             // No need to check if the last char is a DQUOTE,
             // we already did that above.
             return Ok(EntityTag { weak: false, tag: slice[1..length-1].to_owned() });
-        } else if slice.starts_with("W/\"") && check_slice_validity(&slice[3..length-1]) {
+        } else if slice.len() >= 4 && slice.starts_with("W/\"")
+                && check_slice_validity(&slice[3..length-1]) {
             return Ok(EntityTag { weak: true, tag: slice[3..length-1].to_owned() });
         }
         Err(::Error::Header)


### PR DESCRIPTION
- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines

Bugs found using fuzzing in:

* `QualityItem` (fixed)
* `ETag` (fixed)
* `Authorization` header field (both simple and bearer schemes)
* `ContentType` header
* maybe more as the fuzzer is still running...

Do you want to include fuzzers in this repository?