### PR TITLE
refactor(server): remove unneeded Send + Sync

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -86,8 +86,7 @@ impl<B: AsRef<[u8]> + 'static> Http<B> {
     /// The returned `Server` contains one method, `run`, which is used to
     /// actually run the server.
     pub fn bind<S, Bd>(&self, addr: &SocketAddr, new_service: S) -> ::Result<Server<S, Bd>>
-        where S: NewService<Request = Request, Response = Response<Bd>, Error = ::Error> +
-                    Send + Sync + 'static,
+        where S: NewService<Request = Request, Response = Response<Bd>, Error = ::Error> + 'static,
               Bd: Stream<Item=B, Error=::Error>,
     {
         let core = try!(Core::new());
@@ -337,8 +336,7 @@ impl<T, B> Service for HttpService<T>
 }
 
 impl<S, B> Server<S, B>
-    where S: NewService<Request = Request, Response = Response<B>, Error = ::Error>
-                + Send + Sync + 'static,
+    where S: NewService<Request = Request, Response = Response<B>, Error = ::Error> + 'static,
           B: Stream<Error=::Error> + 'static,
           B::Item: AsRef<[u8]>,
 {


### PR DESCRIPTION
Http and Server placed Send + Sync bounds on NewService implementations which
were not actually required given tokio's event loop model. Remove them to reduce
limitations on end users of hyper.

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
