### PR TITLE
fix(dependencies): Hyper does not compile with tokio-core < 0.1.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ mime = "0.3.2"
 percent-encoding = "1.0"
 relay = "0.1"
 time = "0.1"
-tokio-core = "0.1.6"
+tokio-core = "0.1.11"
 tokio-proto = { version = "0.1", optional = true }
 tokio-service = "0.1"
 tokio-io = "0.1"


### PR DESCRIPTION
Error:
```
error[E0277]: `tokio::reactor::Timeout` doesn't implement `std::fmt::Debug`
   --> src/server/mod.rs:108:5
    |
108 |     timeout: Option<Timeout>,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ `tokio::reactor::Timeout` cannot be formatted using `:?` because it doesn't implement `std::fmt::Debug`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `tokio::reactor::Timeout`
    = note: required because of the requirements on the impl of `std::fmt::Debug` for `std::option::Option<tokio::reactor::Timeout>`
    = note: required because of the requirements on the impl of `std::fmt::Debug` for `&std::option::Option<tokio::reactor::Timeout>`
    = note: required for the cast to the object type `std::fmt::Debug`

error: aborting due to previous error

If you want more information on this error, try using "rustc --explain E0277"
error: Could not compile `hyper`.
```