### PR TITLE
feat(client): add support for title case header names at the socket level

### DIFF
--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -67,6 +67,7 @@ where
 pub struct Builder {
     exec: Exec,
     h1_writev: bool,
+    h1_title_case_headers: bool,
     http2: bool,
 }
 
@@ -419,6 +420,7 @@ impl Builder {
         Builder {
             exec: Exec::Default,
             h1_writev: true,
+            h1_title_case_headers: false,
             http2: false,
         }
     }
@@ -432,6 +434,11 @@ impl Builder {
 
     pub(super) fn h1_writev(&mut self, enabled: bool) -> &mut Builder {
         self.h1_writev = enabled;
+        self
+    }
+
+    pub(super) fn h1_title_case_headers(&mut self, enabled: bool) -> &mut Builder {
+        self.h1_title_case_headers = enabled;
         self
     }
 
@@ -549,6 +556,9 @@ where
             let mut conn = proto::Conn::new(io);
             if !self.builder.h1_writev {
                 conn.set_write_strategy_flatten();
+            }
+            if self.builder.h1_title_case_headers {
+                conn.set_title_case_headers();
             }
             let cd = proto::h1::dispatch::Client::new(rx);
             let dispatch = proto::h1::Dispatcher::new(cd, conn);

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -50,6 +50,7 @@ where I: AsyncRead + AsyncWrite,
                 error: None,
                 keep_alive: KA::Busy,
                 method: None,
+                title_case_headers: false,
                 read_task: None,
                 reading: Reading::Init,
                 writing: Writing::Init,
@@ -71,6 +72,10 @@ where I: AsyncRead + AsyncWrite,
 
     pub fn set_write_strategy_flatten(&mut self) {
         self.io.set_write_strategy_flatten();
+    }
+
+    pub fn set_title_case_headers(&mut self) {
+        self.state.title_case_headers = true;
     }
 
     pub fn into_inner(self) -> (I, Bytes) {
@@ -430,7 +435,7 @@ where I: AsyncRead + AsyncWrite,
         self.enforce_version(&mut head);
 
         let buf = self.io.write_buf_mut();
-        self.state.writing = match T::encode(head, body, &mut self.state.method, buf) {
+        self.state.writing = match T::encode(head, body, &mut self.state.method, self.state.title_case_headers, buf) {
             Ok(encoder) => {
                 if !encoder.is_eof() {
                     Writing::Body(encoder)
@@ -620,6 +625,7 @@ struct State {
     error: Option<::Error>,
     keep_alive: KA,
     method: Option<Method>,
+    title_case_headers: bool,
     read_task: Option<Task>,
     reading: Reading,
     writing: Writing,
@@ -649,6 +655,7 @@ impl fmt::Debug for State {
             .field("keep_alive", &self.keep_alive)
             .field("error", &self.error)
             //.field("method", &self.method)
+            //.field("title_case_headers", &self.title_case_headers)
             .field("read_task", &self.read_task)
             .finish()
     }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -72,6 +72,7 @@ pub(crate) trait Http1Transaction {
         head: MessageHead<Self::Outgoing>,
         body: Option<BodyLength>,
         method: &mut Option<Method>,
+        title_case_headers: bool,
         dst: &mut Vec<u8>,
     ) -> ::Result<h1::Encoder>;
     fn on_error(err: &::Error) -> Option<MessageHead<Self::Outgoing>>;


### PR DESCRIPTION
This introduces support for the HTTP/1 Client to write header names as title case when encoding
the request.

Need to work on tests.

Closes #1492

