### PR TITLE
Fix a typo in ContentType header's doc

### DIFF
--- a/src/header/common/content_type.rs
+++ b/src/header/common/content_type.rs
@@ -23,7 +23,7 @@ header! {
     ///
     /// # Example values
     /// * `text/html; charset=utf-8`
-    /// * `application/json
+    /// * `application/json`
     ///
     /// # Examples
     /// ```


### PR DESCRIPTION
- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
