### PR TITLE
feat(server): add http1_only configuration to conn::Connection

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -167,6 +167,14 @@ impl<I> Builder<I> {
         }
     }
 
+    /// Sets whether HTTP/1 is required.
+    ///
+    /// Default is `false`.
+    pub fn http1_only(mut self, val: bool) -> Self {
+        self.protocol.http1_only(val);
+        self
+    }
+
     /// Sets whether HTTP/2 is required.
     ///
     /// Default is `false`.


### PR DESCRIPTION
A new configuration `http1_only` to `Builder` and `Connection` are added, which indicates that the upgrading to h2 does not perform when a parsing error occurs.

Fixes #1512.