### PR TITLE
feat(headers): support known extensions

### DIFF
--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -21,7 +21,7 @@ pub use self::access_control_request_headers::AccessControlRequestHeaders;
 pub use self::access_control_request_method::AccessControlRequestMethod;
 pub use self::allow::Allow;
 pub use self::authorization::{Authorization, Scheme, Basic, Bearer};
-pub use self::cache_control::{CacheControl, CacheDirective};
+pub use self::cache_control::{CacheControl, CacheDirective, CacheDirectiveExtension};
 pub use self::connection::{Connection, ConnectionOption};
 pub use self::content_disposition::{ContentDisposition, DispositionType, DispositionParam};
 pub use self::content_encoding::ContentEncoding;


### PR DESCRIPTION
And only known extensions. Clean up parsing of extensions in general.

