### PR TITLE
feat(server): allow non-`Send` closures to be passed into Http::bind()

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -87,9 +87,8 @@ impl<B: AsRef<[u8]> + 'static> Http<B> {
     /// The returned `Server` contains one method, `run`, which is used to
     /// actually run the server.
     pub fn bind<S, Bd>(&self, addr: &SocketAddr, new_service: S) -> ::Result<Server<S, Bd>>
-        where S: NewService<Request = Request, Response = Response<Bd>, Error = ::Error> +
-                    Send + Sync + 'static,
-              Bd: Stream<Item=B, Error=::Error>,
+        where S: NewService<Request = Request, Response = Response<Bd>, Error = ::Error> + 'static,
+              Bd: Stream<Item = B, Error = ::Error>
     {
         let core = try!(Core::new());
         let handle = core.handle();


### PR DESCRIPTION
If you need to access other HTTP-based APIs in order to service
requests, then the most ergonomic way to implement a server is to
create a global `Core` and `Client`, and reuse them within all
`Service` instances.

Unfortunately, `Handle` doesn't implement `Send`, so the shared-`Core`
approach is incompatible with the previous signature of `Http::bind()`.

If we're planning to write an implementation that maintains a thread
pool for serving requests, then we will want to have a way to expose
thread-local resources to be shared between Service instances on
the same thread. The `Http::bind()` interface isn't capable of that,
so it's probably worth admitting that it's mainly suitable for
single-threaded servers, and then work on a `Http::bind_threaded()`
interface that will set up a threadpool for you properly.

Of course, concurrent Rust is a fairly new thing for me, so it's quite likely that I'm missing something, and `Send` *is* required. If so, feel free to reject this PR.

- [ ] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
- [] If you want me to write some examples of how to use `Http::bind()` with shared-`Core` approach, then I can.