### PR TITLE
fix(lib): Export hyper::RawStatus if the raw_status feature is enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ pub use method::Method::{self, Get, Head, Post, Put, Delete};
 pub use status::StatusCode::{self, Ok, BadRequest, NotFound};
 pub use server::Server;
 pub use version::HttpVersion;
+#[cfg(feature = "raw_status")]
+pub use http::RawStatus;
 
 #[cfg(test)]
 mod mock;


### PR DESCRIPTION
- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
