### PR TITLE
refactor(http): return poll more

### DIFF
--- a/src/http/conn.rs
+++ b/src/http/conn.rs
@@ -47,11 +47,6 @@ where I: AsyncRead + AsyncWrite,
         }
     }
 
-    fn parse(&mut self) -> ::Result<Option<http::MessageHead<T::Incoming>>> {
-        self.io.parse::<T>()
-    }
-
-
     fn is_read_closed(&self) -> bool {
         self.state.is_read_closed()
     }
@@ -79,9 +74,9 @@ where I: AsyncRead + AsyncWrite,
         debug_assert!(self.can_read_head());
         trace!("Conn::read_head");
 
-        let (version, head) = match self.parse() {
-            Ok(Some(head)) => (head.version, head),
-            Ok(None) => return Ok(Async::NotReady),
+        let (version, head) = match self.io.parse::<T>() {
+            Ok(Async::Ready(head)) => (head.version, head),
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
             Err(e) => {
                 let must_respond_with_error = !self.state.is_idle();
                 self.state.close_read();

--- a/src/http/conn.rs
+++ b/src/http/conn.rs
@@ -136,7 +136,7 @@ where I: AsyncRead + AsyncWrite,
 
         let (reading, ret) = match self.state.reading {
             Reading::Body(ref mut decoder) => {
-                let slice = try_nb!(decoder.decode(&mut self.io));
+                let slice = try_ready!(decoder.decode(&mut self.io));
                 if !slice.is_empty() {
                     return Ok(Async::Ready(Some(http::Chunk::from(slice))));
                 } else if decoder.is_eof() {


### PR DESCRIPTION
- [x] The commit messages match [the guidelines](https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines)

**Disclaimer**: Modifies `unsafe` (very slightly) in `read_from_io`

Summary: Its a pretty big CR, but I just change the types around.

More stuff:
Ideally, `io` and `decoder` would not be coupled, but that is above my pay grade.
`conn -> io, decoder`

Currently, this is what the dependencies look like:
`conn -> decoder -> io`
`conn`: Uses `Poll`
`decoder`:  Does not use `Poll`
`io`: Should use `Poll`

So I need to push `Poll` through decoder which, on the one hand, kinda sucks because there are more characters around, and it makes the tests harder to write. On the other hand, its the only good way to refactor `Buffered` to use things like `AsyncRead` and `AsyncWrite`.

Thoughts?