### PR TITLE
docs(headers): clarify Basic auth

### DIFF
--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -140,7 +140,8 @@ pub struct Basic {
     /// The username as a possibly empty string
     pub username: String,
     /// The password. `None` if the `:` delimiter character was not
-    /// part of the parsed input.
+    /// part of the parsed input. Note: A compliant client MUST
+    /// always send a password (which may be the empty string).
     pub password: Option<String>
 }
 


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc7617

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
