### PR TITLE
feat(server): support upgrading to other protocols 

### DIFF
--- a/src/common/fmt.rs
+++ b/src/common/fmt.rs
@@ -1,0 +1,9 @@
+use std::fmt;
+
+pub struct Omitted;
+
+impl fmt::Debug for Omitted {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "...")
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,5 @@
+pub use self::fmt::Omitted;
 pub use self::str::ByteStr;
 
+mod fmt;
 mod str;

--- a/src/http/io.rs
+++ b/src/http/io.rs
@@ -86,6 +86,17 @@ impl<T: AsyncRead + AsyncWrite> Buffered<T> {
         }
     }
 
+    /// Extracts the underlying I/O stream and any buffered data already read,
+    /// but only if the write buffer is already empty.
+    #[inline]
+    pub fn try_into_inner(self) -> Result<(T, BytesMut), Self> {
+        if self.write_buf.remaining() == 0 {
+            Ok((self.io, self.read_buf))
+        } else {
+            Err(self)
+        }
+    }
+
     fn read_from_io(&mut self) -> Poll<usize, io::Error> {
         use bytes::BufMut;
         // TODO: Investigate if we still need these unsafe blocks

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -142,6 +142,16 @@ impl fmt::Debug for Response {
     }
 }
 
+impl fmt::Debug for Response<()> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Response")
+            .field("status", &self.status)
+            .field("version", &self.version)
+            .field("headers", &self.headers)
+            .finish()
+    }
+}
+
 /// Constructs a response using a received ResponseHead and optional body
 #[inline]
 #[cfg(not(feature = "raw_status"))]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -34,6 +34,8 @@ use http::request;
 pub use http::response::Response;
 pub use http::request::Request;
 
+use common::Omitted;
+
 /// An instance of the HTTP protocol, and implementation of tokio-proto's
 /// `ServerProto` trait.
 ///
@@ -668,7 +670,7 @@ impl<T, B, P> fmt::Debug for BindUpgradableConnection<T, B, P>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("BindUpgradableConnection")
-            .field("receiver", &"...")
+            .field("receiver", &Omitted)
             .field("state", &self.state)
             .finish()
     }
@@ -889,7 +891,7 @@ where B::Item: AsRef<[u8]>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Server")
-         .field("core", &"...")
+         .field("core", &Omitted)
          .field("listener", &self.listener)
          .field("new_service", &self.new_service)
          .field("protocol", &self.protocol)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,6 +15,7 @@ use futures::future;
 use futures::task::{self, Task};
 use futures::{Future, Stream, Poll, Async, Sink, StartSend, AsyncSink};
 use futures::future::Map;
+use futures::sync::oneshot::{self, Receiver, Sender};
 
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio::reactor::{Core, Handle, Timeout};
@@ -23,6 +24,8 @@ use tokio_proto::BindServer;
 use tokio_proto::streaming::Message;
 use tokio_proto::streaming::pipeline::{Transport, Frame, ServerProto};
 pub use tokio_service::{NewService, Service};
+
+use bytes::BytesMut;
 
 use http;
 use http::response;
@@ -130,6 +133,49 @@ impl<B: AsRef<[u8]> + 'static> Http<B> {
             inner: service,
             remote_addr: remote_addr,
         })
+    }
+
+    /// Use this `Http` instance to create a new server task which handles the
+    /// connection `io` provided, and can be upgraded to another protocol in
+    /// response to a request from the client.
+    ///
+    /// This behaves like `bind_connection`, except the `Service` supplied must
+    /// return an `UpgradableResponse` containing either an HTTP `Response` or
+    /// some information describing a protocol switch. If an `Upgrade` response
+    /// is returned, the server task is shut down (without closing the
+    /// underlying `io`) and this information is forwarded to the `Future`
+    /// returned by this method, along with the underlying `io` and any
+    /// remaining buffered data that has already been read from it.
+    ///
+    /// If the server task shuts down normally, the `Future` completes with a
+    /// `None` output value. In the case of an error handling the connection,
+    /// the error is also forwarded to this `Future`.
+    pub fn bind_upgradable_connection<S, I, P, Bd>(&self,
+                                                   handle: &Handle,
+                                                   io: I,
+                                                   remote_addr: SocketAddr,
+                                                   service: S)
+                                                   -> BindUpgradableConnection<I, B, P>
+        where S: Service<Request = Request,
+                         Response = UpgradableResponse<P, Bd>,
+                         Error = ::Error> + 'static,
+              Bd: Stream<Item=B, Error=::Error> + 'static,
+              I: AsyncRead + AsyncWrite + 'static,
+              P: 'static,
+    {
+        let (sender, receiver) = oneshot::channel();
+        let proto = UpgradableHttp {
+            inner: self.clone(),
+            _marker: PhantomData,
+        };
+        proto.bind_server(handle, (io, sender), UpgradableHttpService {
+            inner: service,
+            remote_addr: remote_addr,
+        });
+        BindUpgradableConnection {
+            receiver: receiver,
+            state: None,
+        }
     }
 }
 
@@ -308,6 +354,23 @@ impl<B> Into<Message<__ProtoResponse, B>> for Response<B> {
     }
 }
 
+impl<B, P> Into<Message<Result<__ProtoResponse, P>, B>> for UpgradableResponse<P, B> {
+    #[inline]
+    fn into(self) -> Message<Result<__ProtoResponse, P>, B> {
+        match self {
+            UpgradableResponse::Response(res) => {
+                let (head, body) = response::split(res);
+                if let Some(body) = body {
+                    Message::WithBody(Ok(__ProtoResponse(head)), body.into())
+                } else {
+                    Message::WithoutBody(Ok(__ProtoResponse(head)))
+                }
+            }
+            UpgradableResponse::Upgrade(upgrade_info) => Message::WithoutBody(Err(upgrade_info)),
+        }
+    }
+}
+
 struct HttpService<T> {
     inner: T,
     remote_addr: SocketAddr,
@@ -324,6 +387,357 @@ impl<T, B> Service for HttpService<T>
     type Response = Message<__ProtoResponse, B>;
     type Error = ::Error;
     type Future = Map<T::Future, fn(Response<B>) -> Message<__ProtoResponse, B>>;
+
+    #[inline]
+    fn call(&self, message: Self::Request) -> Self::Future {
+        let (head, body) = match message {
+            Message::WithoutBody(head) => (head.0, http::Body::empty()),
+            Message::WithBody(head, body) => (head.0, body.into()),
+        };
+        let req = request::from_wire(Some(self.remote_addr), head, body);
+        self.inner.call(req).map(Into::into)
+    }
+}
+
+struct UpgradableHttp<P, B = ::Chunk> {
+    inner: Http<B>,
+    _marker: PhantomData<P>,
+}
+
+type UpgradablePayload<T, B, P> = Result<(__ProtoTransport<T, B>, P), ::Error>;
+type UpgradableReceiver<T, B, P> = Receiver<UpgradablePayload<T, B, P>>;
+type UpgradableSender<T, B, P> = Sender<UpgradablePayload<T, B, P>>;
+
+impl<T, B, P> ServerProto<(T, UpgradableSender<T, B, P>)> for UpgradableHttp<P, B>
+    where T: AsyncRead + AsyncWrite + 'static,
+          B: AsRef<[u8]> + 'static,
+          P: 'static,
+{
+    type Request = __ProtoRequest;
+    type RequestBody = http::Chunk;
+    type Response = Result<__ProtoResponse, P>;
+    type ResponseBody = B;
+    type Error = ::Error;
+    type Transport = UpgradableTransport<T, B, P>;
+    type BindTransport = UpgradableBindTransport<T, B, P>;
+
+    #[inline]
+    fn bind_transport(&self, (io, sender): (T, UpgradableSender<T, B, P>)) -> Self::BindTransport {
+        UpgradableBindTransport {
+            inner: self.inner.bind_transport(io),
+            sender: Some(sender),
+        }
+    }
+}
+
+struct UpgradableBindTransport<T, B, P> {
+    inner: __ProtoBindTransport<T, B>,
+    sender: Option<UpgradableSender<T, B, P>>,
+}
+
+impl<T, B, P> Future for UpgradableBindTransport<T, B, P>
+    where T: AsyncRead + AsyncWrite + 'static,
+{
+    type Item = UpgradableTransport<T, B, P>;
+    type Error = io::Error;
+
+    #[inline]
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let inner_transport = try_ready!(self.inner.poll());
+        let transport = UpgradableTransport {
+            inner: Some(inner_transport),
+            sender: Some(self.sender.take().unwrap()),
+            recv_task: None,
+        };
+        Ok(transport.into())
+    }
+}
+
+struct UpgradableTransport<T, B, P> {
+    inner: Option<__ProtoTransport<T, B>>,
+    sender: Option<UpgradableSender<T, B, P>>,
+    recv_task: Option<Task>,
+}
+
+impl<T, B, P> UpgradableTransport<T, B, P> {
+    fn inner_mut(&mut self) -> &mut __ProtoTransport<T, B> {
+        self.inner.as_mut().expect("hyper: UpgradableTransport missing inner")
+    }
+
+    fn take_inner(&mut self) -> __ProtoTransport<T, B> {
+        self.inner.take().expect("hyper: UpgradableTransport missing inner")
+    }
+
+    fn take_sender(&mut self) -> UpgradableSender<T, B, P> {
+        self.sender.take().expect("hyper: UpgradableTransport missing sender")
+    }
+
+    fn send_error<E>(&mut self, err: E) -> E
+        where E: From<io::Error> + Into<::Error>,
+    {
+        match self.sender.take() {
+            None => err,
+            Some(sender) => {
+                let _ = sender.send(Err(err.into()));
+                proto_error()
+            }
+        }
+    }
+}
+
+/// This error will go back to the tokio-proto internals which in turn will
+/// simply discard it and shut down the connection, so we don't need to worry
+/// about what it contains.
+fn proto_error<E>() -> E
+    where E: From<io::Error>
+{
+    io::Error::from(io::ErrorKind::Other).into()
+}
+
+impl<T, B, P> Stream for UpgradableTransport<T, B, P>
+    where T: AsyncRead + AsyncWrite + 'static,
+          B: AsRef<[u8]> + 'static,
+{
+    type Item = Frame<__ProtoRequest, http::Chunk, ::Error>;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        let result = match self.inner {
+            None => return Ok(None.into()),
+            Some(ref mut inner) => {
+                self.recv_task = Some(task::current());
+                inner.poll()
+            }
+        };
+        let item = match try_ready!(result.map_err(|err| self.send_error(err))) {
+            Some(Frame::Error { error }) => Some(Frame::Error { error: self.send_error(error) }),
+            item => item,
+        };
+        Ok(item.into())
+    }
+}
+
+impl<T, B, P> Sink for UpgradableTransport<T, B, P>
+    where T: AsyncRead + AsyncWrite + 'static,
+          B: AsRef<[u8]> + 'static,
+{
+    type SinkItem = Frame<Result<__ProtoResponse, P>, B, ::Error>;
+    type SinkError = io::Error;
+
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
+        let item = match item {
+            Frame::Error { error } => {
+                let alt = proto_error();
+                let result = self.inner_mut().start_send(Frame::Error { error: alt });
+                return Ok(match result.map_err(|err| self.send_error(err))? {
+                    AsyncSink::NotReady(_) => AsyncSink::NotReady(Frame::Error { error: error }),
+                    AsyncSink::Ready => {
+                        self.send_error(error);
+                        AsyncSink::Ready
+                    }
+                });
+            }
+            Frame::Body { chunk } => Frame::Body { chunk: chunk },
+            Frame::Message { message, body } => {
+                match message {
+                    Ok(message) => Frame::Message { message: message, body: body },
+                    Err(upgrade_info) => {
+                        let inner = self.take_inner();
+                        let sender = self.take_sender();
+                        let _ = sender.send(Ok((inner, upgrade_info)));
+
+                        if let Some(recv_task) = self.recv_task.take() {
+                            recv_task.notify();
+                        }
+
+                        return Ok(AsyncSink::Ready);
+                    }
+                }
+            }
+        };
+
+        let result = self.inner_mut().start_send(item);
+        Ok(match result.map_err(|err| self.send_error(err))? {
+            AsyncSink::Ready => AsyncSink::Ready,
+            AsyncSink::NotReady(item) => {
+                AsyncSink::NotReady(match item {
+                    Frame::Message { message, body } => {
+                        Frame::Message {
+                            message: Ok(message),
+                            body: body,
+                        }
+                    }
+                    Frame::Body { chunk } => Frame::Body { chunk: chunk },
+                    Frame::Error {..} => unreachable!(),
+                })
+            }
+        })
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        let result = match self.inner {
+            None => return Ok(().into()),
+            Some(ref mut inner) => inner.poll_complete(),
+        };
+        result.map_err(|err| self.send_error(err))
+    }
+
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
+        let result = match self.inner {
+            None => return Ok(().into()),
+            Some(ref mut inner) => inner.close(),
+        };
+        result.map_err(|err| self.send_error(err))
+    }
+}
+
+impl<T, B, P> Transport for UpgradableTransport<T, B, P>
+    where T: AsyncRead + AsyncWrite + 'static,
+          B: AsRef<[u8]> + 'static,
+          P: 'static,
+{
+    #[inline]
+    fn tick(&mut self) {
+        if let Some(ref mut inner) = self.inner {
+            inner.tick();
+        }
+    }
+
+    #[inline]
+    fn cancel(&mut self) -> io::Result<()> {
+        if self.recv_task.as_mut().map_or(false, |task| task.will_notify_current()) {
+            self.recv_task = None;
+        }
+
+        if let Some(ref mut inner) = self.inner {
+            inner.cancel()
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// The return type of `Http::bind_upgradable_connection`.
+///
+/// If the server task shuts down normally, this future completes with a `None`
+/// output value.
+///
+/// If an `Upgrade` response is returned by the bound `Service`, the server task
+/// is shut down (without closing the underlying I/O object) and the provided
+/// upgrade information is forwarded to this future, along with the underlying
+/// I/O object and any remaining buffered data that has already been read from
+/// it.
+///
+/// In the case of an error handling the connection, this future will complete
+/// with that error.
+pub struct BindUpgradableConnection<T, B, P> {
+    receiver: UpgradableReceiver<T, B, P>,
+    state: Option<(http::Conn<T, B, http::ServerTransaction>, P)>,
+}
+
+impl<T, B, P> fmt::Debug for BindUpgradableConnection<T, B, P>
+    where B: AsRef<[u8]>,
+          P: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BindUpgradableConnection")
+            .field("receiver", &"...")
+            .field("state", &self.state)
+            .finish()
+    }
+}
+
+impl<T, B, P> Future for BindUpgradableConnection<T, B, P>
+    where T: AsyncRead + AsyncWrite + 'static,
+          B: AsRef<[u8]> + 'static,
+{
+    type Item = Option<(T, BytesMut, P)>;
+    type Error = ::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            if let Some((ref mut conn, _)) = self.state {
+                try_ready!(conn.poll_complete());
+            }
+
+            if let Some((conn, upgrade_info)) = self.state.take() {
+                // We ensure above that the connection is flushed before
+                // unwrapping.
+                let (io, read_buf) = conn.try_into_inner().ok().unwrap();
+                return Ok(Some((io, read_buf, upgrade_info)).into());
+            }
+
+            match self.receiver.poll() {
+                Err(_) => return Ok(None.into()),
+                Ok(Async::NotReady) => return Ok(Async::NotReady),
+                Ok(Async::Ready(result)) => {
+                    match result {
+                        Err(err) => return Err(err),
+                        Ok((transport, upgrade_info)) => {
+                            self.state = Some((transport.0, upgrade_info));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Either an HTTP response or a signal to upgrade from HTTP to another
+/// protocol.
+///
+/// If the latter, the `Upgrade` variant should contain information pertaining
+/// to this protocol switch.
+pub enum UpgradableResponse<P = (), B = ::Body> {
+    /// An HTTP response.
+    Response(Response<B>),
+    /// A protocol upgrade signal with accompanying information.
+    Upgrade(P),
+}
+
+impl<P, B> fmt::Debug for UpgradableResponse<P, B>
+    where Response<B>: fmt::Debug,
+          P: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            UpgradableResponse::Response(ref response) => {
+                f.debug_tuple("Response").field(response).finish()
+            }
+            UpgradableResponse::Upgrade(ref upgrade_info) => {
+                f.debug_tuple("Upgrade").field(upgrade_info).finish()
+            }
+        }
+    }
+}
+
+impl<P, B> From<Response<B>> for UpgradableResponse<P, B> {
+    fn from(src: Response<B>) -> Self {
+        UpgradableResponse::Response(src)
+    }
+}
+
+impl<P, B> Default for UpgradableResponse<P, B> {
+    fn default() -> Self {
+        Response::default().into()
+    }
+}
+
+struct UpgradableHttpService<T> {
+    inner: T,
+    remote_addr: SocketAddr,
+}
+
+impl<T, B, P> Service for UpgradableHttpService<T>
+    where T: Service<Request=Request, Response=UpgradableResponse<P, B>, Error=::Error>,
+          B: Stream<Error=::Error>,
+          B::Item: AsRef<[u8]>,
+{
+    type Request = Message<__ProtoRequest, http::TokioBody>;
+    type Response = Message<Result<__ProtoResponse, P>, B>;
+    type Error = ::Error;
+    type Future = Map<T::Future,
+                      fn(UpgradableResponse<P, B>) -> Message<Result<__ProtoResponse, P>, B>>;
 
     #[inline]
     fn call(&self, message: Self::Request) -> Self::Future {

--- a/tests/upgradable_server.rs
+++ b/tests/upgradable_server.rs
@@ -1,0 +1,242 @@
+extern crate bytes;
+extern crate hyper;
+extern crate futures;
+extern crate tokio_core;
+extern crate tokio_io;
+extern crate tokio_service;
+
+use bytes::BytesMut;
+use futures::{Future, Sink, Stream};
+use futures::future::{self, Either};
+use hyper::{Request, Response, StatusCode};
+use hyper::header::{self, Headers, Raw};
+use hyper::server::{Http, UpgradableResponse};
+use std::ascii::AsciiExt;
+use std::io;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::str;
+use std::time;
+use tokio_core::net::{TcpListener, TcpStream};
+use tokio_core::reactor::{Core, Handle};
+use tokio_io::codec::{Decoder, Encoder, Framed, FramedParts};
+use tokio_service::Service;
+
+struct TestService;
+
+fn detect_handshake(headers: &Headers) -> Option<String> {
+    match headers.get::<header::Connection>() {
+        None => return None,
+        Some(&header::Connection(ref options)) => {
+            let upgrade = options.iter().any(|option| {
+                match option {
+                    &header::ConnectionOption::ConnectionHeader(ref value) if value.as_ref()
+                        .eq_ignore_ascii_case("upgrade") => true,
+                    _ => false,
+                }
+            });
+            if !upgrade {
+                return None;
+            }
+        }
+    }
+
+    match headers.get::<header::Upgrade>() {
+        None => return None,
+        Some(&header::Upgrade(ref protocols)) => {
+            if !protocols.iter()
+                .any(|p| p.name == header::ProtocolName::Unregistered("line".into())) {
+                return None;
+            }
+        }
+    }
+
+    let echo = match headers.get_raw("x-line-echo").and_then(Raw::one) {
+        None => return None,
+        Some(echo) => echo,
+    };
+
+    str::from_utf8(echo).ok().map(str::to_owned)
+}
+
+impl Service for TestService {
+    type Request = Request;
+    type Response = UpgradableResponse<String>;
+    type Error = hyper::Error;
+    type Future = Box<Future<Item = Self::Response, Error = Self::Error>>;
+
+    fn call(&self, req: Self::Request) -> Self::Future {
+        match detect_handshake(req.headers()) {
+            None => {
+                Box::new(future::ok(UpgradableResponse::Response(Response::new()
+                    .with_status(StatusCode::Ok)
+                    .with_header(header::Date(time::UNIX_EPOCH.into()))
+                    .with_body("Hello World"))))
+            }
+            Some(echo) => {
+                let res = Response::new()
+                    .with_status(StatusCode::SwitchingProtocols)
+                    .with_header(header::Date(time::UNIX_EPOCH.into()))
+                    .with_header(header::Connection(vec![
+                            header::ConnectionOption::ConnectionHeader("Upgrade".parse().unwrap())
+                    ]))
+                    .with_header(header::Upgrade(vec!["line".parse().unwrap()]));
+                Box::new(future::ok(UpgradableResponse::Upgrade(echo, Some(res))))
+            }
+        }
+    }
+}
+
+pub struct LineCodec;
+
+impl Encoder for LineCodec {
+    type Item = String;
+    type Error = io::Error;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        dst.extend(item.as_bytes());
+        dst.extend(b"\n");
+        Ok(())
+    }
+}
+
+impl Decoder for LineCodec {
+    type Item = String;
+    type Error = io::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if let Some(pos) = src.iter().position(|c| *c == b'\n') {
+            let line_bytes = src.split_to(pos);
+            src.split_to(1);
+            str::from_utf8(line_bytes.as_ref())
+                .map(|s| Some(s.to_owned()))
+                .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+fn start_server(handle: &Handle) -> SocketAddr {
+    let server_handle = handle.clone();
+
+    let server_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 0));
+    let listener = TcpListener::bind(&server_addr, &handle).expect("listener bind error");
+    let server_addr = listener.local_addr().expect("server address retrieval error");
+
+    let server_proto = Http::new();
+    let serve = listener.incoming()
+        .for_each(move |(tcp, remote_addr)| {
+            server_proto.bind_upgradable_connection(&server_handle, tcp, remote_addr, TestService)
+                .then(|result| {
+                    let maybe_upgrade = result.expect("server http error");
+                    let (io, read_buf, echo) = match maybe_upgrade {
+                        None => return Either::A(future::ok(())),
+                        Some(upgrade) => upgrade,
+                    };
+
+                    let parts = FramedParts {
+                        inner: io,
+                        readbuf: read_buf,
+                        writebuf: BytesMut::with_capacity(8192),
+                    };
+                    let framed = Framed::from_parts(parts, LineCodec);
+
+                    Either::B(framed.send(echo)
+                        .then(|result| {
+                            let framed = result.expect("server echo error");
+                            framed.send("Foo".into())
+                        })
+                        .then(|result| {
+                            let framed = result.expect("server send error");
+                            framed.into_future().map_err(|(err, _framed)| err)
+                        })
+                        .then(|result| {
+                            let (maybe_msg, _framed) = result.expect("server receive error");
+                            assert_eq!(maybe_msg, Some("Bar".into()));
+                            Ok(())
+                        }))
+                })
+        })
+        .then(|result| {
+            result.expect("server accept error");
+            Ok(())
+        });
+    handle.spawn(serve);
+
+    server_addr
+}
+
+#[test]
+fn test_http() {
+    let mut core = Core::new().expect("core creation error");
+    let handle = core.handle();
+    let server_addr = start_server(&handle);
+
+    let client = hyper::Client::new(&handle);
+    let test = client.get(format!("http://{}", server_addr).parse().expect("uri parse error"))
+        .then(|result| {
+            let res = result.expect("client http error");
+            res.body().concat2()
+        })
+        .and_then(|body| {
+            let body_str = str::from_utf8(body.as_ref()).expect("client body decode error");
+            assert_eq!(body_str, "Hello World");
+            Ok(())
+        });
+    core.run(test).expect("client body read error");
+}
+
+#[test]
+fn test_upgrade() {
+    let mut core = Core::new().expect("core creation error");
+    let handle = core.handle();
+    let server_addr = start_server(&handle);
+
+    let to_server =
+        "GET / HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         \r\n\
+         GET / HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: line\r\n\
+         X-Line-Echo: Echo\r\n\
+         \r\n\
+         Bar\n";
+
+    let from_server =
+        "HTTP/1.1 200 OK\r\n\
+         Date: Thu, 01 Jan 1970 00:00:00 GMT\r\n\
+         Transfer-Encoding: chunked\r\n\
+         \r\n\
+         B\r\n\
+         Hello World\r\n\
+         0\r\n\
+         \r\n\
+         HTTP/1.1 101 Switching Protocols\r\n\
+         Date: Thu, 01 Jan 1970 00:00:00 GMT\r\n\
+         Connection: Upgrade\r\n\
+         Upgrade: line\r\n\
+         Content-Length: 0\r\n\
+         \r\n\
+         Echo\n\
+         Foo\n";
+    let from_server_len = from_server.len();
+
+    let test = TcpStream::connect(&server_addr, &handle)
+        .then(move |result| {
+            let tcp = result.expect("client connect error");
+            tokio_io::io::write_all(tcp, to_server.as_bytes())
+        })
+        .then(move |result| {
+            let (tcp, _msg) = result.expect("client send error");
+            let buf = vec![0; from_server_len];
+            tokio_io::io::read_exact(tcp, buf)
+        })
+        .and_then(move |(_tcp, msg)| {
+            let msg_str = String::from_utf8(msg).expect("client decode error");
+            assert_eq!(msg_str, from_server);
+            Ok(())
+        });
+    core.run(test).expect("client receive error");
+}


### PR DESCRIPTION
The Http type learns a new method, bind_upgradable_connection, which returns a Future. This method behaves like bind_connection, except the Service supplied must return an UpgradableResponse containing either an HTTP Response or some information describing a protocol switch. If an Upgrade response is returned, the server task is shut down (without closing the underlying io) and this information is forwarded to the Future, along with the underlying io and any remaining buffered data that has already been read from it.

If the server task shuts down normally, the Future completes with a None output value. In the case of an error handling the connection, the error is also forwarded to the Future.

This allows for implementing servers with hyper that can upgrade their connections to different protocols, such as WebSockets, in response to client requests. Such protocols can be implemented outside of hyper itself. The API is designed to allow for potentially multiple upgrade paths out of an HTTP exchange, with the upgrade information attached to the UpgradableResponse::Upgrade signal determining which is used.

A companion crate implementing WebSocket upgrades can be found [here](https://github.com/spinda/hyper-websocket), with sample code [here](https://github.com/spinda/hyper-websocket/blob/416ca8588931aa92a737c9c1a4afef2bef5d24b6/tests/test.rs).

Importantly, the code path for normal, non-upgradable connections is entirely untouched by this addition.

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines