### PR TITLE
feat(client): enable CONNECT requests through the `Client`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 bytes = "0.4.4"
 futures = "0.1.21"
 futures-cpupool = { version = "0.1.6", optional = true }
-http = "0.1.5"
+http = "0.1.7"
 httparse = "1.0"
 h2 = "0.1.5"
 iovec = "0.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,8 @@ pub(crate) enum Kind {
     UnsupportedVersion,
     /// User tried to create a CONNECT Request with the Client.
     UnsupportedRequestMethod,
+    /// User tried to send a Request with Client with non-absolute URI.
+    AbsoluteUriRequired,
 
     /// User tried polling for an upgrade that doesn't exist.
     NoUpgrade,
@@ -117,6 +119,7 @@ impl Error {
             Kind::Closed |
             Kind::UnsupportedVersion |
             Kind::UnsupportedRequestMethod |
+            Kind::AbsoluteUriRequired |
             Kind::NoUpgrade |
             Kind::Execute => true,
             _ => false,
@@ -224,6 +227,10 @@ impl Error {
         Error::new(Kind::UnsupportedRequestMethod, None)
     }
 
+    pub(crate) fn new_user_absolute_uri_required() -> Error {
+        Error::new(Kind::AbsoluteUriRequired, None)
+    }
+
     pub(crate) fn new_user_no_upgrade() -> Error {
         Error::new(Kind::NoUpgrade, None)
     }
@@ -303,6 +310,7 @@ impl StdError for Error {
             Kind::Http2 => "http2 general error",
             Kind::UnsupportedVersion => "request has unsupported HTTP version",
             Kind::UnsupportedRequestMethod => "request has unsupported HTTP method",
+            Kind::AbsoluteUriRequired => "client requires absolute-form URIs",
             Kind::NoUpgrade => "no upgrade available",
             Kind::ManualUpgrade => "upgrade expected but low level API in use",
             Kind::Execute => "executor failed to spawn task",


### PR DESCRIPTION
While the upgrades feature enabled HTTP upgrades in both and the server and client, and the goal was for `CONNECT` requests to work as well, only the server could use them for `CONNECT`. The `Client` had some specific code rejecting `CONNECT` requests, and this removes it and prepares the `Client` to handle them correctly.