### PR TITLE
fix(lib): Remove unused unimplemented! macro.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,18 +46,6 @@ pub use status::StatusCode::{self, Ok, BadRequest, NotFound};
 pub use server::Server;
 pub use version::HttpVersion;
 
-macro_rules! unimplemented {
-    () => ({
-        panic!("unimplemented")
-    });
-    ($msg:expr) => ({
-        unimplemented!("{}", $msg)
-    });
-    ($fmt:expr, $($arg:tt)*) => ({
-        panic!(concat!("unimplemented: ", $fmt), $($arg)*)
-    });
-}
-
 #[cfg(test)]
 mod mock;
 pub mod client;


### PR DESCRIPTION
This macro isn't used anywhere, std now has an unimplemented macro
if we want to use it, and the nightly compiler now warns that this
unused.  This warning is a failure when compiling tests.

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
