### PR TITLE
feat(server): Provide reference to Response body

### DIFF
--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -93,6 +93,10 @@ impl<B> Response<B> {
         self.set_body(body);
         self
     }
+
+    /// Read the body.
+    #[inline]
+    pub fn body_ref(&self) -> Option<&B> { self.body.as_ref() }
 }
 
 impl Response<Body> {


### PR DESCRIPTION
The Response body was previously inaccessible to application code. This
change allows applications that may wish to alter the Response based on
previous creation (or not) of the body to do so.

n.b. discussion in #1216 indicates this function may change in
0.12 or be removed in favour of some other api.

Closes #1216.

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
