### PR TITLE
feat(http): add Body::from(cow) for bytes and strings

### DIFF
--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -2,6 +2,7 @@ use bytes::Bytes;
 use futures::{Poll, Stream};
 use futures::sync::mpsc;
 use tokio_proto;
+use std::borrow::Cow;
 
 use http::Chunk;
 
@@ -94,6 +95,17 @@ impl From<&'static [u8]> for Body {
     }
 }
 
+impl From<Cow<'static, [u8]>> for Body {
+    #[inline]
+    fn from (cow: Cow<'static, [u8]>) -> Body {
+		if let Cow::Borrowed(value) = cow {
+			Body::from(value)
+		} else {
+			Body::from(cow.to_owned())
+		}
+    }
+}
+
 impl From<String> for Body {
     #[inline]
     fn from (s: String) -> Body {
@@ -105,6 +117,17 @@ impl From<&'static str> for Body {
     #[inline]
     fn from (slice: &'static str) -> Body {
         Body(TokioBody::from(Chunk::from(slice.as_bytes())))
+    }
+}
+
+impl From<Cow<'static, str>> for Body {
+    #[inline]
+    fn from (cow: Cow<'static, str>) -> Body {
+		if let Cow::Borrowed(value) = cow {
+			Body::from(value)
+		} else {
+			Body::from(cow.to_owned())
+		}
     }
 }
 


### PR DESCRIPTION
This change adds the ability to use Cow<'static, [u8]> and Cow<'static, str> for the body of a
HTTP request or response.
This makes it easier to create abstractions that serve static web pages, redirect messages and the
like.

- [ ] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
