### PR TITLE
Updates to 0.10.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 ]
 
 [dependencies]
-base64 = "0.6.0"
+base64 = "0.9.0"
 httparse = "1.0"
 language-tags = "0.2"
 log = "0.3"

--- a/src/header/common/link.rs
+++ b/src/header/common/link.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::borrow::Cow;
 use std::str::FromStr;
+
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 
 use mime::Mime;

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -137,6 +137,7 @@ macro_rules! test_header {
     ($id:ident, $raw:expr) => {
         #[test]
         fn $id() {
+            #[allow(unused_imports)]
             use std::ascii::AsciiExt;
             let raw = $raw;
             let a: Vec<Vec<u8>> = raw.iter().map(|x| x.to_vec()).collect();

--- a/src/header/common/pragma.rs
+++ b/src/header/common/pragma.rs
@@ -1,4 +1,6 @@
 use std::fmt;
+
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 
 use header::{Header, HeaderFormat, parsing};

--- a/src/header/common/referrer_policy.rs
+++ b/src/header/common/referrer_policy.rs
@@ -1,4 +1,6 @@
 use std::fmt;
+
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 
 use header::{Header, HeaderFormat, parsing};

--- a/src/header/shared/charset.rs
+++ b/src/header/shared/charset.rs
@@ -1,5 +1,7 @@
 use std::fmt::{self, Display};
 use std::str::FromStr;
+
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 
 use self::Charset::*;


### PR DESCRIPTION
Adds  `#[allow(unused_imports)]` to `AsciiExt` imports to fix tests. Updates `base64` to `0.9.0`.