### PR TITLE
perf(http): prefer ErrorKind::WouldBlock

### DIFF
--- a/src/http/h1/encode.rs
+++ b/src/http/h1/encode.rs
@@ -202,7 +202,7 @@ impl Chunked {
         match *self {
             Chunked::Init |
             Chunked::End => Ok(msg.len()),
-            _ => Err(io::Error::new(io::ErrorKind::WouldBlock, "chunked incomplete"))
+            _ => Err(io::ErrorKind::WouldBlock.into())
         }
     }
 }

--- a/src/http/io.rs
+++ b/src/http/io.rs
@@ -132,7 +132,7 @@ impl<T: Write> Write for Buffered<T> {
     fn write(&mut self, data: &[u8]) -> io::Result<usize> {
         let n = self.write_buf.buffer(data);
         if n == 0 {
-            Err(io::Error::from(io::ErrorKind::WouldBlock))
+            Err(io::ErrorKind::WouldBlock.into())
         } else {
             Ok(n)
         }

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -107,7 +107,7 @@ impl<T: Read> Read for AsyncIo<T> {
             Err(err)
         } else if self.bytes_until_block == 0 {
             self.blocked = true;
-            Err(io::Error::new(io::ErrorKind::WouldBlock, "mock block"))
+            Err(io::ErrorKind::WouldBlock.into())
         } else {
             let n = cmp::min(self.bytes_until_block, buf.len());
             let n = try!(self.inner.read(&mut buf[..n]));
@@ -122,7 +122,7 @@ impl<T: Write> Write for AsyncIo<T> {
         if let Some(err) = self.error.take() {
             Err(err)
         } else if self.bytes_until_block == 0 {
-            Err(io::Error::new(io::ErrorKind::WouldBlock, "mock block"))
+            Err(io::ErrorKind::WouldBlock.into())
         } else {
             trace!("AsyncIo::write() block_in = {}, data.len() = {}", self.bytes_until_block, data.len());
             self.flushed = false;


### PR DESCRIPTION
Improved codegen, without allocations or function calls

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
