### PR TITLE
feat(http): add map_body to Request and Response

### DIFF
--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -98,6 +98,20 @@ impl<B> Request<B> {
     #[inline]
     pub fn set_body<T: Into<B>>(&mut self, body: T) { self.body = Some(body.into()); }
 
+    /// Set the body and move the Request, using the previous body as context.
+    #[inline]
+    pub fn map_body<F: FnOnce(B) -> T, T>(self, f: F) -> Request<T> {
+        Request {
+            method: self.method,
+            uri: self.uri,
+            version: self.version,
+            headers: self.headers,
+            body: self.body.map(f),
+            is_proxy: self.is_proxy,
+            remote_addr: self.remote_addr,
+        }
+    }
+
     /// Set that the URI should use the absolute form.
     ///
     /// This is only needed when talking to HTTP/1 proxies to URLs not

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -94,6 +94,31 @@ impl<B> Response<B> {
         self
     }
 
+    /// Set the body and move the Response, using the previous body as context.
+    #[cfg(not(feature = "raw_status"))]
+    #[inline]
+    pub fn map_body<F: FnOnce(B) -> T, T>(self, f: F) -> Response<T> {
+        Response {
+            version: self.version,
+            headers: self.headers,
+            status: self.status,
+            body: self.body.map(f),
+        }
+    }
+
+    /// Set the body and move the Response, using the previous body as context.
+    #[cfg(feature = "raw_status")]
+    #[inline]
+    pub fn map_body<F: FnOnce(B) -> T, T>(self, f: F) -> Response<T> {
+        Response {
+            version: self.version,
+            headers: self.headers,
+            status: self.status,
+            raw_status: self.raw_status,
+            body: self.body.map(f),
+        }
+    }
+
     /// Read the body.
     #[inline]
     pub fn body_ref(&self) -> Option<&B> { self.body.as_ref() }


### PR DESCRIPTION
Add Request::map_body and Response::map_body to allow for swapping out the body
with a new version based on the old one -- wrapping a stream combinator around
it, for example.

Motivating scenario: I have a `Service` combinator which wraps around another `Service`. The inner `Service` returns a `Response` whose body type is a stream of messages. The outer `Service` needs to wrap a serializer around this body type to serialize its output to binary chunks, before turning the resulting `Response` over to hyper.

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
