### PR TITLE
Ignore invalid cookies

### DIFF
--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -102,8 +102,6 @@ impl Header for Cookie {
                 let key_val = (key_val.next(), key_val.next());
                 if let (Some(key), Some(val)) = key_val {
                     vec_map.insert(key.trim().to_owned().into(), val.trim().to_owned().into());
-                } else {
-                    return Err(::Error::Header);
                 }
             }
         }
@@ -213,8 +211,18 @@ mod tests {
         cookie.append("foo", "bar");
         assert_eq!(cookie, parsed);
 
+        let parsed = Cookie::parse_header(&b"foo=bar;".to_vec().into()).unwrap();
+        assert_eq!(cookie, parsed);
+
         let parsed = Cookie::parse_header(&b"foo=bar; baz=quux".to_vec().into()).unwrap();
         cookie.append("baz", "quux");
+        assert_eq!(cookie, parsed);
+
+        let parsed = Cookie::parse_header(&b"foo=bar;; baz=quux".to_vec().into()).unwrap();
+        assert_eq!(cookie, parsed);
+
+        let parsed = Cookie::parse_header(&b"foo=bar; invalid ; bad; ;; baz=quux".to_vec().into())
+            .unwrap();
         assert_eq!(cookie, parsed);
 
         let parsed = Cookie::parse_header(&b" foo  =    bar;baz= quux  ".to_vec().into()).unwrap();
@@ -241,9 +249,6 @@ mod tests {
                 .unwrap();
         cookie.append("double", "=2");
         assert_eq!(cookie, parsed);
-
-        Cookie::parse_header(&b"foo;bar=baz;quux".to_vec().into()).unwrap_err();
-
     }
 }
 

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -42,12 +42,12 @@ impl Cookie {
     /// Sets a name and value for the `Cookie`.
     ///
     /// # Note
-    /// 
+    ///
     /// This will remove all other instances with the same name,
     /// and insert the new value.
     pub fn set<K, V>(&mut self, key: K, value: V)
-    where K: Into<Cow<'static, str>>,
-          V: Into<Cow<'static, str>>,
+        where K: Into<Cow<'static, str>>,
+              V: Into<Cow<'static, str>>
     {
         let key = key.into();
         let value = value.into();
@@ -69,15 +69,15 @@ impl Cookie {
     /// cookie.append("foo", "quux");
     /// assert_eq!(cookie.to_string(), "foo=bar; foo=quux");
     pub fn append<K, V>(&mut self, key: K, value: V)
-    where K: Into<Cow<'static, str>>,
-          V: Into<Cow<'static, str>>,
+        where K: Into<Cow<'static, str>>,
+              V: Into<Cow<'static, str>>
     {
         self.0.append(key.into(), value.into());
     }
 
     /// Get a value for the name, if it exists.
     ///
-    /// # Note 
+    /// # Note
     ///
     /// Only returns the first instance found. To access
     /// any other values associated with the name, parse
@@ -158,7 +158,7 @@ impl fmt::Display for Cookie {
 
 #[cfg(test)]
 mod tests {
-    use ::header::Header;
+    use header::Header;
     use super::Cookie;
 
     #[test]
@@ -220,7 +220,26 @@ mod tests {
         let parsed = Cookie::parse_header(&b" foo  =    bar;baz= quux  ".to_vec().into()).unwrap();
         assert_eq!(cookie, parsed);
 
-        let parsed = Cookie::parse_header(&vec![b"foo  =    bar".to_vec(),b"baz= quux  ".to_vec()].into()).unwrap();
+        let parsed =
+            Cookie::parse_header(&vec![b"foo  =    bar".to_vec(), b"baz= quux  ".to_vec()].into())
+                .unwrap();
+        assert_eq!(cookie, parsed);
+
+        let parsed = Cookie::parse_header(&b"foo=bar; baz=quux ; empty=".to_vec().into()).unwrap();
+        cookie.append("empty", "");
+        assert_eq!(cookie, parsed);
+
+
+        let mut cookie = Cookie::new();
+
+        let parsed = Cookie::parse_header(&b"middle=equals=in=the=middle".to_vec().into()).unwrap();
+        cookie.append("middle", "equals=in=the=middle");
+        assert_eq!(cookie, parsed);
+
+        let parsed =
+            Cookie::parse_header(&b"middle=equals=in=the=middle; double==2".to_vec().into())
+                .unwrap();
+        cookie.append("double", "=2");
         assert_eq!(cookie, parsed);
 
         Cookie::parse_header(&b"foo;bar=baz;quux".to_vec().into()).unwrap_err();
@@ -228,4 +247,6 @@ mod tests {
     }
 }
 
-bench_header!(bench, Cookie, { vec![b"foo=bar; baz=quux".to_vec()] });
+bench_header!(bench, Cookie, {
+    vec![b"foo=bar; baz=quux".to_vec()]
+});


### PR DESCRIPTION
In the spirit of Postel's law, ignore invalid cookies rather than
completely discard the entire Cookie header, which is what the current
code does, and which will lead to confusion when dealing with headers
with invalid cookies injected by proxies and intermediate apps servers.

Cookies are injected at multiple different layers between the browser and the end server, proxies, load balancers, security appliances, A/B testing appliances, etc... some of them inject invalid cookies, it's fine to discard those, but in I'm opinion it is wrong to discard every cookie because one field is bad. The separation of cookies between semi-colon makes it easy enough to cleanly separate cookies, ignore the invalid ones, and keep the good ones.

- [X] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
