### PR TITLE
fix(client): remove config requirement for Connect

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -322,7 +322,7 @@ impl<C, B> Config<C, B> {
 
     /// Set the `Connect` type to be used.
     #[inline]
-    pub fn connector<CC: Connect>(self, val: CC) -> Config<CC, B> {
+    pub fn connector<CC>(self, val: CC) -> Config<CC, B> {
         Config {
             _body_type: self._body_type,
             //connect_timeout: self.connect_timeout,


### PR DESCRIPTION
Remove requirement when calling client::Config::connector() that the connector implements Connect.

Removing this requirement allows users to set the connector back to UseDefaultConnector. Previously,
this was not possible.

I'm not sure if there's any specific reason for requiring Connect on this method, as far as I can tell from past commits it was just an included part in the original design?

My use case for this is setting the connector back to `UseDefaultConnector`, as well as opening up the possibility for a `UseHttpsConnector` or a similar marker type to be used in a wrapper builder around `Config`.

Tests fail, but as far as I can tell this is only because of deprecated things that hyper is using. Locally, if `#![deny(warnings)]` is temporarily commented out, all tests pass.

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
