### PR TITLE
Fix example & cherry-pick server::conn::Parts.service to master

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -5,7 +5,7 @@ extern crate pretty_env_logger;
 use std::env;
 use std::io::{self, Write};
 
-use hyper::{Body, Client, Request};
+use hyper::Client;
 use hyper::rt::{self, Future, Stream};
 
 fn main() {

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -354,7 +354,7 @@ where
     ///
     /// Only works for HTTP/1 connections. HTTP/2 connections will panic.
     pub fn into_parts(self) -> Parts<T> {
-        let (io, read_buf) = match self.inner {
+        let (io, read_buf, _) = match self.inner {
             Either::A(h1) => h1.into_inner(),
             Either::B(_h2) => {
                 panic!("http2 cannot into_inner");

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -27,7 +27,7 @@ pub(crate) trait Dispatch {
 
 pub struct Server<S: Service> {
     in_flight: Option<S::Future>,
-    service: S,
+    pub(crate) service: S,
 }
 
 pub struct Client<B> {
@@ -58,8 +58,9 @@ where
         self.conn.disable_keep_alive()
     }
 
-    pub fn into_inner(self) -> (I, Bytes) {
-        self.conn.into_inner()
+    pub fn into_inner(self) -> (I, Bytes, D) {
+        let (io, buf) = self.conn.into_inner();
+        (io, buf, self.dispatch)
     }
 
     /// The "Future" poll function. Runs this dispatcher until the


### PR DESCRIPTION
The first commit fixes `cargo test` for me.

The second commit ~~backports~~ forwardports the fix to issue #1471 to master. Hopefully it was just forgotten and not omitted intentionally, because otherwise implementing server upgrades is more difficult.