### PR TITLE
chore(dev): upgrade base64 to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 ]
 
 [dependencies]
-base64 = "0.5.2"
+base64 = "0.6.0"
 httparse = "1.0"
 language-tags = "0.2"
 log = "0.3"


### PR DESCRIPTION
Just a simple dependency update.