### PR TITLE
Add Sender::abort

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -265,7 +265,7 @@ impl StdError for Error {
             Kind::NewService => "calling user's new_service failed",
             Kind::Service => "error from user's server service",
             Kind::Body => "error reading a body from connection",
-            Kind::BodyWrite => "error write a body to connection",
+            Kind::BodyWrite => "error writing a body to connection",
             Kind::BodyUser => "error from user's Payload stream",
             Kind::Shutdown => "error shutting down connection",
             Kind::Http2 => "http2 general error",


### PR DESCRIPTION
This allows a client to indicate that the request body should be cut off
in an abnormal fashion so the server doesn't simply get a "valid" but
truncated body.

