### PR TITLE
feat(headers): add ContentType::octet_stream() constructor

### DIFF
--- a/src/header/common/content_type.rs
+++ b/src/header/common/content_type.rs
@@ -95,6 +95,12 @@ impl ContentType {
     pub fn png() -> ContentType {
         ContentType(mime!(Image/Png))
     }
+
+    /// A constructor  to easily create a `Content-Type: application/octet-stream` header.
+    #[inline]
+    pub fn octet_stream() -> ContentType {
+        ContentType(mime!(Application/OctetStream))
+    }
 }
 
 impl Eq for ContentType {}


### PR DESCRIPTION
- [X] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines

This PR adds an utility function for`Content-Type: application/octet-stream` header.