### PR TITLE
Drop logging verbosity of listener accept error

### DIFF
--- a/src/server/listener.rs
+++ b/src/server/listener.rs
@@ -49,7 +49,7 @@ where A: NetworkListener + Send + 'static,
             match acceptor.accept() {
                 Ok(stream) => work(stream),
                 Err(e) => {
-                    error!("Connection failed: {}", e);
+                    info!("Connection failed: {}", e);
                 }
             }
         }


### PR DESCRIPTION
Errors are not that uncommon here when using TLS since the accept includes the TLS handshake. `error` is typically reserved for "someone needs to be paged" which is not the case here.

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
