### PR TITLE
Make client lifetime and shutdown more explicit in client example

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -15,8 +15,7 @@ fn main() {
     let url = match env::args().nth(1) {
         Some(url) => url,
         None => {
-            println!("Usage: client <url>");
-            return;
+            "http://www.columbia.edu/~fdc/sample.html".to_owned()
         }
     };
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -11,16 +11,13 @@ use hyper::Client;
 use hyper::rt::{Future, Stream};
 use tokio::runtime::Runtime;
 
-
 fn main() {
     pretty_env_logger::init();
 
     // Pass URL as first argument, or use a default
     let url = match env::args().nth(1) {
         Some(url) => url,
-        None => {
-            "http://www.columbia.edu/~fdc/sample.html".to_owned()
-        }
+        None => "http://www.columbia.edu/~fdc/sample.html".to_owned()
     };
 
     // HTTPS requires picking a TLS implementation, so give a better warning
@@ -34,9 +31,8 @@ fn main() {
     let mut runtime = Runtime::new().unwrap();
     let client = Client::new();
 
-    let job = client
-        .get(url)         // HTTP GET request on URL
-        .and_then(|res| { // On successful (non-error) response
+    let job = client.get(url) // HTTP GET request on URL
+        .and_then(|res| {     // On successful (non-error) response
             println!("Response: {}", res.status());
             println!("Headers: {:#?}", res.headers());
 
@@ -51,10 +47,10 @@ fn main() {
                     })
             })
         })
-        .map(|_| {       // When done (success)
+        .map(|_| {           // When done (success)
             println!("\n\nDone.");
         })
-        .map_err(|err| { // When done (error)
+        .map_err(|err| {     // When done (error)
             eprintln!("Error {}", err);
         });
     runtime.spawn(job); // non-blocking

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,17 +1,21 @@
 #![deny(warnings)]
 extern crate hyper;
+extern crate tokio;
+
 extern crate pretty_env_logger;
 
 use std::env;
 use std::io::{self, Write};
 
 use hyper::Client;
-use hyper::rt::{self, Future, Stream};
+use hyper::rt::{Future, Stream};
+use tokio::runtime::Runtime;
+
 
 fn main() {
     pretty_env_logger::init();
 
-    // Some simple CLI args requirements...
+    // Pass URL as first argument, or use a default
     let url = match env::args().nth(1) {
         Some(url) => url,
         None => {
@@ -19,40 +23,44 @@ fn main() {
         }
     };
 
-    // HTTPS requires picking a TLS implementation, so give a better
-    // warning if the user tries to request an 'https' URL.
+    // HTTPS requires picking a TLS implementation, so give a better warning
+    // if the user tries to request an 'https' URL.
     let url = url.parse::<hyper::Uri>().unwrap();
     if url.scheme_part().map(|s| s.as_ref()) != Some("http") {
         println!("This example only works with 'http' URLs.");
         return;
     }
 
-    rt::run(rt::lazy(move || {
-        let client = Client::new();
+    let mut runtime = Runtime::new().unwrap();
+    let client = Client::new();
 
-        client
-            // Fetch the url...
-            .get(url)
-            // And then, if we get a response back...
-            .and_then(|res| {
-                println!("Response: {}", res.status());
-                println!("Headers: {:#?}", res.headers());
+    let job = client
+        .get(url)         // HTTP GET request on URL
+        .and_then(|res| { // On successful (non-error) response
+            println!("Response: {}", res.status());
+            println!("Headers: {:#?}", res.headers());
 
-                // The body is a stream, and for_each returns a new Future
-                // when the stream is finished, and calls the closure on
-                // each chunk of the body...
-                res.into_body().for_each(|chunk| {
-                    io::stdout().write_all(&chunk)
-                        .map_err(|e| panic!("example expects stdout is open, error={}", e))
-                })
+            // The body is a stream, and for_each returns a new Future when
+            // the stream is finished, and calls the closure on each chunk of
+            // the body...
+            res.into_body().for_each(|chunk| {
+                io::stdout()
+                    .write_all(&chunk)
+                    .map_err(|e| {
+                        panic!("example expects stdout is open, error={}", e)
+                    })
             })
-            // If all good, just tell the user...
-            .map(|_| {
-                println!("\n\nDone.");
-            })
-            // If there was an error, let the user know...
-            .map_err(|err| {
-                eprintln!("Error {}", err);
-            })
-    }));
+        })
+        .map(|_| {       // When done (success)
+            println!("\n\nDone.");
+        })
+        .map_err(|err| { // When done (error)
+            eprintln!("Error {}", err);
+        });
+    runtime.spawn(job); // non-blocking
+
+    // Wait and shutdown sequence: drop `client` first, in order for "idle"
+    // to occur as soon as `job` completes.
+    drop(client);
+    runtime.shutdown_on_idle().wait().unwrap();
 }


### PR DESCRIPTION
This is complimentary/in-addition to #1565. Originally I figured we might be able to resolve that one first, but then I found I needed to also reference this proposal.

Summary of examples/client.rs changes:

* Uses `spawn`, which is *more async*™ than `run`, and thus more educational for a real application.
* Avoids the magic of `lazy(Fn)` and moving the `Client` instance into a single request future. Thus this example is more amendable to multiple-requests on a shared Client for keep-alive, etc.
* Makes the shutdown sequence explicit and clarifies potential pitfalls. 
* Adds a working default URL as a convenience, not unlike the doctest.  HTTP-only websites are getting harder to find!

Note (as in #1565) `tokio::runtime::Runtime` isn't currently re-exported in `hyper::rt`. I could add it there instead, if desired (though I wonder about the sustainability of this re-export approach.)

The client sections of the *guide* also uses this example, so with some positive indication, I could pursue a compatible guide change PR.