### PR TITLE
feat(body): implement limited buffering

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -139,6 +139,22 @@ impl From<httparse::Error> for Error {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+/// Possible error when the body buffer limit is exceeded.
+pub struct BodyTooLargeError;
+
+impl fmt::Display for BodyTooLargeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.description())
+    }
+}
+
+impl StdError for BodyTooLargeError {
+    fn description(&self) -> &str {
+        "Body is too large"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::error::Error as StdError;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -13,7 +13,7 @@ use version::HttpVersion;
 use version::HttpVersion::{Http10, Http11};
 
 pub use self::conn::{Conn, KeepAlive, KA};
-pub use self::body::{Body, TokioBody};
+pub use self::body::{Body, TokioBody, Buffering};
 pub use self::chunk::Chunk;
 
 mod body;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub use uri::Uri;
 pub use client::Client;
 pub use error::{Result, Error};
 pub use header::Headers;
-pub use http::{Body, Chunk};
+pub use http::{Body, Buffering, Chunk};
 pub use http::request::Request;
 pub use http::response::Response;
 pub use method::Method::{self, Get, Head, Post, Put, Delete};


### PR DESCRIPTION
Apologies for opening yet another PR while my previous one is still open. Please do take your time!

This is some logic that I noticed I started copying between projects, so it seemed high time to make it reusable. The basic idea is to protect against DoS attacks in cases where you do need to buffer the full body in memory, for instance JSON parsing, by enforcing a maximum size while buffering.

Initially I thought of putting it into a separate crate, but it would be nice to have this available directly in hyper. For instance, I noticed that the guide is using `Stream::concat2` [here](https://hyper.rs/guides/client/json/) in the example for JSON parsing. In the spirit of Rust being safe by default, I believe we should promote `Body::buffer` as the default way of doing this, rather than `Stream::concat2` which is vulnerable to DoS attacks through large request or response bodies.

Let me know what you think!


- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
