### PR TITLE
fix(http,server): Update tests to use non-deprecated futures methods.

### DIFF
--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -133,7 +133,7 @@ fn test_body_stream_concat() {
         tx.send(Ok("world".into())).wait().unwrap();
     });
 
-    let total = body.concat().wait().unwrap();
+    let total = body.concat2().wait().unwrap();
     assert_eq!(total.as_ref(), b"hello world");
 
 }

--- a/src/http/conn.rs
+++ b/src/http/conn.rs
@@ -160,11 +160,11 @@ where I: AsyncRead + AsyncWrite,
             // us that it is ready until we drain it. However, we're currently
             // finished reading, so we need to park the task to be able to
             // wake back up later when more reading should happen.
-            self.state.read_task = Some(::futures::task::park());
+            self.state.read_task = Some(::futures::task::current());
         }
     }
 
-    fn maybe_unpark(&mut self) {
+    fn maybe_notify(&mut self) {
         // its possible that we returned NotReady from poll() without having
         // exhausted the underlying Io. We would have done this when we
         // determined we couldn't keep reading until we knew how writing
@@ -188,13 +188,13 @@ where I: AsyncRead + AsyncWrite,
         }
 
         if let Some(task) = self.state.read_task.take() {
-            task.unpark();
+            task.notify();
         }
     }
 
     fn try_keep_alive(&mut self) {
         self.state.try_keep_alive();
-        self.maybe_unpark();
+        self.maybe_notify();
     }
 
     fn can_write_head(&self) -> bool {
@@ -838,21 +838,22 @@ mod tests {
     #[test]
     fn test_conn_parking() {
         use std::sync::Arc;
-        use futures::executor::Unpark;
+        use futures::executor::Notify;
+        use futures::executor::NotifyHandle;
 
         struct Car {
             permit: bool,
         }
-        impl Unpark for Car {
-            fn unpark(&self) {
+        impl Notify for Car {
+            fn notify(&self, _id: usize) {
                 assert!(self.permit, "unparked without permit");
             }
         }
 
-        fn car(permit: bool) -> Arc<Unpark> {
+        fn car(permit: bool) -> NotifyHandle {
             Arc::new(Car {
                 permit: permit,
-            })
+            }).into()
         }
 
         // test that once writing is done, unparks
@@ -866,7 +867,7 @@ mod tests {
             assert!(conn.poll_complete().unwrap().is_ready());
             Ok::<(), ()>(())
         });
-        ::futures::executor::spawn(f).poll_future(car(true)).unwrap();
+        ::futures::executor::spawn(f).poll_future_notify(&car(true), 0).unwrap();
 
 
         // test that flushing when not waiting on read doesn't unpark
@@ -877,7 +878,7 @@ mod tests {
             assert!(conn.poll_complete().unwrap().is_ready());
             Ok::<(), ()>(())
         });
-        ::futures::executor::spawn(f).poll_future(car(false)).unwrap();
+        ::futures::executor::spawn(f).poll_future_notify(&car(false), 0).unwrap();
 
 
         // test that flushing and writing isn't done doesn't unpark
@@ -890,7 +891,7 @@ mod tests {
             assert!(conn.poll_complete().unwrap().is_ready());
             Ok::<(), ()>(())
         });
-        ::futures::executor::spawn(f).poll_future(car(false)).unwrap();
+        ::futures::executor::spawn(f).poll_future_notify(&car(false), 0).unwrap();
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -479,7 +479,7 @@ impl<S> Drop for NotifyService<S> {
         info.active -= 1;
         if info.active == 0 {
             if let Some(task) = info.blocker.take() {
-                task.unpark();
+                task.notify();
             }
         }
     }
@@ -494,7 +494,7 @@ impl Future for WaitUntilZero {
         if info.active == 0 {
             Ok(().into())
         } else {
-            info.blocker = Some(task::park());
+            info.blocker = Some(task::current());
             Ok(Async::NotReady)
         }
     }


### PR DESCRIPTION
These seem mostly to be renames, with the exception of Unpark -> Notify, which includes a functional change. Needed so that travis will build with the `#![deny(warnings)]`.

In the test set using Notify, I'm unsure exactly what the `id` passed around should be referring to. Here I've ignored it when receiving, and just sent `0`, though that may not be the best solution.

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
