### PR TITLE
Refactoring inlined AtomicWrite, and removed unneeded branch in parse

### DIFF
--- a/src/http/io.rs
+++ b/src/http/io.rs
@@ -218,34 +218,6 @@ impl<T: AsRef<[u8]>> fmt::Debug for Cursor<T> {
     }
 }
 
-pub trait AtomicWrite {
-    fn write_atomic(&mut self, data: &[&[u8]]) -> io::Result<usize>;
-}
-
-/*
-#[cfg(not(windows))]
-impl<T: Write + ::vecio::Writev> AtomicWrite for T {
-
-    fn write_atomic(&mut self, bufs: &[&[u8]]) -> io::Result<usize> {
-        self.writev(bufs)
-    }
-
-}
-
-#[cfg(windows)]
-*/
-impl<T: Write> AtomicWrite for T {
-    fn write_atomic(&mut self, bufs: &[&[u8]]) -> io::Result<usize> {
-        if bufs.len() == 1 {
-            self.write(bufs[0])
-        } else {
-            let vec = bufs.concat();
-            self.write(&vec)
-        }
-    }
-}
-//}
-
 // an internal buffer to collect writes before flushes
 #[derive(Debug)]
 struct WriteBuf(Cursor<Vec<u8>>);


### PR DESCRIPTION
- [X] The commit messages match the [guidelines](https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines)

I'm not sure if this is the direction you're aiming for, but I'm trying as much as possible to move hyper's encoder / decoder types to match these tokio [method signatures](https://tokio.rs/docs/going-deeper-tokio/streaming/) and finding refactorings along the way

All the refactoring I've done so far should have no behavioral change, and I'm kinda scared to make behavioral changes. Instead I've just added TODOs, I hope that is cool. For example, moving io out of Encoder would allow it to impl Tokio::Encoder, but changing when io takes place is a bit scary.