### PR TITLE
feat(server): Make sleep_on_error duration configurable and enable it per default

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -20,7 +20,6 @@ fn main() {
     }));
 
     let server = Http::new()
-        .sleep_on_errors(true)
         .bind(&addr, new_service)
         .unwrap();
     println!("Listening on http://{} with 1 thread.", server.local_addr().unwrap());


### PR DESCRIPTION
For issue #1455 .

This is a minor API break because I'm changing the type of the sleep_on_error() method. This method exists only for a very short amount of time and Hyper is pre-1.0 so changing this might be ok?