### PR TITLE
fix(lib): move to futures master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ url = "1.0"
 nightly = []
 
 [replace]
-"futures:0.2.0-beta" = { git = "https://github.com/srijs/futures-rs.git", branch = "with-executor" }
+"futures:0.2.0-beta" = { git = "https://github.com/rust-lang-nursery/futures-rs.git" }


### PR DESCRIPTION
Just a small patch, but my `with_executor` changes got merged into futures, so we can point to the main futures repo now instead.