### PR TITLE
feature(version): impl FromStr for HttpVersion

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -61,6 +61,7 @@ impl Default for HttpVersion {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+    use error::Error;
     use super::HttpVersion;
     use super::HttpVersion::{Http09,Http10,Http11,H2,H2c};
 
@@ -81,7 +82,8 @@ mod tests {
     #[test]
     fn test_from_str_panic() {
         match HttpVersion::from_str("foo") {
-            Err(_) => assert!(true),
+            Err(Error::Version) => assert!(true),
+            Err(_) => assert!(false),
             Ok(_) => assert!(false),
         }
     }

--- a/src/version.rs
+++ b/src/version.rs
@@ -57,3 +57,31 @@ impl Default for HttpVersion {
         Http11
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use super::HttpVersion;
+    use super::HttpVersion::{Http09,Http10,Http11,H2,H2c};
+
+    #[test]
+    fn test_default() {
+        assert_eq!(Http11, HttpVersion::default());
+    }
+
+    #[test]
+    fn test_from_str() {
+        assert_eq!(Http09, HttpVersion::from_str("HTTP/0.9").unwrap());
+        assert_eq!(Http10, HttpVersion::from_str("HTTP/1.0").unwrap());
+        assert_eq!(Http11, HttpVersion::from_str("HTTP/1.1").unwrap());
+        assert_eq!(H2, HttpVersion::from_str("h2").unwrap());
+        assert_eq!(H2c, HttpVersion::from_str("h2c").unwrap());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_from_str_panic() {
+        HttpVersion::from_str("foo").unwrap();
+    }
+        
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -41,18 +41,14 @@ impl fmt::Display for HttpVersion {
 impl FromStr for HttpVersion {
     type Err = Error;
     fn from_str(s: &str) -> Result<HttpVersion, Error> {
-        if s == "" {
-            Err(Error::Method)
-        } else {
-            Ok(match s {
-                "HTTP/0.9" => Http09,
-                "HTTP/1.0" => Http10,
-                "HTTP/1.1" => Http11,
-                "h2" => H2,
-                "h2c" => H2c,
-                _ => unreachable!(),
-            })
-        }
+        Ok(match s {
+            "HTTP/0.9" => Http09,
+            "HTTP/1.0" => Http10,
+            "HTTP/1.1" => Http11,
+            "h2" => H2,
+            "h2c" => H2c,
+            _ => return Err(Error::Version),
+        })
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -79,9 +79,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_from_str_panic() {
-        HttpVersion::from_str("foo").unwrap();
+        match HttpVersion::from_str("foo") {
+            Err(_) => assert!(true),
+            Ok(_) => assert!(false),
+        }
     }
         
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -3,7 +3,9 @@
 //! Instead of relying on typo-prone Strings, use expected HTTP versions as
 //! the `HttpVersion` enum.
 use std::fmt;
+use std::str::FromStr;
 
+use error::Error;
 use self::HttpVersion::{Http09, Http10, Http11, H2, H2c};
 
 /// Represents a version of the HTTP spec.
@@ -33,6 +35,24 @@ impl fmt::Display for HttpVersion {
             H2c => "h2c",
             HttpVersion::__DontMatchMe => unreachable!(),
         })
+    }
+}
+
+impl FromStr for HttpVersion {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<HttpVersion, Error> {
+        if s == "" {
+            Err(Error::Method)
+        } else {
+            Ok(match s {
+                "HTTP/0.9" => Http09,
+                "HTTP/1.0" => Http10,
+                "HTTP/1.1" => Http11,
+                "h2" => H2,
+                "h2c" => H2c,
+                _ => unreachable!(),
+            })
+        }
     }
 }
 


### PR DESCRIPTION
Hello. 
I'm using hyper to take apart some log requests and construct new requests from them. This is a simple change that matches a String back to the enum. The default case uses same unreachable!() macro that display uses.

Not sure if this has been addressed before, but since I needed it to go forward, figured I'd put a PR together for it.

Thanks,
liam

- [ x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines

