### PR TITLE
Backport to 0.10.x: refactor(header): Change to base64 serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ include = [
 ]
 
 [dependencies]
+base64 = "0.5.2"
 httparse = "1.0"
 language-tags = "0.2"
 log = "0.3"
 mime = "0.2"
 num_cpus = "1.0"
-rustc-serialize = "0.3"
 time = "0.1"
 traitobject = "0.1"
 typeable = "0.1"

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::fmt::{self, Display};
 use std::str::{FromStr, from_utf8};
 use std::ops::{Deref, DerefMut};
-use serialize::base64::{ToBase64, FromBase64, Standard, Config, Newline};
+use base64::{encode, decode};
 use header::{Header, HeaderFormat};
 
 /// `Authorization` header, defined in [RFC7235](https://tools.ietf.org/html/rfc7235#section-4.2)
@@ -152,19 +152,15 @@ impl Scheme for Basic {
         if let Some(ref pass) = self.password {
             text.push_str(&pass[..]);
         }
-        f.write_str(&text.as_bytes().to_base64(Config {
-            char_set: Standard,
-            newline: Newline::CRLF,
-            pad: true,
-            line_length: None
-        })[..])
+
+        f.write_str(&encode(text.as_bytes()))
     }
 }
 
 impl FromStr for Basic {
     type Err = ::Error;
     fn from_str(s: &str) -> ::Result<Basic> {
-        match s.from_base64() {
+        match decode(s) {
             Ok(decoded) => match String::from_utf8(decoded) {
                 Ok(text) => {
                     let mut parts = &mut text.split(':');

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@
 //! implement `Reader` and can be read to get the data out of a `Response`.
 //!
 
-extern crate rustc_serialize as serialize;
+extern crate base64;
 extern crate time;
 #[macro_use] extern crate url;
 extern crate unicase;


### PR DESCRIPTION
See #1028. This is a cherry-pick of 529ad56 with fixed conflicts and using the newest version of the crate.

CC @M3rs 