### PR TITLE
feat(lib): remove extern Url type usage

### DIFF
--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -28,7 +28,7 @@ fn get_one_at_a_time(b: &mut test::Bencher) {
 
     let client = hyper::Client::new(&handle);
 
-    let url: hyper::Url = format!("http://{}/get", addr).parse().unwrap();
+    let url: hyper::Uri = format!("http://{}/get", addr).parse().unwrap();
 
     b.bytes = 160 * 2 + PHRASE.len() as u64;
     b.iter(move || {
@@ -51,7 +51,7 @@ fn post_one_at_a_time(b: &mut test::Bencher) {
 
     let client = hyper::Client::new(&handle);
 
-    let url: hyper::Url = format!("http://{}/get", addr).parse().unwrap();
+    let url: hyper::Uri = format!("http://{}/get", addr).parse().unwrap();
 
     let post = "foo bar baz quux";
     b.bytes = 180 * 2 + post.len() as u64 + PHRASE.len() as u64;

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -24,8 +24,8 @@ fn main() {
         }
     };
 
-    let url = hyper::Url::parse(&url).unwrap();
-    if url.scheme() != "http" {
+    let url = url.parse::<hyper::Uri>().unwrap();
+    if url.scheme() != Some("http") {
         println!("This example only works with 'http' URLs.");
         return;
     }

--- a/src/header/common/content_disposition.rs
+++ b/src/header/common/content_disposition.rs
@@ -9,10 +9,9 @@
 use language_tags::LanguageTag;
 use std::fmt;
 use unicase::UniCase;
-use url::percent_encoding;
 
 use header::{Header, Raw, parsing};
-use header::parsing::{parse_extended_value, HTTP_VALUE};
+use header::parsing::{parse_extended_value, http_percent_encode};
 use header::shared::Charset;
 
 /// The implied disposition of the content of the HTTP body
@@ -182,8 +181,7 @@ impl fmt::Display for ContentDisposition {
                             try!(write!(f, "{}", lang));
                         };
                         try!(write!(f, "'"));
-                        try!(f.write_str(
-                            &percent_encoding::percent_encode(bytes, HTTP_VALUE).to_string()))
+                        try!(http_percent_encode(f, bytes))
                     }
                 },
                 DispositionParam::Ext(ref k, ref v) => try!(write!(f, "; {}=\"{}\"", k, v)),

--- a/src/http/h1/parse.rs
+++ b/src/http/h1/parse.rs
@@ -61,7 +61,7 @@ impl Http1Transaction for ServerTransaction {
         let path = unsafe { ByteStr::from_utf8_unchecked(path) };
         let subject = RequestLine(
             method,
-            try!(::uri::from_mem_str(path)),
+            try!(::uri::from_byte_str(path)),
         );
 
         headers.extend(HeadersAsBytesIter {

--- a/src/http/str.rs
+++ b/src/http/str.rs
@@ -1,8 +1,9 @@
+use std::ops::Deref;
 use std::str;
 
 use bytes::Bytes;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ByteStr(Bytes);
 
 impl ByteStr {
@@ -10,7 +11,35 @@ impl ByteStr {
         ByteStr(slice)
     }
 
+    pub fn from_static(s: &'static str) -> ByteStr {
+        ByteStr(Bytes::from_static(s.as_bytes()))
+    }
+
+    pub fn slice(&self, from: usize, to: usize) -> ByteStr {
+        assert!(self.as_str().is_char_boundary(from));
+        assert!(self.as_str().is_char_boundary(to));
+        ByteStr(self.0.slice(from, to))
+    }
+
+    pub fn slice_to(&self, idx: usize) -> ByteStr {
+        assert!(self.as_str().is_char_boundary(idx));
+        ByteStr(self.0.slice_to(idx))
+    }
+
     pub fn as_str(&self) -> &str {
         unsafe { str::from_utf8_unchecked(self.0.as_ref()) }
+    }
+}
+
+impl Deref for ByteStr {
+    type Target = str;
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<'a> From<&'a str> for ByteStr {
+    fn from(s: &'a str) -> ByteStr {
+        ByteStr(Bytes::from(s))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc(html_root_url = "https://hyperium.github.io/hyper/")]
 #![deny(missing_docs)]
-//#![deny(warnings)]
+#![deny(warnings)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 
@@ -35,7 +35,6 @@ extern crate test;
 
 
 pub use uri::Uri;
-pub use url::Url;
 pub use client::Client;
 pub use error::{Result, Error};
 pub use header::Headers;


### PR DESCRIPTION
Closes #1089 

BREAKING CHANGE: 

The `Url` type is no longer used. Any instance in the
  `Client` API has had it replaced with `hyper::Uri`.

  This also means `Error::Uri` has changed types to
  `hyper::error::UriError`.

  The type `hyper::header::parsing::HTTP_VALUE` has been made private,
  as an implementation detail. The function `http_percent_encoding`
  should be used instead.
