### PR TITLE
feat(client): skip dns resolution when host is a valid ip addr

### DIFF
--- a/src/client/dns.rs
+++ b/src/client/dns.rs
@@ -1,5 +1,9 @@
 use std::io;
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::{
+    Ipv4Addr, Ipv6Addr,
+    SocketAddr, ToSocketAddrs,
+    SocketAddrV4, SocketAddrV6,
+};
 use std::vec;
 
 use ::futures::{Async, Future, Poll};
@@ -28,6 +32,20 @@ impl Future for Work {
 
 pub struct IpAddrs {
     iter: vec::IntoIter<SocketAddr>,
+}
+
+impl IpAddrs {
+    pub fn try_parse(host: &str, port: u16) -> Option<IpAddrs> {
+        if let Ok(addr) = host.parse::<Ipv4Addr>() {
+            let addr = SocketAddrV4::new(addr, port);
+            return Some(IpAddrs { iter: vec![SocketAddr::V4(addr)].into_iter() })
+        }
+        if let Ok(addr) = host.parse::<Ipv6Addr>() {
+            let addr = SocketAddrV6::new(addr, port, 0, 0);
+            return Some(IpAddrs { iter: vec![SocketAddr::V6(addr)].into_iter() })
+        }
+        None
+    }
 }
 
 impl Iterator for IpAddrs {


### PR DESCRIPTION
This change allows us to skip going to the thread pool for dns lookup in cases where the host itself is already a valid ipv4 or ipv6 address.

This is useful for performance reasons, as well as to allow passing in a no-op executor in cases where it's known that only static IPs will be connected to.