### PR TITLE
perf(client): Remove parked senders when a checkout is dropped to prevent memory leaks

### DIFF
--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -271,6 +271,16 @@ impl<T: Clone> Future for Checkout<T> {
     }
 }
 
+impl<T> Drop for Checkout<T> {
+    fn drop(&mut self) {
+        // Cleanup the parked senders in the pool to prevent a memory leak where
+        // it would grow indefinitely.
+        // @todo This clears out other parked senders as well, how should we
+        // remove just our sender of this checkout?
+        self.pool.inner.borrow_mut().parked.remove(&self.key);
+    }
+}
+
 struct Expiration(Option<Duration>);
 
 impl Expiration {


### PR DESCRIPTION
Attempt to fix #1315 .

Note that I'm not sure what I'm doing here is right because I have not groked yet what the purpose of those parked senders is.