### PR TITLE
feat(client): add Client::handle

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -77,6 +77,12 @@ impl Client<HttpConnector, http::Body> {
 }
 
 impl<C, B> Client<C, B> {
+    /// Return a reference to a handle to the event loop this Client is associated with.
+    #[inline]
+    pub fn handle<'a>(&'a self) -> &'a Handle {
+        &self.handle
+    }
+
     /// Create a new client with a specific connector.
     #[inline]
     fn configured(config: Config<C, B>, handle: &Handle) -> Client<C, B> {


### PR DESCRIPTION
This is useful for external structs which own (or have a reference to) a `Client` but have no access to the event loop the client is associated with.

- [X] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
