### PR TITLE
refactor(http): consolidate state into Conn::State

### DIFF
--- a/src/http/conn.rs
+++ b/src/http/conn.rs
@@ -38,6 +38,7 @@ where I: AsyncRead + AsyncWrite,
         Conn {
             io: Buffered::new(io),
             state: State {
+                read_blocked: false,
                 reading: Reading::Init,
                 writing: Writing::Init,
                 read_task: None,
@@ -70,6 +71,7 @@ where I: AsyncRead + AsyncWrite,
         }
     }
 
+    // TODO: This function only ever returns `Ok`. Change type?
     fn read_head(&mut self) -> Poll<Option<Frame<http::MessageHead<T::Incoming>, http::Chunk, ::Error>>, io::Error> {
         debug_assert!(self.can_read_head());
         trace!("Conn::read_head");
@@ -148,7 +150,7 @@ where I: AsyncRead + AsyncWrite,
     }
 
     fn maybe_park_read(&mut self) {
-        if !self.io.is_read_blocked() {
+        if !self.state.read_blocked {
             // the Io object is ready to read, which means it will never alert
             // us that it is ready until we drain it. However, we're currently
             // finished reading, so we need to park the task to be able to
@@ -365,15 +367,20 @@ where I: AsyncRead + AsyncWrite,
                 .map(|async| async.map(|chunk| Some(Frame::Body {
                     chunk: chunk
                 })))
-                .or_else(|err| {
-                    self.state.close_read();
-                    Ok(Async::Ready(Some(Frame::Error { error: err.into() })))
-                })
         } else {
             trace!("poll when on keep-alive");
             self.maybe_park_read();
-            Ok(Async::NotReady)
+            // TODO: Should this set `read_blocked = true`?
+            return Ok(Async::NotReady);
         }
+        .map(|async| {
+            self.state.read_blocked = async.is_not_ready();
+            async
+        })
+        .or_else(|err| {
+            self.state.close_read();
+            Ok(Async::Ready(Some(Frame::Error { error: err.into() })))
+        })
     }
 }
 
@@ -467,6 +474,7 @@ impl<I, B: AsRef<[u8]>, T, K: fmt::Debug> fmt::Debug for Conn<I, B, T, K> {
 }
 
 struct State<B, K> {
+    read_blocked: bool,
     reading: Reading,
     writing: Writing<B>,
     read_task: Option<Task>,
@@ -492,6 +500,7 @@ enum Writing<B> {
 impl<B: AsRef<[u8]>, K: fmt::Debug> fmt::Debug for State<B, K> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("State")
+            .field("read_blocked", &self.read_blocked)
             .field("reading", &self.reading)
             .field("writing", &self.writing)
             .field("keep_alive", &self.keep_alive)

--- a/src/http/io.rs
+++ b/src/http/io.rs
@@ -14,7 +14,6 @@ pub const MAX_BUFFER_SIZE: usize = 8192 + 4096 * 100;
 
 pub struct Buffered<T> {
     io: T,
-    read_blocked: bool,
     read_buf: BytesMut,
     write_buf: WriteBuf,
 }
@@ -34,7 +33,6 @@ impl<T: AsyncRead + AsyncWrite> Buffered<T> {
             io: io,
             read_buf: BytesMut::with_capacity(0),
             write_buf: WriteBuf::new(),
-            read_blocked: false,
         }
     }
 
@@ -91,19 +89,10 @@ impl<T: AsyncRead + AsyncWrite> Buffered<T> {
                 ptr::write_bytes(buf.as_mut_ptr(), 0, len);
             }
         }
-        self.read_blocked = false;
-        unsafe { // Can we use AsyncRead::read_buf instead?
-            let n = match self.io.read(self.read_buf.bytes_mut()) {
-                Ok(n) => n,
-                Err(e) => {
-                    if e.kind() == io::ErrorKind::WouldBlock {
-                        // TODO: Push this out, ideally, into http::Conn.
-                        self.read_blocked = true;
-                        return Ok(Async::NotReady);
-                    }
-                    return Err(e)
-                }
-            };
+        // TODO: Use AsyncRead::read_buf instead
+        //     Ensure `read_buf` wouldn't re-zero the buffer each call
+        unsafe {
+            let n = try_nb!(self.io.read(self.read_buf.bytes_mut()));
             self.read_buf.advance_mut(n);
             Ok(Async::Ready(n))
         }
@@ -115,10 +104,6 @@ impl<T: AsyncRead + AsyncWrite> Buffered<T> {
 
     pub fn io_mut(&mut self) -> &mut T {
         &mut self.io
-    }
-
-    pub fn is_read_blocked(&self) -> bool {
-        self.read_blocked
     }
 }
 


### PR DESCRIPTION
- [X] The commit messages match [the guidelines](https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines)

**Disclaimer**: Modifies `unsafe` in `read_from_io`

Moving the `read_blocked` state into `http:Conn::State`. Not only allows us to refactor `http::io` more, but consolidating state usually results in easier mental models and long term code quality.