### PR TITLE
<docs>: add link to easy issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Hyper
 
-You want to contribute? You're awesome! Don't know where to start? Check the [list of easy issues][].
+You want to contribute? You're awesome! Don't know where to start? Check the [list of easy issues](https://github.com/hyperium/hyper/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy).
 
 [easy tag]: https://github.com/hyperium/hyper/issues?q=label%3AE-easy+is%3Aopen
 


### PR DESCRIPTION
Fill the missing link in the CONTRIBUTING.md 

Closes no (known) open issue

- [ ] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
