### PR TITLE
feat(buffer): add from_parts and into_parts functions

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -18,6 +18,16 @@ impl<R: Read> BufReader<R> {
     }
 
     #[inline]
+    pub fn from_parts(rdr: R, buf: Vec<u8>, pos: usize, cap: usize) -> BufReader<R> {
+        BufReader {
+            inner: rdr,
+            buf: buf,
+            pos: pos,
+            cap: cap,
+        }
+    }
+
+    #[inline]
     pub fn with_capacity(rdr: R, cap: usize) -> BufReader<R> {
         BufReader {
             inner: rdr,
@@ -64,6 +74,11 @@ impl<R: Read> BufReader<R> {
 
     #[inline]
     pub fn into_inner(self) -> R { self.inner }
+
+    #[inline]
+    pub fn into_parts(self) -> (R, Vec<u8>, usize, usize) {
+        (self.inner, self.buf, self.pos, self.cap)
+    }
 
     #[inline]
     pub fn read_into_buf(&mut self) -> io::Result<usize> {


### PR DESCRIPTION
this adds the ability to deconstruct a buffer into all of its parts
and the ability to create a buffer from all of its parts, this lets
users deconstruct the buffer, edit the reader, then build it back up
again without losing any information

Currently a whole heap of changes is coming to rust-websocket, some of the changes require that we handle streams generically and therefore we need better interoperability with other buffered reader implementations. The large changes (which had to be done all at once) are in cyderize/rust-websocket#80, and include the ability to upgrade a hyper request to a websocket connection.
