### PR TITLE
fix(logging): Don't error log for IO errors

### DIFF
--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -95,7 +95,7 @@ impl Drop for Response {
         if !(is_drained && http::should_keep_alive(self.version, &self.headers)) {
             trace!("Response.drop closing connection");
             if let Err(e) = self.message.close_connection() {
-                error!("Response.drop error closing connection: {}", e);
+                info!("Response.drop error closing connection: {}", e);
             }
         }
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -270,7 +270,7 @@ impl<H: Handler + 'static> Worker<H> {
         let addr = match stream.peer_addr() {
             Ok(addr) => addr,
             Err(e) => {
-                error!("Peer Name error: {:?}", e);
+                info!("Peer Name error: {:?}", e);
                 return;
             }
         };
@@ -282,7 +282,7 @@ impl<H: Handler + 'static> Worker<H> {
 
         while self.keep_alive_loop(&mut rdr, &mut wrt, addr) {
             if let Err(e) = self.set_read_timeout(*rdr.get_ref(), self.timeouts.keep_alive) {
-                error!("set_read_timeout keep_alive {:?}", e);
+                info!("set_read_timeout keep_alive {:?}", e);
                 break;
             }
         }
@@ -310,7 +310,7 @@ impl<H: Handler + 'static> Worker<H> {
             }
             Err(e) => {
                 //TODO: send a 400 response
-                error!("request error = {:?}", e);
+                info!("request error = {:?}", e);
                 return false;
             }
         };
@@ -320,7 +320,7 @@ impl<H: Handler + 'static> Worker<H> {
         }
 
         if let Err(e) = req.set_read_timeout(self.timeouts.read) {
-            error!("set_read_timeout {:?}", e);
+            info!("set_read_timeout {:?}", e);
             return false;
         }
 
@@ -353,7 +353,7 @@ impl<H: Handler + 'static> Worker<H> {
             match write!(wrt, "{} {}\r\n\r\n", Http11, status).and_then(|_| wrt.flush()) {
                 Ok(..) => (),
                 Err(e) => {
-                    error!("error writing 100-continue: {:?}", e);
+                    info!("error writing 100-continue: {:?}", e);
                     return false;
                 }
             }


### PR DESCRIPTION
It's not particularly unexpected for the other end to drop off, and
error level logging is reserved for serious issues that need to be
corrected.

There are two error level logs remaining - when trying to attach a body
to messages that aren't supposed to have one, and when a non-UTF header
is encountered. Both of these would only be encountered due to
programmer error.
