### PR TITLE
Drop the connecting item from pool when dropping an idle connection

### DIFF
--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -132,6 +132,10 @@ impl<T: Clone + Ready> Pool<T> {
         }
         if remove_parked {
             inner.parked.remove(&key);
+            #[cfg(feature = "http2")]
+            {
+                inner.connecting.remove(&key);
+            }
         }
 
         match entry {
@@ -178,6 +182,11 @@ impl<T: Clone + Ready> Pool<T> {
 
             if should_remove {
                 inner.idle.remove(key);
+
+                #[cfg(feature = "http2")]
+                {
+                    inner.connecting.remove(key);
+                }
             }
             entry
         };


### PR DESCRIPTION
So when we hit the keep-alive timeout, we cannot open a new connection because we had a leftover item in the connecting map. This seems to fix the issue, but I'm not sure is this how kosher and did I break something else. 