### PR TITLE
refactor(lib): update unicase to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ tokio-core = "0.1.6"
 tokio-proto = "0.1"
 tokio-service = "0.1"
 tokio-io = "0.1"
-unicase = "1.0"
+unicase = "2.0"
 url = "1.0"
 
 [dev-dependencies]

--- a/src/header/common/access_control_allow_credentials.rs
+++ b/src/header/common/access_control_allow_credentials.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 use std::str;
-use unicase::UniCase;
+use unicase;
 use header::{Header, Raw};
 
 /// `Access-Control-Allow-Credentials` header, part of
@@ -38,7 +38,7 @@ use header::{Header, Raw};
 #[derive(Clone, PartialEq, Debug)]
 pub struct AccessControlAllowCredentials;
 
-const ACCESS_CONTROL_ALLOW_CREDENTIALS_TRUE: UniCase<&'static str> = UniCase("true");
+const ACCESS_CONTROL_ALLOW_CREDENTIALS_TRUE: &'static str = "true";
 
 impl Header for AccessControlAllowCredentials {
     fn header_name() -> &'static str {
@@ -56,7 +56,7 @@ impl Header for AccessControlAllowCredentials {
                 //    None. No big deal.
                 str::from_utf8_unchecked(line)
             };
-            if UniCase(text) == ACCESS_CONTROL_ALLOW_CREDENTIALS_TRUE {
+            if unicase::eq_ascii(text, ACCESS_CONTROL_ALLOW_CREDENTIALS_TRUE) {
                 return Ok(AccessControlAllowCredentials);
             }
         }

--- a/src/header/common/access_control_allow_headers.rs
+++ b/src/header/common/access_control_allow_headers.rs
@@ -1,4 +1,4 @@
-use unicase::UniCase;
+use unicase::Ascii;
 
 header! {
     /// `Access-Control-Allow-Headers` header, part of
@@ -24,11 +24,11 @@ header! {
     /// // extern crate unicase;
     ///
     /// use hyper::header::{Headers, AccessControlAllowHeaders};
-    /// use unicase::UniCase;
+    /// use unicase::Ascii;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(
-    ///     AccessControlAllowHeaders(vec![UniCase("date".to_owned())])
+    ///     AccessControlAllowHeaders(vec![Ascii::new("date".to_owned())])
     /// );
     /// # }
     /// ```
@@ -39,18 +39,18 @@ header! {
     /// // extern crate unicase;
     ///
     /// use hyper::header::{Headers, AccessControlAllowHeaders};
-    /// use unicase::UniCase;
+    /// use unicase::Ascii;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(
     ///     AccessControlAllowHeaders(vec![
-    ///         UniCase("accept-language".to_owned()),
-    ///         UniCase("date".to_owned()),
+    ///         Ascii::new("accept-language".to_owned()),
+    ///         Ascii::new("date".to_owned()),
     ///     ])
     /// );
     /// # }
     /// ```
-    (AccessControlAllowHeaders, "Access-Control-Allow-Headers") => (UniCase<String>)*
+    (AccessControlAllowHeaders, "Access-Control-Allow-Headers") => (Ascii<String>)*
 
     test_access_control_allow_headers {
         test_header!(test1, vec![b"accept-language, date"]);

--- a/src/header/common/access_control_expose_headers.rs
+++ b/src/header/common/access_control_expose_headers.rs
@@ -1,4 +1,4 @@
-use unicase::UniCase;
+use unicase::Ascii;
 
 header! {
     /// `Access-Control-Expose-Headers` header, part of
@@ -23,13 +23,13 @@ header! {
     /// // extern crate unicase;
     ///
     /// use hyper::header::{Headers, AccessControlExposeHeaders};
-    /// use unicase::UniCase;
+    /// use unicase::Ascii;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(
     ///     AccessControlExposeHeaders(vec![
-    ///         UniCase("etag".to_owned()),
-    ///         UniCase("content-length".to_owned())
+    ///         Ascii::new("etag".to_owned()),
+    ///         Ascii::new("content-length".to_owned())
     ///     ])
     /// );
     /// # }
@@ -41,18 +41,18 @@ header! {
     /// // extern crate unicase;
     ///
     /// use hyper::header::{Headers, AccessControlExposeHeaders};
-    /// use unicase::UniCase;
+    /// use unicase::Ascii;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(
     ///     AccessControlExposeHeaders(vec![
-    ///         UniCase("etag".to_owned()),
-    ///         UniCase("content-length".to_owned())
+    ///         Ascii::new("etag".to_owned()),
+    ///         Ascii::new("content-length".to_owned())
     ///     ])
     /// );
     /// # }
     /// ```
-    (AccessControlExposeHeaders, "Access-Control-Expose-Headers") => (UniCase<String>)*
+    (AccessControlExposeHeaders, "Access-Control-Expose-Headers") => (Ascii<String>)*
 
     test_access_control_expose_headers {
         test_header!(test1, vec![b"etag, content-length"]);

--- a/src/header/common/access_control_request_headers.rs
+++ b/src/header/common/access_control_request_headers.rs
@@ -1,4 +1,4 @@
-use unicase::UniCase;
+use unicase::Ascii;
 
 header! {
     /// `Access-Control-Request-Headers` header, part of
@@ -24,11 +24,11 @@ header! {
     /// // extern crate unicase;
     ///
     /// use hyper::header::{Headers, AccessControlRequestHeaders};
-    /// use unicase::UniCase;
+    /// use unicase::Ascii;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(
-    ///     AccessControlRequestHeaders(vec![UniCase("date".to_owned())])
+    ///     AccessControlRequestHeaders(vec![Ascii::new("date".to_owned())])
     /// );
     /// # }
     /// ```
@@ -39,18 +39,18 @@ header! {
     /// // extern crate unicase;
     ///
     /// use hyper::header::{Headers, AccessControlRequestHeaders};
-    /// use unicase::UniCase;
+    /// use unicase::Ascii;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(
     ///     AccessControlRequestHeaders(vec![
-    ///         UniCase("accept-language".to_owned()),
-    ///         UniCase("date".to_owned()),
+    ///         Ascii::new("accept-language".to_owned()),
+    ///         Ascii::new("date".to_owned()),
     ///     ])
     /// );
     /// # }
     /// ```
-    (AccessControlRequestHeaders, "Access-Control-Request-Headers") => (UniCase<String>)*
+    (AccessControlRequestHeaders, "Access-Control-Request-Headers") => (Ascii<String>)*
 
     test_access_control_request_headers {
         test_header!(test1, vec![b"accept-language, date"]);

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -1,11 +1,11 @@
 use std::fmt::{self, Display};
 use std::str::FromStr;
-use unicase::UniCase;
+use unicase::Ascii;
 
 pub use self::ConnectionOption::{KeepAlive, Close, ConnectionHeader};
 
-const KEEP_ALIVE: UniCase<&'static str> = UniCase("keep-alive");
-const CLOSE: UniCase<&'static str> = UniCase("close");
+static KEEP_ALIVE: &'static str = "keep-alive";
+static CLOSE: &'static str = "close";
 
 /// Values that can be in the `Connection` header.
 #[derive(Clone, PartialEq, Debug)]
@@ -22,18 +22,18 @@ pub enum ConnectionOption {
     // TODO: it would be nice if these "Strings" could be stronger types, since
     // they are supposed to relate to other Header fields (which we have strong
     // types for).
-    ConnectionHeader(UniCase<String>),
+    ConnectionHeader(Ascii<String>),
 }
 
 impl FromStr for ConnectionOption {
     type Err = ();
     fn from_str(s: &str) -> Result<ConnectionOption, ()> {
-        if UniCase(s) == KEEP_ALIVE {
+        if Ascii::new(s) == KEEP_ALIVE {
             Ok(KeepAlive)
-        } else if UniCase(s) == CLOSE {
+        } else if Ascii::new(s) == CLOSE {
             Ok(Close)
         } else {
-            Ok(ConnectionHeader(UniCase(s.to_owned())))
+            Ok(ConnectionHeader(Ascii::new(s.to_owned())))
         }
     }
 }
@@ -43,7 +43,7 @@ impl Display for ConnectionOption {
         f.write_str(match *self {
             KeepAlive => "keep-alive",
             Close => "close",
-            ConnectionHeader(UniCase(ref s)) => s.as_ref()
+            ConnectionHeader(ref s) => s.as_ref()
         })
     }
 }
@@ -83,12 +83,12 @@ header! {
     /// // extern crate unicase;
     ///
     /// use hyper::header::{Headers, Connection, ConnectionOption};
-    /// use unicase::UniCase;
+    /// use unicase::Ascii;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(
     ///     Connection(vec![
-    ///         ConnectionOption::ConnectionHeader(UniCase("upgrade".to_owned())),
+    ///         ConnectionOption::ConnectionHeader(Ascii::new("upgrade".to_owned())),
     ///     ])
     /// );
     /// # }
@@ -124,7 +124,7 @@ bench_header!(header, Connection, { vec![b"authorization".to_vec()] });
 mod tests {
     use super::{Connection,ConnectionHeader};
     use header::Header;
-    use unicase::UniCase;
+    use unicase::Ascii;
 
     fn parse_option(header: Vec<u8>) -> Connection {
         let val = header.into();
@@ -137,7 +137,7 @@ mod tests {
         assert_eq!(Connection::close(),parse_option(b"close".to_vec()));
         assert_eq!(Connection::keep_alive(),parse_option(b"keep-alive".to_vec()));
         assert_eq!(Connection::keep_alive(),parse_option(b"Keep-Alive".to_vec()));
-        assert_eq!(Connection(vec![ConnectionHeader(UniCase("upgrade".to_owned()))]),
+        assert_eq!(Connection(vec![ConnectionHeader(Ascii::new("upgrade".to_owned()))]),
             parse_option(b"upgrade".to_vec()));
     }
 }

--- a/src/header/common/content_disposition.rs
+++ b/src/header/common/content_disposition.rs
@@ -8,7 +8,7 @@
 
 use language_tags::LanguageTag;
 use std::fmt;
-use unicase::UniCase;
+use unicase;
 
 use header::{Header, Raw, parsing};
 use header::parsing::{parse_extended_value, http_percent_encode};
@@ -102,9 +102,9 @@ impl Header for ContentDisposition {
             };
 
             let mut cd = ContentDisposition {
-                disposition: if UniCase(&*disposition) == UniCase("inline") {
+                disposition: if unicase::eq_ascii(&*disposition, "inline") {
                     DispositionType::Inline
-                } else if UniCase(&*disposition) == UniCase("attachment") {
+                } else if unicase::eq_ascii(&*disposition, "attachment") {
                     DispositionType::Attachment
                 } else {
                     DispositionType::Ext(disposition.to_owned())
@@ -128,11 +128,11 @@ impl Header for ContentDisposition {
                 };
 
                 cd.parameters.push(
-                    if UniCase(&*key) == UniCase("filename") {
+                    if unicase::eq_ascii(&*key, "filename") {
                         DispositionParam::Filename(
                             Charset::Ext("UTF-8".to_owned()), None,
                             val.trim_matches('"').as_bytes().to_owned())
-                    } else if UniCase(&*key) == UniCase("filename*") {
+                    } else if unicase::eq_ascii(&*key, "filename*") {
                         let extended_value = try!(parse_extended_value(val));
                         DispositionParam::Filename(extended_value.charset, extended_value.language_tag, extended_value.value)
                     } else {
@@ -164,7 +164,7 @@ impl fmt::Display for ContentDisposition {
                     let mut use_simple_format: bool = false;
                     if opt_lang.is_none() {
                         if let Charset::Ext(ref ext) = *charset {
-                            if UniCase(&**ext) == UniCase("utf-8") {
+                            if unicase::eq_ascii(&**ext, "utf-8") {
                                 use_simple_format = true;
                             }
                         }

--- a/src/header/common/expect.rs
+++ b/src/header/common/expect.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::str;
 
-use unicase::UniCase;
+use unicase;
 
 use header::{Header, Raw};
 
@@ -26,8 +26,6 @@ pub enum Expect {
     Continue
 }
 
-const EXPECT_CONTINUE: UniCase<&'static str> = UniCase("100-continue");
-
 impl Header for Expect {
     fn header_name() -> &'static str {
         static NAME: &'static str = "Expect";
@@ -44,7 +42,7 @@ impl Header for Expect {
                 //    None. No big deal.
                 str::from_utf8_unchecked(line)
             };
-            if UniCase(text) == EXPECT_CONTINUE {
+            if unicase::eq_ascii(text, "100-continue") {
                 Ok(Expect::Continue)
             } else {
                 Err(::Error::Header)

--- a/src/header/common/strict_transport_security.rs
+++ b/src/header/common/strict_transport_security.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::str::{self, FromStr};
 
-use unicase::UniCase;
+use unicase;
 
 use header::{Header, Raw, parsing};
 
@@ -85,13 +85,13 @@ impl FromStr for StrictTransportSecurity {
     fn from_str(s: &str) -> ::Result<StrictTransportSecurity> {
         s.split(';')
             .map(str::trim)
-            .map(|sub| if UniCase(sub) == UniCase("includeSubdomains") {
+            .map(|sub| if unicase::eq_ascii(sub, "includeSubdomains") {
                 Ok(Directive::IncludeSubdomains)
             } else {
                 let mut sub = sub.splitn(2, '=');
                 match (sub.next(), sub.next()) {
                     (Some(left), Some(right))
-                    if UniCase(left.trim()) == UniCase("max-age") => {
+                    if unicase::eq_ascii(left.trim(), "max-age") => {
                         right
                             .trim()
                             .trim_matches('"')

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 use std::str::FromStr;
-use unicase::UniCase;
+use unicase;
 
 header! {
     /// `Upgrade` header, defined in [RFC7230](http://tools.ietf.org/html/rfc7230#section-6.7)
@@ -99,7 +99,7 @@ impl FromStr for ProtocolName {
             "TLS" => ProtocolName::Tls,
             "h2c" => ProtocolName::H2c,
             _ => {
-                if UniCase(s) == UniCase("websocket") {
+                if unicase::eq_ascii(s, "websocket") {
                     ProtocolName::WebSocket
                 } else {
                     ProtocolName::Unregistered(s.to_owned())

--- a/src/header/common/vary.rs
+++ b/src/header/common/vary.rs
@@ -1,4 +1,4 @@
-use unicase::UniCase;
+use unicase::Ascii;
 
 header! {
     /// `Vary` header, defined in [RFC7231](https://tools.ietf.org/html/rfc7231#section-7.1.4)
@@ -34,18 +34,18 @@ header! {
     /// // extern crate unicase;
     ///
     /// use hyper::header::{Headers, Vary};
-    /// use unicase::UniCase;
+    /// use unicase::Ascii;
     ///
     /// let mut headers = Headers::new();
     /// headers.set(
     ///     Vary::Items(vec![
-    ///         UniCase("accept-encoding".to_owned()),
-    ///         UniCase("accept-language".to_owned()),
+    ///         Ascii::new("accept-encoding".to_owned()),
+    ///         Ascii::new("accept-language".to_owned()),
     ///     ])
     /// );
     /// # }
     /// ```
-    (Vary, "Vary") => {Any / (UniCase<String>)+}
+    (Vary, "Vary") => {Any / (Ascii<String>)+}
 
     test_vary {
         test_header!(test1, vec![b"accept-encoding, accept-language"]);


### PR DESCRIPTION
BREAKING CHANGE: Some headers used `UniCase`, but now use
  `unicase::Ascii`. Upgrade code to `Ascii::new(s)`.
