### PR TITLE
refactor(client): replace futures-cpupool with tokio's thread pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ include = [
 [dependencies]
 bytes = "0.4.4"
 futures = "0.1.21"
-futures-cpupool = { version = "0.1.6", optional = true }
 http = "0.1.5"
 httparse = "1.0"
 h2 = "0.1.5"
@@ -37,6 +36,7 @@ tokio-io = "0.1"
 tokio-reactor = { version = "0.1", optional = true }
 tokio-tcp = { version = "0.1", optional = true }
 tokio-timer = { version = "0.2", optional = true }
+tokio-threadpool = { version = "0.1.3", optional = true }
 want = "0.0.4"
 
 [dev-dependencies]
@@ -53,13 +53,13 @@ default = [
     "runtime",
 ]
 runtime = [
-    "futures-cpupool",
     "net2",
     "tokio",
     "tokio-executor",
     "tokio-reactor",
     "tokio-tcp",
     "tokio-timer",
+    "tokio-threadpool",
 ]
 nightly = []
 __internal_flaky_tests = []

--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -22,7 +22,7 @@ fn get_one_at_a_time(b: &mut test::Bencher) {
     let mut rt = Runtime::new().unwrap();
     let addr = spawn_hello(&mut rt);
 
-    let connector = HttpConnector::new_with_handle(1, rt.reactor().clone());
+    let connector = HttpConnector::new_with_handle(rt.reactor().clone());
     let client = hyper::Client::builder()
         .executor(rt.executor())
         .build::<_, Body>(connector);
@@ -46,7 +46,7 @@ fn post_one_at_a_time(b: &mut test::Bencher) {
     let mut rt = Runtime::new().unwrap();
     let addr = spawn_hello(&mut rt);
 
-    let connector = HttpConnector::new_with_handle(1, rt.reactor().clone());
+    let connector = HttpConnector::new_with_handle(rt.reactor().clone());
     let client = hyper::Client::builder()
         .executor(rt.executor())
         .build::<_, Body>(connector);

--- a/src/client/dns.rs
+++ b/src/client/dns.rs
@@ -6,8 +6,6 @@ use std::net::{
 };
 use std::vec;
 
-use ::futures::{Async, Future, Poll};
-
 pub struct Work {
     host: String,
     port: u16
@@ -19,14 +17,11 @@ impl Work {
     }
 }
 
-impl Future for Work {
-    type Item = IpAddrs;
-    type Error = io::Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+impl Work {
+    pub fn resolve(&self) -> Result<IpAddrs, io::Error> {
         debug!("resolving host={:?}, port={:?}", self.host, self.port);
         (&*self.host, self.port).to_socket_addrs()
-            .map(|i| Async::Ready(IpAddrs { iter: i }))
+            .map(|i| IpAddrs { iter: i })
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -752,7 +752,7 @@ impl Builder {
         B: Payload + Send,
         B::Data: Send,
     {
-        let mut connector = HttpConnector::new(4);
+        let mut connector = HttpConnector::new();
         if self.keep_alive {
             connector.set_keepalive(self.keep_alive_timeout);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
 
 extern crate bytes;
 #[macro_use] extern crate futures;
-#[cfg(feature = "runtime")] extern crate futures_cpupool;
 extern crate h2;
 extern crate http;
 extern crate httparse;
@@ -32,6 +31,7 @@ extern crate time;
 #[cfg(feature = "runtime")] extern crate tokio_reactor;
 #[cfg(feature = "runtime")] extern crate tokio_tcp;
 #[cfg(feature = "runtime")] extern crate tokio_timer;
+#[cfg(feature = "runtime")] extern crate tokio_threadpool;
 extern crate want;
 
 #[cfg(all(test, feature = "nightly"))]

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -231,7 +231,7 @@ macro_rules! test {
         let addr = server.local_addr().expect("local_addr");
         let runtime = $runtime;
 
-        let connector = ::hyper::client::HttpConnector::new_with_handle(1, runtime.reactor().clone());
+        let connector = ::hyper::client::HttpConnector::new_with_handle(runtime.reactor().clone());
         let client = Client::builder()
             .set_host($set_host)
             .http1_title_case_headers($title_case_headers)
@@ -737,7 +737,7 @@ mod dispatch_impl {
         let (closes_tx, closes) = mpsc::channel(10);
         let client = Client::builder()
             .executor(runtime.executor())
-            .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(1, runtime.reactor().clone()), closes_tx));
+            .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(runtime.reactor().clone()), closes_tx));
 
         let (tx1, rx1) = oneshot::channel();
 
@@ -796,7 +796,7 @@ mod dispatch_impl {
         let res = {
             let client = Client::builder()
                 .executor(runtime.executor())
-                .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(1, handle.clone()), closes_tx));
+                .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(handle.clone()), closes_tx));
 
             let req = Request::builder()
                 .uri(&*format!("http://{}/a", addr))
@@ -849,7 +849,7 @@ mod dispatch_impl {
 
         let client = Client::builder()
             .executor(runtime.executor())
-            .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(1, handle.clone()), closes_tx));
+            .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(handle.clone()), closes_tx));
 
         let req = Request::builder()
             .uri(&*format!("http://{}/a", addr))
@@ -913,7 +913,7 @@ mod dispatch_impl {
         let res = {
             let client = Client::builder()
                 .executor(runtime.executor())
-                .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(1, handle.clone()), closes_tx));
+                .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(handle.clone()), closes_tx));
 
             let req = Request::builder()
                 .uri(&*format!("http://{}/a", addr))
@@ -964,7 +964,7 @@ mod dispatch_impl {
         let res = {
             let client = Client::builder()
                 .executor(runtime.executor())
-                .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(1, handle.clone()), closes_tx));
+                .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(handle.clone()), closes_tx));
 
             let req = Request::builder()
                 .uri(&*format!("http://{}/a", addr))
@@ -1015,7 +1015,7 @@ mod dispatch_impl {
         let client = Client::builder()
             .keep_alive(false)
             .executor(runtime.executor())
-            .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(1, handle.clone()), closes_tx));
+            .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(handle.clone()), closes_tx));
 
         let req = Request::builder()
             .uri(&*format!("http://{}/a", addr))
@@ -1063,7 +1063,7 @@ mod dispatch_impl {
 
         let client = Client::builder()
             .executor(runtime.executor())
-            .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(1, handle.clone()), closes_tx));
+            .build(DebugConnector::with_http_and_closes(HttpConnector::new_with_handle(handle.clone()), closes_tx));
 
         let req = Request::builder()
             .uri(&*format!("http://{}/a", addr))
@@ -1287,7 +1287,7 @@ mod dispatch_impl {
 
     impl DebugConnector {
         fn new(handle: &Handle) -> DebugConnector {
-            let http = HttpConnector::new_with_handle(1, handle.clone());
+            let http = HttpConnector::new_with_handle(handle.clone());
             let (tx, _) = mpsc::channel(10);
             DebugConnector::with_http_and_closes(http, tx)
         }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -205,7 +205,7 @@ pub fn __run_test(cfg: __TestConfig) {
         Version::HTTP_11
     };
 
-    let connector = HttpConnector::new_with_handle(1, handle.clone());
+    let connector = HttpConnector::new_with_handle(handle.clone());
     let client = Client::builder()
         .keep_alive_timeout(Duration::from_secs(10))
         .http2_only(cfg.client_version == 2)


### PR DESCRIPTION
The tokio thread pool is already transitively used by the tokio runtime,
so by using it for the DNS as well, the futures-cpupool dependency is
removed without adding a new one.

The code uses tokio-threadpool's `blocking` function which makes the
code very straightforward.

Tokio's thread pool is supposedly faster than futures-cpupool's one.
According to its README, "Why not futures-cpupool? It's 10x slower.".

The user of the library can configure the maximum number of threads for
executing blocking tasks as part of configuring tokio's runtime, which
also holds for any other blocking code besides hyper (e.g. blocking file
operations using tokio-fs ). Hyper no longer needs to concern itself
with that.

BREAKING CHANGE: The `threads` argument is removed from
  `hyper::client::HttpConnector::new()` and `new_with_handle()`. To set
  the maximum amount of threads to use for DNS resolving, configure the
  `max_blocking` parameter of the tokio runtime instead.

  The function `hyper::client::HttpConnector::new_with_executor()` is
  removed. The thread pool of the tokio runtime is now always used. Use
  `new()` or `new_with_handle()` instead.