### PR TITLE
feat(server): add local_addr to retrieve resolved address

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -204,6 +204,11 @@ impl<L: NetworkListener> Server<L> {
     pub fn set_write_timeout(&mut self, dur: Option<Duration>) {
         self.listener.set_write_timeout(dur);
     }
+
+    /// Get the address that the server is listening on.
+    pub fn local_addr(&mut self) -> io::Result<SocketAddr> {
+        self.listener.local_addr()
+    }
 }
 
 impl Server<HttpListener> {


### PR DESCRIPTION
As the title suggests, this adds a `local_addr` method to `Server` to retrieve the address that was resolved. This makes it possible to retrieve the resolved address when a `Server` instance is created with the `Server::http` or `Server:https` methods.