### PR TITLE
Add higher-level HTTP upgrade support to Client and Server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ iovec = "0.1"
 log = "0.4"
 net2 = { version = "0.2.32", optional = true }
 time = "0.1"
-tokio = { version = "0.1.5", optional = true }
+tokio = { version = "0.1.7", optional = true }
 tokio-executor = { version = "0.1.0", optional = true }
 tokio-io = "0.1"
 tokio-reactor = { version = "0.1", optional = true }
@@ -100,6 +100,12 @@ required-features = ["runtime"]
 name = "send_file"
 path = "examples/send_file.rs"
 required-features = ["runtime"]
+
+[[example]]
+name = "upgrades"
+path = "examples/upgrades.rs"
+required-features = ["runtime"]
+
 
 [[example]]
 name = "web_api"

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,4 +16,6 @@ Run examples with `cargo run --example example_name`.
 
 * [`send_file`](send_file.rs) - A server that sends back content of files using tokio_fs to read the files asynchronously.
 
+* [`upgrades`](upgrades.rs) - A server and client demonstrating how to do HTTP upgrades (such as WebSockets or `CONNECT` tunneling).
+
 * [`web_api`](web_api.rs) - A server consisting in a service that returns incoming POST request's content in the response in uppercase and a service that call that call the first service and includes the first service response in its own response.

--- a/examples/upgrades.rs
+++ b/examples/upgrades.rs
@@ -1,0 +1,127 @@
+// Note: `hyper::upgrade` docs link to this upgrade.
+extern crate futures;
+extern crate hyper;
+extern crate tokio;
+
+use std::str;
+
+use futures::sync::oneshot;
+
+use hyper::{Body, Client, Request, Response, Server, StatusCode};
+use hyper::header::{UPGRADE, HeaderValue};
+use hyper::rt::{self, Future};
+use hyper::service::service_fn_ok;
+
+/// Our server HTTP handler to initiate HTTP upgrades.
+fn server_upgrade(req: Request<Body>) -> Response<Body> {
+    let mut res = Response::new(Body::empty());
+
+    // Send a 400 to any request that doesn't have
+    // an `Upgrade` header.
+    if !req.headers().contains_key(UPGRADE) {
+        *res.status_mut() = StatusCode::BAD_REQUEST;
+        return res;
+    }
+
+    // Setup a future that will eventually receive the upgraded
+    // connection and talk a new protocol, and spawn the future
+    // into the runtime.
+    //
+    // Note: This can't possibly be fulfilled until the 101 response
+    // is returned below, so it's better to spawn this future instead
+    // waiting for it to complete to then return a response.
+    let on_upgrade = req
+        .into_body()
+        .on_upgrade()
+        .map_err(|err| eprintln!("upgrade error: {}", err))
+        .and_then(|upgraded| {
+            // We have an upgraded connection that we can read and
+            // write on directly.
+            //
+            // Since we completely control this example, we know exactly
+            // how many bytes the client will write, so just read exact...
+            tokio::io::read_exact(upgraded, vec![0; 7])
+                .and_then(|(upgraded, vec)| {
+                    println!("server[foobar] recv: {:?}", str::from_utf8(&vec));
+
+                    // And now write back the server 'foobar' protocol's
+                    // response...
+                    tokio::io::write_all(upgraded, b"bar=foo")
+                })
+                .map(|_| println!("server[foobar] sent"))
+                .map_err(|e| eprintln!("server foobar io error: {}", e))
+        });
+
+    rt::spawn(on_upgrade);
+
+
+    // Now return a 101 Response saying we agree to the upgrade to some
+    // made-up 'foobar' protocol.
+    *res.status_mut() = StatusCode::SWITCHING_PROTOCOLS;
+    res.headers_mut().insert(UPGRADE, HeaderValue::from_static("foobar"));
+    res
+}
+
+fn main() {
+    // For this example, we just make a server and our own client to talk to
+    // it, so the exact port isn't important. Instead, let the OS give us an
+    // unused port.
+    let addr = ([127, 0, 0, 1], 0).into();
+
+    let server = Server::bind(&addr)
+        .serve(|| service_fn_ok(server_upgrade));
+
+    // We need the assigned address for the client to send it messages.
+    let addr = server.local_addr();
+
+
+    // For this example, a oneshot is used to signal that after 1 request,
+    // the server should be shutdown.
+    let (tx, rx) = oneshot::channel();
+
+    let server = server
+        .map_err(|e| eprintln!("server error: {}", e))
+        .select2(rx)
+        .then(|_| Ok(()));
+
+    rt::run(rt::lazy(move || {
+        rt::spawn(server);
+
+        let req = Request::builder()
+            .uri(format!("http://{}/", addr))
+            .header(UPGRADE, "foobar")
+            .body(Body::empty())
+            .unwrap();
+
+        Client::new()
+            .request(req)
+            .and_then(|res| {
+                if res.status() != StatusCode::SWITCHING_PROTOCOLS {
+                    panic!("Our server didn't upgrade: {}", res.status());
+                }
+
+                res
+                    .into_body()
+                    .on_upgrade()
+            })
+            .map_err(|e| eprintln!("client error: {}", e))
+            .and_then(|upgraded| {
+                // We've gotten an upgraded connection that we can read
+                // and write directly on. Let's start out 'foobar' protocol.
+                tokio::io::write_all(upgraded, b"foo=bar")
+                    .and_then(|(upgraded, _)| {
+                        println!("client[foobar] sent");
+                        tokio::io::read_to_end(upgraded, Vec::new())
+                    })
+                    .map(|(_upgraded, vec)| {
+                        println!("client[foobar] recv: {:?}", str::from_utf8(&vec));
+
+
+                        // Complete the oneshot so that the server stops
+                        // listening and the process can close down.
+                        let _ = tx.send(());
+                    })
+                    .map_err(|e| eprintln!("client foobar io error: {}", e))
+            })
+    }));
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -268,7 +268,7 @@ where C: Connect + Sync + 'static,
                                 .h1_writev(h1_writev)
                                 .h1_title_case_headers(h1_title_case_headers)
                                 .http2_only(pool_key.1 == Ver::Http2)
-                                .handshake_no_upgrades(io)
+                                .handshake(io)
                                 .and_then(move |(tx, conn)| {
                                     executor.execute(conn.map_err(|e| {
                                         debug!("client connection error: {}", e)

--- a/src/common/io/mod.rs
+++ b/src/common/io/mod.rs
@@ -1,0 +1,3 @@
+mod rewind;
+
+pub(crate) use self::rewind::Rewind;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,5 +1,6 @@
 mod buf;
 mod exec;
+pub(crate) mod io;
 mod never;
 
 pub(crate) use self::buf::StaticBuf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,3 +62,4 @@ mod proto;
 pub mod server;
 pub mod service;
 #[cfg(feature = "runtime")] pub mod rt;
+pub mod upgrade;

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -5,7 +5,7 @@ use tokio_io::{AsyncRead, AsyncWrite};
 
 use body::{Body, Payload};
 use body::internal::FullDataArg;
-use proto::{BodyLength, Conn, MessageHead, RequestHead, RequestLine, ResponseHead};
+use proto::{BodyLength, DecodedLength, Conn, Dispatched, MessageHead, RequestHead, RequestLine, ResponseHead};
 use super::Http1Transaction;
 use service::Service;
 
@@ -65,32 +65,34 @@ where
         (io, buf, self.dispatch)
     }
 
-    /// The "Future" poll function. Runs this dispatcher until the
-    /// connection is shutdown, or an error occurs.
-    pub fn poll_until_shutdown(&mut self) -> Poll<(), ::Error> {
-        self.poll_catch(true)
-    }
-
     /// Run this dispatcher until HTTP says this connection is done,
     /// but don't call `AsyncWrite::shutdown` on the underlying IO.
     ///
-    /// This is useful for HTTP upgrades.
+    /// This is useful for old-style HTTP upgrades, but ignores
+    /// newer-style upgrade API.
     pub fn poll_without_shutdown(&mut self) -> Poll<(), ::Error> {
         self.poll_catch(false)
+            .map(|x| {
+                x.map(|ds| if let Dispatched::Upgrade(pending) = ds {
+                    pending.manual();
+                })
+            })
     }
 
-    fn poll_catch(&mut self, should_shutdown: bool) -> Poll<(), ::Error> {
+    fn poll_catch(&mut self, should_shutdown: bool) -> Poll<Dispatched, ::Error> {
         self.poll_inner(should_shutdown).or_else(|e| {
             // An error means we're shutting down either way.
             // We just try to give the error to the user,
             // and close the connection with an Ok. If we
             // cannot give it to the user, then return the Err.
-            self.dispatch.recv_msg(Err(e)).map(Async::Ready)
+            self.dispatch.recv_msg(Err(e))?;
+            Ok(Async::Ready(Dispatched::Shutdown))
         })
     }
 
-    fn poll_inner(&mut self, should_shutdown: bool) -> Poll<(), ::Error> {
+    fn poll_inner(&mut self, should_shutdown: bool) -> Poll<Dispatched, ::Error> {
         T::update_date();
+
         loop {
             self.poll_read()?;
             self.poll_write()?;
@@ -110,11 +112,14 @@ where
         }
 
         if self.is_done() {
-            if should_shutdown {
+            if let Some(pending) = self.conn.pending_upgrade() {
+                self.conn.take_error()?;
+                return Ok(Async::Ready(Dispatched::Upgrade(pending)));
+            } else if should_shutdown {
                 try_ready!(self.conn.shutdown().map_err(::Error::new_shutdown));
             }
             self.conn.take_error()?;
-            Ok(Async::Ready(()))
+            Ok(Async::Ready(Dispatched::Shutdown))
         } else {
             Ok(Async::NotReady)
         }
@@ -190,20 +195,18 @@ where
         }
         // dispatch is ready for a message, try to read one
         match self.conn.read_head() {
-            Ok(Async::Ready(Some((head, body_len)))) => {
-                let body = if let Some(body_len) = body_len {
-                    let (mut tx, rx) =
-                        Body::new_channel(if let BodyLength::Known(len) = body_len {
-                            Some(len)
-                        } else {
-                            None
-                        });
-                    let _ = tx.poll_ready(); // register this task if rx is dropped
-                    self.body_tx = Some(tx);
-                    rx
-                } else {
-                    Body::empty()
+            Ok(Async::Ready(Some((head, body_len, wants_upgrade)))) => {
+                let mut body = match body_len {
+                    DecodedLength::ZERO => Body::empty(),
+                    other => {
+                        let (tx, rx) = Body::new_channel(other.into_opt());
+                        self.body_tx = Some(tx);
+                        rx
+                    },
                 };
+                if wants_upgrade {
+                    body.set_on_upgrade(self.conn.on_upgrade());
+                }
                 self.dispatch.recv_msg(Ok((head, body)))?;
                 Ok(Async::Ready(()))
             }
@@ -326,7 +329,6 @@ where
     }
 }
 
-
 impl<D, Bs, I, T> Future for Dispatcher<D, Bs, I, T>
 where
     D: Dispatch<PollItem=MessageHead<T::Outgoing>, PollBody=Bs, RecvItem=MessageHead<T::Incoming>>,
@@ -334,12 +336,12 @@ where
     T: Http1Transaction,
     Bs: Payload,
 {
-    type Item = ();
+    type Item = Dispatched;
     type Error = ::Error;
 
     #[inline]
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.poll_until_shutdown()
+        self.poll_catch(true)
     }
 }
 
@@ -519,7 +521,7 @@ mod tests {
 
     use super::*;
     use mock::AsyncIo;
-    use proto::ClientTransaction;
+    use proto::h1::ClientTransaction;
 
     #[test]
     fn client_read_bytes_before_writing_request() {

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -93,6 +93,12 @@ where
         self.read_buf.as_ref()
     }
 
+    #[cfg(test)]
+    #[cfg(feature = "nightly")]
+    pub(super) fn read_buf_mut(&mut self) -> &mut BytesMut {
+        &mut self.read_buf
+    }
+
     pub fn headers_buf(&mut self) -> &mut Vec<u8> {
         let buf = self.write_buf.headers_mut();
         &mut buf.bytes
@@ -595,7 +601,7 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut None,
         };
-        assert!(buffered.parse::<::proto::ClientTransaction>(ctx).unwrap().is_not_ready());
+        assert!(buffered.parse::<::proto::h1::ClientTransaction>(ctx).unwrap().is_not_ready());
         assert!(buffered.io.blocked());
     }
 

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,11 +1,11 @@
 //! Pieces pertaining to the HTTP message protocol.
 use http::{HeaderMap, Method, StatusCode, Uri, Version};
 
-pub(crate) use self::h1::{dispatch, Conn, ClientTransaction, ClientUpgradeTransaction, ServerTransaction};
+pub(crate) use self::h1::{dispatch, Conn, ServerTransaction};
+use self::body_length::DecodedLength;
 
 pub(crate) mod h1;
 pub(crate) mod h2;
-
 
 /// An Incoming Message head. Includes request/status line, and headers.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -27,34 +27,6 @@ pub struct RequestLine(pub Method, pub Uri);
 /// An incoming response message.
 pub type ResponseHead = MessageHead<StatusCode>;
 
-/*
-impl<S> MessageHead<S> {
-    pub fn should_keep_alive(&self) -> bool {
-        should_keep_alive(self.version, &self.headers)
-    }
-
-    pub fn expecting_continue(&self) -> bool {
-        expecting_continue(self.version, &self.headers)
-    }
-}
-
-/// Checks if a connection should be kept alive.
-#[inline]
-pub fn should_keep_alive(version: Version, headers: &HeaderMap) -> bool {
-    if version == Version::HTTP_10 {
-        headers::connection_keep_alive(headers)
-    } else {
-        !headers::connection_close(headers)
-    }
-}
-
-/// Checks if a connection is expecting a `100 Continue` before sending its body.
-#[inline]
-pub fn expecting_continue(version: Version, headers: &HeaderMap) -> bool {
-    version == Version::HTTP_11 && headers::expect_continue(headers)
-}
-*/
-
 #[derive(Debug)]
 pub enum BodyLength {
     /// Content-Length
@@ -63,32 +35,72 @@ pub enum BodyLength {
     Unknown,
 }
 
-/*
-#[test]
-fn test_should_keep_alive() {
-    let mut headers = HeaderMap::new();
-
-    assert!(!should_keep_alive(Version::HTTP_10, &headers));
-    assert!(should_keep_alive(Version::HTTP_11, &headers));
-
-    headers.insert("connection", ::http::header::HeaderValue::from_static("close"));
-    assert!(!should_keep_alive(Version::HTTP_10, &headers));
-    assert!(!should_keep_alive(Version::HTTP_11, &headers));
-
-    headers.insert("connection", ::http::header::HeaderValue::from_static("keep-alive"));
-    assert!(should_keep_alive(Version::HTTP_10, &headers));
-    assert!(should_keep_alive(Version::HTTP_11, &headers));
+/// Status of when an Disaptcher future completes.
+pub(crate) enum Dispatched {
+    /// Dispatcher completely shutdown connection.
+    Shutdown,
+    /// Dispatcher has pending upgrade, and so did not shutdown.
+    Upgrade(::upgrade::Pending),
 }
 
-#[test]
-fn test_expecting_continue() {
-    let mut headers = HeaderMap::new();
+/// A separate module to encapsulate the invariants of the DecodedLength type.
+mod body_length {
+    use std::fmt;
 
-    assert!(!expecting_continue(Version::HTTP_10, &headers));
-    assert!(!expecting_continue(Version::HTTP_11, &headers));
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(crate) struct DecodedLength(u64);
 
-    headers.insert("expect", ::http::header::HeaderValue::from_static("100-continue"));
-    assert!(!expecting_continue(Version::HTTP_10, &headers));
-    assert!(expecting_continue(Version::HTTP_11, &headers));
+    const MAX_LEN: u64 = ::std::u64::MAX - 2;
+
+    impl DecodedLength {
+        pub(crate) const CLOSE_DELIMITED: DecodedLength = DecodedLength(::std::u64::MAX);
+        pub(crate) const CHUNKED: DecodedLength = DecodedLength(::std::u64::MAX - 1);
+        pub(crate) const ZERO: DecodedLength = DecodedLength(0);
+
+        #[cfg(test)]
+        pub(crate) fn new(len: u64) -> Self {
+            debug_assert!(len <= MAX_LEN);
+            DecodedLength(len)
+        }
+
+        /// Takes the length as a content-length without other checks.
+        ///
+        /// Should only be called if previously confirmed this isn't
+        /// CLOSE_DELIMITED or CHUNKED.
+        #[inline]
+        pub(crate) fn danger_len(self) -> u64 {
+            debug_assert!(self.0 < Self::CHUNKED.0);
+            self.0
+        }
+
+        /// Converts to an Option<u64> representing a Known or Unknown length.
+        pub(crate) fn into_opt(self) -> Option<u64> {
+            match self {
+                DecodedLength::CHUNKED |
+                DecodedLength::CLOSE_DELIMITED => None,
+                DecodedLength(known) => Some(known)
+            }
+        }
+
+        /// Checks the `u64` is within the maximum allowed for content-length.
+        pub(crate) fn checked_new(len: u64) -> Result<Self, ::error::Parse> {
+            if len <= MAX_LEN {
+                Ok(DecodedLength(len))
+            } else {
+                warn!("content-length bigger than maximum: {} > {}", len, MAX_LEN);
+                Err(::error::Parse::TooLarge)
+            }
+        }
+    }
+
+    impl fmt::Display for DecodedLength {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match *self {
+                DecodedLength::CLOSE_DELIMITED => f.write_str("close-delimited"),
+                DecodedLength::CHUNKED => f.write_str("chunked encoding"),
+                DecodedLength::ZERO => f.write_str("empty"),
+                DecodedLength(n) => write!(f, "content-length ({} bytes)", n),
+            }
+        }
+    }
 }
-*/

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -50,7 +50,6 @@
 
 pub mod conn;
 #[cfg(feature = "runtime")] mod tcp;
-mod rewind;
 
 use std::fmt;
 #[cfg(feature = "runtime")] use std::net::SocketAddr;

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,0 +1,254 @@
+//! HTTP Upgrades
+//!
+//! See [this example][example] showing how upgrades work with both
+//! Clients and Servers.
+//!
+//! [example]: https://github.com/hyperium/hyper/master/examples/upgrades.rs
+
+use std::any::TypeId;
+use std::error::Error as StdError;
+use std::fmt;
+use std::io::{self, Read, Write};
+
+use bytes::{Buf, BufMut, Bytes};
+use futures::{Async, Future, Poll};
+use futures::sync::oneshot;
+use tokio_io::{AsyncRead, AsyncWrite};
+
+use common::io::Rewind;
+
+/// An upgraded HTTP connection.
+///
+/// This type holds a trait object internally of the original IO that
+/// was used to speak HTTP before the upgrade. It can be used directly
+/// as a `Read` or `Write` for convenience.
+///
+/// Alternatively, if the exact type is known, this can be deconstructed
+/// into its parts.
+pub struct Upgraded {
+    io: Rewind<Box<Io + Send>>,
+}
+
+/// A future for a possible HTTP upgrade.
+///
+/// If no upgrade was available, or it doesn't succeed, yields an `Error`.
+pub struct OnUpgrade {
+    rx: Option<oneshot::Receiver<::Result<Upgraded>>>,
+}
+
+/// The deconstructed parts of an [`Upgraded`](Upgraded) type.
+///
+/// Includes the original IO type, and a read buffer of bytes that the
+/// HTTP state machine may have already read before completing an upgrade.
+#[derive(Debug)]
+pub struct Parts<T> {
+    /// The original IO object used before the upgrade.
+    pub io: T,
+    /// A buffer of bytes that have been read but not processed as HTTP.
+    ///
+    /// For instance, if the `Connection` is used for an HTTP upgrade request,
+    /// it is possible the server sent back the first bytes of the new protocol
+    /// along with the response upgrade.
+    ///
+    /// You will want to check for any existing bytes if you plan to continue
+    /// communicating on the IO object.
+    pub read_buf: Bytes,
+    _inner: (),
+}
+
+pub(crate) struct Pending {
+    tx: oneshot::Sender<::Result<Upgraded>>
+}
+
+/// Error cause returned when an upgrade was expected but canceled
+/// for whatever reason.
+///
+/// This likely means the actual `Conn` future wasn't polled and upgraded.
+#[derive(Debug)]
+struct UpgradeExpected(());
+
+pub(crate) fn pending() -> (Pending, OnUpgrade) {
+    let (tx, rx) = oneshot::channel();
+    (
+        Pending {
+            tx,
+        },
+        OnUpgrade {
+            rx: Some(rx),
+        },
+    )
+}
+
+pub(crate) trait Io: AsyncRead + AsyncWrite + 'static {
+    fn __hyper_type_id(&self) -> TypeId {
+        TypeId::of::<Self>()
+    }
+}
+
+impl Io + Send {
+    fn __hyper_is<T: Io>(&self) -> bool {
+        let t = TypeId::of::<T>();
+        self.__hyper_type_id() == t
+    }
+
+    fn __hyper_downcast<T: Io>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+        if self.__hyper_is::<T>() {
+            // Taken from `std::error::Error::downcast()`.
+            unsafe {
+                let raw: *mut Io = Box::into_raw(self);
+                Ok(Box::from_raw(raw as *mut T))
+            }
+        } else {
+            Err(self)
+        }
+    }
+}
+
+impl<T: AsyncRead + AsyncWrite + 'static> Io for T {}
+
+// ===== impl Upgraded =====
+
+impl Upgraded {
+    pub(crate) fn new(io: Box<Io + Send>, read_buf: Bytes) -> Self {
+        Upgraded {
+            io: Rewind::new_buffered(io, read_buf),
+        }
+    }
+
+    /// Tries to downcast the internal trait object to the type passed.
+    ///
+    /// On success, returns the downcasted parts. On error, returns the
+    /// `Upgraded` back.
+    pub fn downcast<T: AsyncRead + AsyncWrite + 'static>(self) -> Result<Parts<T>, Self> {
+        let (io, buf) = self.io.into_inner();
+        match io.__hyper_downcast() {
+            Ok(t) => Ok(Parts {
+                io: *t,
+                read_buf: buf,
+                _inner: (),
+            }),
+            Err(io) => Err(Upgraded {
+                io: Rewind::new_buffered(io, buf),
+            })
+        }
+    }
+}
+
+impl Read for Upgraded {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.io.read(buf)
+    }
+}
+
+impl Write for Upgraded {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.io.write(buf)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.io.flush()
+    }
+}
+
+impl AsyncRead for Upgraded {
+    #[inline]
+    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
+        self.io.prepare_uninitialized_buffer(buf)
+    }
+
+    #[inline]
+    fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        self.io.read_buf(buf)
+    }
+}
+
+impl AsyncWrite for Upgraded {
+    #[inline]
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        AsyncWrite::shutdown(&mut self.io)
+    }
+
+    #[inline]
+    fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        self.io.write_buf(buf)
+    }
+}
+
+impl fmt::Debug for Upgraded {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Upgraded")
+            .finish()
+    }
+}
+
+// ===== impl OnUpgrade =====
+
+impl OnUpgrade {
+    pub(crate) fn none() -> Self {
+        OnUpgrade {
+            rx: None,
+        }
+    }
+
+    pub(crate) fn is_none(&self) -> bool {
+        self.rx.is_none()
+    }
+}
+
+impl Future for OnUpgrade {
+    type Item = Upgraded;
+    type Error = ::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.rx {
+            Some(ref mut rx) => match rx.poll() {
+                Ok(Async::NotReady) => Ok(Async::NotReady),
+                Ok(Async::Ready(Ok(upgraded))) => Ok(Async::Ready(upgraded)),
+                Ok(Async::Ready(Err(err))) => Err(err),
+                Err(_oneshot_canceled) => Err(
+                    ::Error::new_canceled(Some(UpgradeExpected(())))
+                ),
+            },
+            None => Err(::Error::new_user_no_upgrade()),
+        }
+    }
+}
+
+impl fmt::Debug for OnUpgrade {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("OnUpgrade")
+            .finish()
+    }
+}
+
+// ===== impl Pending =====
+
+impl Pending {
+    pub(crate) fn fulfill(self, upgraded: Upgraded) {
+        let _ = self.tx.send(Ok(upgraded));
+    }
+
+    /// Don't fulfill the pending Upgrade, but instead signal that
+    /// upgrades are handled manually.
+    pub(crate) fn manual(self) {
+        let _ = self.tx.send(Err(::Error::new_user_manual_upgrade()));
+    }
+}
+
+// ===== impl UpgradeExpected =====
+
+impl fmt::Display for UpgradeExpected {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(self.description())
+    }
+}
+
+impl StdError for UpgradeExpected {
+    fn description(&self) -> &str {
+        "upgrade expected but not completed"
+    }
+}
+


### PR DESCRIPTION
This proposes a way to offer an easier way to manage HTTP upgrades than using the lower-level `client::conn` and `server::conn` APIs. This includes both `Upgrade` + `101 Switching Protocols`, and `CONNECT` tunneling.

# `Body::on_upgrade`

It makes use of the `Body` type that is returned by hyper. When the HTTP1 state machine notices an attempt to trigger an upgrade in either the client or the server, the returned `Body` will have some additional state to allow getting a `Future` of an eventual upgrade: `Body::on_upgrade(self) -> impl Future`.

This `on_upgrade` future, if successful, will return a new `hyper::upgrade::Upgraded` type that fully owns the original IO transport, after the upgrade. The `Upgraded` can itself be used as an `AsyncRead`/`AsyncWrite` for convenience (and automatically including any buffered bytes as part of the `read`s). However, if desired, you can also try to deconstruct/downcast from an `Upgraded` into `hyper::upgrade::Parts<T>`.

## `hyper::upgrade::Upgraded`

An added benefit to this API is that it allows adding support for `CONNECT` over HTTP2 without breaking backwards compatibility. The tricky part there normally is that `CONNECT` in HTTP2 doesn't actually take control of the IO transport, but instead continues to send `DATA` frames over the h2 stream. So, once the `h2` library adds support, hyper can encapsulate that support in a private `impl AsyncRead + AsyncWrite` implementation, and still just return an `Upgraded`.

A **papercut** in the proposal is that `Upgraded` needs to put the IO in a trait object that can be put `Body`, which is `Send`. There was a missing `I: Send` bounds on `server::conn::Connection`, which makes it impossible to use this new API when using the lower-level `Http::server_connection`. The proposed solution is to add `Connection::with_upgrades()` that converts into a type that does have a `Send` bound, and allows using this API.

Any usage of `serve_connection` that forgets to add `with_upgrades` will not have upgrades work. The `on_upgrade` future will yield an `Error`. This error however, does include specific messaging when an upgrade was expected to work, but couldn't because of use of lower-level APIs. Additionally, this means that manual upgrades with the lower-level APIs still work correctly.

# TODO

- [x] Implement the feature
- [x] Write tests
- [x] Include an example in the examples directory of both client and server usage.
- [x] Document the `hyper::upgrade` module.
- [x] Document the `server::conn::Connection::with_upgrades` method.
- [x] Investigate performance implications of adding upgrade machinery.
- [x] Consider if messaging needs improving for anyone doing manual upgrades.

Closes #1395 