### PR TITLE
feat(version): implement FromStr and AsRef<str> for Version

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -3,7 +3,9 @@
 //! Instead of relying on typo-prone Strings, use expected HTTP versions as
 //! the `HttpVersion` enum.
 use std::fmt;
+use std::str::FromStr;
 
+use error::Error;
 use self::HttpVersion::{Http09, Http10, Http11, Http20};
 
 /// Represents a version of the HTTP spec.
@@ -16,16 +18,36 @@ pub enum HttpVersion {
     /// `HTTP/1.1`
     Http11,
     /// `HTTP/2.0`
-    Http20
+    Http20,
 }
 
 impl fmt::Display for HttpVersion {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str(match *self {
+        fmt.write_str(self.as_ref())
+    }
+}
+
+impl AsRef<str> for HttpVersion {
+    fn as_ref(&self) -> &str {
+        match *self {
             Http09 => "HTTP/0.9",
             Http10 => "HTTP/1.0",
             Http11 => "HTTP/1.1",
             Http20 => "HTTP/2.0",
-        })
+        }
+    }
+}
+
+impl FromStr for HttpVersion {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HTTP/0.9" => Ok(Http09),
+            "HTTP/1.0" => Ok(Http10),
+            "HTTP/1.1" => Ok(Http11),
+            "HTTP/2.0" => Ok(Http20),
+            _ => Err(Error::Version),
+        }
     }
 }


### PR DESCRIPTION
- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines

The `FromStr` trait was implemented in the master branch too, `AsRef<str>` is not but it's rather useful when serializing and deserializing types (which is what I'm currently doing with my upcoming mocking/replaying library for reqwest).