### PR TITLE
feat(headers): add 'Token' token support

### DIFF
--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -20,7 +20,7 @@ pub use self::access_control_max_age::AccessControlMaxAge;
 pub use self::access_control_request_headers::AccessControlRequestHeaders;
 pub use self::access_control_request_method::AccessControlRequestMethod;
 pub use self::allow::Allow;
-pub use self::authorization::{Authorization, Scheme, Basic, Bearer};
+pub use self::authorization::{Authorization, Scheme, Basic, Bearer, Token};
 pub use self::cache_control::{CacheControl, CacheDirective};
 pub use self::connection::{Connection, ConnectionOption};
 pub use self::content_disposition::{ContentDisposition, DispositionType, DispositionParam};


### PR DESCRIPTION
This adds support for static Token authorization used in some APIs.
Code is pretty similar to [Bearer token support](https://github.com/hyperium/hyper/pull/572/files).

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
