### PR TITLE
docs(server): refer to `bind` method, not `serve`

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -114,7 +114,7 @@ impl<B: AsRef<[u8]> + 'static> Http<B> {
     /// will be handled (and mapped to responses).
     ///
     /// This method is typically not invoked directly but is rather transitively
-    /// used through the `serve` helper method above. This can be useful,
+    /// used through [`bind`](#method.bind). This can be useful,
     /// however, when writing mocks or accepting sockets from a non-TCP
     /// location.
     pub fn bind_connection<S, I, Bd>(&self,


### PR DESCRIPTION
Fixes #1180.

- [X] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
