### PR TITLE
Introduce Response::get_ref

### DIFF
--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -26,7 +26,6 @@ pub struct Response {
 }
 
 impl Response {
-
     /// Creates a new response from a server.
     pub fn new(url: Url, stream: Box<NetworkStream + Send>) -> ::Result<Response> {
         trace!("Response::new");
@@ -61,6 +60,12 @@ impl Response {
     #[inline]
     pub fn status_raw(&self) -> &RawStatus {
         &self.status_raw
+    }
+
+    /// Gets a borrowed reference to the underlying `HttpMessage`.
+    #[inline]
+    pub fn get_ref(&self) -> &HttpMessage {
+        &*self.message
     }
 }
 

--- a/src/http/h1.rs
+++ b/src/http/h1.rs
@@ -377,7 +377,7 @@ impl Http11Message {
         }
     }
 
-    /// Gets a mutable reference to the underlying `NetworkStream`, regardless of the state of the
+    /// Gets a borrowed reference to the underlying `NetworkStream`, regardless of the state of the
     /// `Http11Message`.
     pub fn get_ref(&self) -> &(NetworkStream + Send) {
         match *self.stream.as_ref() {


### PR DESCRIPTION
This ultimately allows end users to retrieve the current cipher from an SSL stream, which is needed for the Web.