### PR TITLE
feat(client): add connect, read, and write timeouts to client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tokio-core = "0.1.6"
 tokio-proto = "0.1"
 tokio-service = "0.1"
 tokio-io = "0.1"
+tokio-io-timeout = "0.1.0"
 unicase = "2.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ extern crate tokio_core as tokio;
 extern crate tokio_proto;
 extern crate tokio_service;
 extern crate unicase;
+extern crate tokio_io_timeout;
 
 #[cfg(all(test, feature = "nightly"))]
 extern crate test;


### PR DESCRIPTION
- Add a `TimeoutConnector` implememtation that can be used to wrap any
  implemention of `Connect`.
- Add read and write timeout support to `Client` and client `Config`.
  The internal client implementation now wraps I/O with the
  tokio-io-timeout crate. Due to the way tokio-proto works, the user
  will see a "broken pipe" error instead of a "timed out" error when
  a read or write timeout occurs.

Closes #1234

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
