### PR TITLE
docs(headers): fix >-quote formatting

### DIFF
--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -19,7 +19,7 @@ use header::{Header, Raw, parsing};
 /// [RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.2):
 ///
 /// > A sender MUST NOT send a Content-Length header field in any message
-/// that > contains a Transfer-Encoding header field.
+/// > that contains a Transfer-Encoding header field.
 ///
 /// # ABNF
 /// ```plain

--- a/src/header/common/pragma.rs
+++ b/src/header/common/pragma.rs
@@ -10,7 +10,6 @@ use header::{Header, Raw, parsing};
 /// > that they will understand (as Cache-Control was not defined until
 /// > HTTP/1.1).  When the Cache-Control header field is also present and
 /// > understood in a request, Pragma is ignored.
-
 /// > In HTTP/1.0, Pragma was defined as an extensible field for
 /// > implementation-specified directives for recipients.  This
 /// > specification deprecates such extensions to improve interoperability.

--- a/src/proto/response.rs
+++ b/src/proto/response.rs
@@ -200,7 +200,7 @@ pub fn from_wire<B>(incoming: ResponseHead, body: Option<B>) -> Response<B> {
     }
 }
 
-/// Splits this response into a MessageHead<StatusCode> and its body
+/// Splits this response into a `MessageHead<StatusCode>` and its body
 #[inline]
 pub fn split<B>(res: Response<B>) -> (MessageHead<StatusCode>, Option<B>) {
     let head = MessageHead::<StatusCode> {


### PR DESCRIPTION
- [x] The commit messages match the guidelines in https://github.com/hyperium/hyper/blob/master/CONTRIBUTING.md#git-commit-guidelines
