### PR TITLE
feat(server): Accepting futures::Streams of connections, and turning the server into a future

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,6 +1,7 @@
 #![deny(warnings)]
 extern crate hyper;
 extern crate futures;
+extern crate tokio_core;
 extern crate pretty_env_logger;
 
 use futures::future::FutureResult;
@@ -31,7 +32,5 @@ impl Service for Hello {
 fn main() {
     pretty_env_logger::init().unwrap();
     let addr = "127.0.0.1:3000".parse().unwrap();
-    let server = Http::new().bind(&addr, || Ok(Hello)).unwrap();
-    println!("Listening on http://{} with 1 thread.", server.local_addr().unwrap());
-    server.run().unwrap();
+    Http::new().run(&addr, || Ok(Hello)).unwrap();
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -47,7 +47,5 @@ fn main() {
     pretty_env_logger::init().unwrap();
     let addr = "127.0.0.1:1337".parse().unwrap();
 
-    let server = Http::new().bind(&addr, || Ok(Echo)).unwrap();
-    println!("Listening on http://{} with 1 thread.", server.local_addr().unwrap());
-    server.run().unwrap();
+    Http::new().run(&addr, || Ok(Echo)).unwrap();
 }


### PR DESCRIPTION
- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines


This PR is maybe not meant to be accepted as such, but solves a number of problems for me:

- I can now run my own event loop, and configure my socket as I want before, without having to resort to low-level functions. This was already possible before, at the price of code duplication between Hyper and my crate. This solves issues #1075 and #1263.

- I can now use the latest developments of rustls (for example their recent addition of SNI): since the server now takes an arbitrary stream of connections, one example use is to negotiate a TLS connection and passing it as a stream, like so:

``` rust
let mut core = Core::new().unwrap();
let http = hyper::server::Http::new();
let listener = tokio_core::net::TcpListener::bind(addr, core.handle())
  .incoming().from_err()
  .and_then(move |(socket, addr)| {
      https_config
        .accept_async(socket)
        .map(move |socket| (socket, addr))
        .from_err()
  });
http.from_listener(listener, | | Ok(MyServer { … }).unwrap()
  .future_run(core.handle())
  .from_err()
```
Of course, it work fine on plain `TcpListener`s, and that's actually what `Http::bind` does.

Also, this PR does not change the existing API, except for:
- `local_addr`, which is now impossible to implement with the more general setting of arbitrary streams of connections instead of just Incoming.
- `handle`, but this is now useless: if you need a handle, you might as well run your own event loop.

