### PR TITLE
fix(http): avoid infinite recursion when Body::from is called with Cow::Owned.

### DIFF
--- a/src/proto/body.rs
+++ b/src/proto/body.rs
@@ -98,10 +98,9 @@ impl From<&'static [u8]> for Body {
 impl From<Cow<'static, [u8]>> for Body {
     #[inline]
     fn from (cow: Cow<'static, [u8]>) -> Body {
-        if let Cow::Borrowed(value) = cow {
-            Body::from(value)
-        } else {
-            Body::from(cow.to_owned())
+        match cow {
+            Cow::Borrowed(b) => Body::from(b),
+            Cow::Owned(o) => Body::from(o)
         }
     }
 }
@@ -123,10 +122,9 @@ impl From<&'static str> for Body {
 impl From<Cow<'static, str>> for Body {
     #[inline]
     fn from(cow: Cow<'static, str>) -> Body {
-        if let Cow::Borrowed(value) = cow {
-            Body::from(value)
-        } else {
-            Body::from(cow.to_owned())
+        match cow {
+            Cow::Borrowed(b) => Body::from(b),
+            Cow::Owned(o) => Body::from(o)
         }
     }
 }


### PR DESCRIPTION
When cow is a Cow::Owned, cow.to_owned() returns a Cow::Owned, which leads to infinite recursion.
Extract the owned or borrowed values from the cow to ensure progress is made in either case.

- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
