### PR TITLE
feat(client): redesign the `Connect` trait

### DIFF
--- a/src/client/compat.rs
+++ b/src/client/compat.rs
@@ -1,10 +1,12 @@
 //! Wrappers to build compatibility with the `http` crate.
 
+use std::io;
+
 use futures::{Future, Poll, Stream};
 use http;
 use tokio_service::Service;
 
-use client::{Connect, Client, FutureResponse};
+use client::{Connect2, Client, FutureResponse};
 use error::Error;
 use proto::Body;
 
@@ -19,7 +21,9 @@ pub(super) fn client<C, B>(client: Client<C, B>) -> CompatClient<C, B> {
 }
 
 impl<C, B> Service for CompatClient<C, B>
-where C: Connect,
+where C: Connect2<Error=io::Error>,
+      C::Transport: 'static,
+      C::Future: 'static,
       B: Stream<Error=Error> + 'static,
       B::Item: AsRef<[u8]>,
 {


### PR DESCRIPTION
The original `Connect` trait had some limitations:

- There was no way to provide more details to the connector about how to
  connect, other than the `Uri`.
- There was no way for the connector to return any extra information
  about the connected transport.
- The `Error` was forced to be an `std::io::Error`.
- The transport and future had `'static` requirements.

As hyper gains HTTP/2 support, some of these things needed to be
changed. We want to allow the user to configure whether they hope to
us ALPN to start an HTTP/2 connection, and the connector needs to be
able to return back to hyper if it did so.

The new `Connect2` trait is meant to solve this.

- The `connect` method now receives a `Destination` type, instead of a
  `Uri`. This allows us to include additional data about how to connect.
- The `Future` returned from `connect` now must be a `Connected`, which
  wraps the transport, and includes possibly extra data about what
  happened when connecting.

The `Connect` trait is deprecated, with the hopes of `Connect2` taking
it's place in the next breaking release. For backwards compatibility,
any type that implements `Connect` now will automaticall implement
`Connect2`, ignoring any of the extra data from `Destination` and
`Connected`.

A step towards #304. 

--------

I've tested this branch with hyper-tls, and ensured that without a change, it still works, and that in a new branch, the new trait can be adopted. Unfortunately, ALPN isn't exposed in native-tls, so that would be needed before hyper-tls could make use of this.

cc @sfackler @carllerche