### PR TITLE
docs(headers): document the fact that <Basic as FromStr>::from_str takes a base-64 encoded string

### DIFF
--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -167,6 +167,7 @@ impl Scheme for Basic {
     }
 }
 
+/// creates a Basic from a base-64 encoded, `:`-delimited utf-8 string
 impl FromStr for Basic {
     type Err = ::Error;
     fn from_str(s: &str) -> ::Result<Basic> {


### PR DESCRIPTION
I couldn't figure out why my "username:password" strings kept failing to parse
into a Basic auth header, until I realized that the implementation expects
it to be base-64 encoded, which would be the case if it was coming from HTTP.
I'm not sure if this is the best place to document it, but hopefully it will
make it more clear for other people / me when I forget.

Perhaps a better approach would be to document somewhere that all `FromStr` impls for
headers are there for parsing request headers, and not really for creating them.