### PR TITLE
Avoid socket thrash

### DIFF
--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -151,7 +151,7 @@ impl<T: Poolable> Pool<T> {
         }
     }
 
-    fn take(&self, key: &Key) -> Option<Pooled<T>> {
+    pub(super) fn take(&self, key: &Key) -> Option<Pooled<T>> {
         let entry = {
             let mut inner = self.inner.connections.lock().unwrap();
             let expiration = Expiration::new(inner.timeout);


### PR DESCRIPTION
Hi, we're experiencing an issue with the latest version of `hyper` where lots of sockets are being placed in time-wait during periods of high load / high re-use of connections.

The problem is due to the race between the `checkout` and `connect` futures. If an idle connection is returned to the pool, the `checkout` future will resolve and the `connect` future will be dropped. If the `connect` future has started establishing a connection on a socket, that socket will be closed and enter time-wait state.

So if the time to establish a new connection is `X` and time to finish a request is `Y`, if `X > Y` a new connection will be discarded. Also the ratio of `X / Y` is the factor that must be exceeded by concurrent requests in order to change the number of connections, so if a request finishes in ~0.05s and a new connection takes ~0.5s to establish then any increase of load greater than your current number of connections (up to 10x) will cause up to ~9x connections to be created and closed.

<img width="181" alt="screen shot 2018-06-27 at 11 27 15 am" src="https://user-images.githubusercontent.com/1581481/41992402-2a802c0e-79fd-11e8-8ee4-374768020ebd.png">

```
(Above) A spike in socket churn during high load. 
Yellow: TCP time-wait sockets. Green: TCP in-use sockets.
```

---

My original approach was to race the `checkout` against a shortened `connect` future which is just the connector's `connect()` future. This didn't work because the `connect()` future returned by the `Connector` begins the process of establishing a connection on the socket in the middle of the future. 

So ideally we would be able to race the checkout until a socket is chosen for connection, but this would change the `Connect` trait API so I wasn't sure if it was the right change to make. Instead I set the checkout future to just check if an idle connection was ready or return `err_canceled`. 

This way if the `avoid_socket_thrash` variable is set, the `checkout` future will always win the race and will return a `Pooled<T>` if it exists or else run the `connect` future.