### PR TITLE
Simplify client doctest with default Runtime::block_on

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -55,7 +55,7 @@
 //!     // Run the job, blocking until it is complete
 //!     let body = rt.block_on(job).unwrap();
 //!     // Write body to stdout
-//!     stdout().write(&body).unwrap();
+//!     stdout().write_all(&body).unwrap();
 //! }
 //! #
 //! # #[cfg(not(feature = "runtime"))]


### PR DESCRIPTION
The client module level doctest benefits from succinctness more than examples/client.rs and the guide. Here I change it to use `Runtime::block_on()` with the following advantages:

* Demonstrates blocking wait for a completed `Result<Chunk,Error>` which should remain a common pattern outside of fully-asynchronous servers.

* Gives a path to reuse the `Client`, which can now outlive job(s) without hanging

* Avoids `rt::lazy`, `from_utf8` and some other unnecessary noise

Below is the rustdoc, example section output without all of the source comment framing:

``` rust
extern crate hyper;
extern crate tokio;

use std::io::{stdout, Write};
use hyper::Client;
use hyper::rt::{Future, Stream};
use tokio::runtime::Runtime;

fn main() {
    let mut rt = Runtime::new().unwrap();
    let client = Client::new();
    let job = client
        // Make a GET /ip to 'http://httpbin.org'
        .get("http://httpbin.org/ip".parse().unwrap())

        // And then, if the request gets a response...
        .and_then(|res| {
            println!("status: {}", res.status());

            // Concatenate the body stream into a single buffer,
            // returning a new future.
            res.into_body().concat2()
        });

    // Run the job, blocking until it is complete
    let body = rt.block_on(job).unwrap();
    // Write body to stdout
    stdout().write_all(&body).unwrap();
}
```

Note `tokio::runtime::Runtime` isn't currently re-exported in hyper::rt. I could add it there instead, if desired, though I wonder about the sustainability of this re-export approach? The `tokio::runtime::Runtime::block_on` method was released in tokio 0.1.7, so before merging or releasing this, (I or someone) should increase the patch release of tokio in Cargo.toml. Alternatively, tokio::runtime::current_thread is available in tokio 0.1.6, but my impression is that this runtime is less general purpose than the default runtime.

I have some related extensions/changes that I'd like to propose with examples/client and therefore the guide as well, but this doctest is simpler and therefore a good starting point to hopefully get some feedback.
