### PR TITLE
chore(travis): fix Travis coverage testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: rust
+sudo: false
+dist: trusty
 matrix:
     fast_finish: true
     include:
@@ -26,14 +28,25 @@ addons:
       - libcurl4-openssl-dev
       - libelf-dev
       - libdw-dev
+      - binutils-dev
+      - libiberty-dev
 
 
 after_success:
   - '[ $TRAVIS_RUST_VERSION = stable ] &&
+    LOCAL="~/.local" && export PATH=$LOCAL/bin:$PATH &&
     wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
-    tar xzf master.tar.gz && mkdir kcov-master/build && cd kcov-master/build && cmake .. && make && make install DESTDIR=../tmp && cd ../.. &&
+    tar xzf master.tar.gz && mkdir kcov-master/build && cd kcov-master/build &&
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=$LOCAL .. && make && make install && cd ../.. &&
     ls target/debug &&
-    ./kcov-master/tmp/usr/local/bin/kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/hyper-*'
+    RUSTFLAGS="-C link-dead-code" cargo test --no-run &&
+    for file in target/debug/hyper-*; do
+      if [[ "${file: -2}" != ".d" ]]; then
+        mkdir -p "target/cov/$(basename $file)";
+        kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file";
+      fi;
+    done &&
+    kcov --coveralls-id=$TRAVIS_JOB_ID --merge target/cov target/cov/*'
   - '[ $TRAVIS_PULL_REQUEST = false ] && [ $TRAVIS_RUST_VERSION = stable ] &&
     { [ "$TRAVIS_TAG" != "" ] || [ "$TRAVIS_BRANCH" == "master" ]; } &&
     ./.travis/docs.sh'


### PR DESCRIPTION
* Move to the Trusty distro, since Precise is nearing end of life this year (https://blog.travis-ci.com/2017-04-17-precise-EOL)
* Add a `--verify` flag to avoid kcov segfaults. This was the reason why a 0% coverage was reported
* Link dead code to get more pessimistic results

---

The move to Trusty was also partially due to difficulties with running a `sudo`-less coverage testing with `kcov`. I have no hard evidence, but I had segfaults all the time in my personal project (even with `--verify`!) until I switched to Trusty.