### PR TITLE
chore(ci): hide gh-pages branch from git log --all

### DIFF
--- a/.travis/docs.sh
+++ b/.travis/docs.sh
@@ -13,15 +13,19 @@ cd deploy_docs
 git config user.name "Sean McArthur"
 git config user.email "sean.monstar@gmail.com"
 
+# Fake up the date to be ages ago, so that it doesn't pollute the output of
+#   git log --graph --all --oneline
+DATE=$((`date +%s`-60*60*24*(365*28+7)))
+
 if [ "$TRAVIS_TAG" = ""  ]; then
     rm -rf master
     mv ../target/doc ./master
     echo "<meta http-equiv=refresh content=0;url=hyper/index.html>" > ./master/index.html
 fi
 
-
 git add -A .
-git commit -m "rebuild pages at ${TRAVIS_COMMIT}"
+GIT_AUTHOR_DATE=$DATE GIT_COMMITTER_DATE=$DATE \
+    git commit -m "rebuild pages at ${TRAVIS_COMMIT}"
 
 echo
 echo "Pushing docs..."


### PR DESCRIPTION
This is done by making the committer date sufficiently old.

28 years is chosen because that's how often weekdays line up
with days of the month reliably. This should continue to be
the case until 2100, when we next skip a leap year.

This should solve https://github.com/hyperium/hyper/issues/1191 without the need to force-push.

to test manually, I did 
```
GIT_AUTHOR_DATE=$((`date +%s`-60*60*24*(365*28+7))) GIT_COMMITTER_DATE=$((`date +%s`-60*60*24*365*20)) git commit -am "try breaking the date"
```
 on the gh-pages branch, and then did `git log --oneline --graph --all` and the gh-pages branch wasn't there (it turns out that breaking the date of the head commit is enough to remove the entire branch from view).