### PR TITLE
 fix(server): remove Sync + Send + 'static trait bound 

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -86,8 +86,7 @@ impl<B: AsRef<[u8]> + 'static> Http<B> {
     /// The returned `Server` contains one method, `run`, which is used to
     /// actually run the server.
     pub fn bind<S, Bd>(&self, addr: &SocketAddr, new_service: S) -> ::Result<Server<S, Bd>>
-        where S: NewService<Request = Request, Response = Response<Bd>, Error = ::Error> +
-                    Send + Sync + 'static,
+        where S: NewService<Request = Request, Response = Response<Bd>, Error = ::Error>,
               Bd: Stream<Item=B, Error=::Error>,
     {
         let core = try!(Core::new());
@@ -337,8 +336,7 @@ impl<T, B> Service for HttpService<T>
 }
 
 impl<S, B> Server<S, B>
-    where S: NewService<Request = Request, Response = Response<B>, Error = ::Error>
-                + Send + Sync + 'static,
+    where S: NewService<Request = Request, Response = Response<B>, Error = ::Error> + 'static,
           B: Stream<Error=::Error> + 'static,
           B::Item: AsRef<[u8]>,
 {


### PR DESCRIPTION
Remove unnecessary for tokio-based async server thait bounds according to Issue #1327

BREAKING CHANGE: server NewService and Http API

Thanks to @LooMaclin for writing this patch in the first place.