### PR TITLE
feat(client): allow custom executors for HttpConnector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 base64 = "0.6"
 bytes = "0.4.4"
 futures = "0.1.14"
-futures-cpupool = "0.1"
+futures-cpupool = "0.1.6"
 http = { version = "0.1", optional = true }
 httparse = "1.0"
 language-tags = "0.2"


### PR DESCRIPTION
Fixes #1330

This got slightly more complex than I initially thought due to trying to make a future-proof API by:
- not exposing any `futures::sync::oneshot::*` types
- catering for the possibility of `HttpConnector` wanting to execute different types of blocking tasks

---

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
