### PR TITLE
fix(client): try to reuse connections when pool checkout wins

### DIFF
--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -151,6 +151,26 @@ impl<T: Poolable> Pool<T> {
         }
     }
 
+    #[cfg(feature = "runtime")]
+    #[cfg(test)]
+    pub(super) fn h1_key(&self, s: &str) -> Key {
+        (Arc::new(s.to_string()), Ver::Http1)
+    }
+
+    #[cfg(feature = "runtime")]
+    #[cfg(test)]
+    pub(super) fn idle_count(&self, key: &Key) -> usize {
+        self
+            .inner
+            .connections
+            .lock()
+            .unwrap()
+            .idle
+            .get(key)
+            .map(|list| list.len())
+            .unwrap_or(0)
+    }
+
     fn take(&self, key: &Key) -> Option<Pooled<T>> {
         let entry = {
             let mut inner = self.inner.connections.lock().unwrap();

--- a/src/common/lazy.rs
+++ b/src/common/lazy.rs
@@ -1,0 +1,63 @@
+use std::mem;
+
+use futures::{Future, IntoFuture, Poll};
+
+pub(crate) fn lazy<F, R>(func: F) -> Lazy<F, R>
+where
+    F: FnOnce() -> R,
+    R: IntoFuture,
+{
+    Lazy {
+        inner: Inner::Init(func),
+    }
+}
+
+pub struct Lazy<F, R: IntoFuture> {
+    inner: Inner<F, R::Future>
+}
+
+enum Inner<F, R> {
+    Init(F),
+    Fut(R),
+    Empty,
+}
+
+impl<F, R> Lazy<F, R>
+where
+    F: FnOnce() -> R,
+    R: IntoFuture,
+{
+    pub fn started(&self) -> bool {
+        match self.inner {
+            Inner::Init(_) => false,
+            Inner::Fut(_) |
+            Inner::Empty => true,
+        }
+    }
+}
+
+impl<F, R> Future for Lazy<F, R>
+where
+    F: FnOnce() -> R,
+    R: IntoFuture,
+{
+    type Item = R::Item;
+    type Error = R::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.inner {
+            Inner::Fut(ref mut f) => return f.poll(),
+            _ => (),
+        }
+
+        match mem::replace(&mut self.inner, Inner::Empty) {
+            Inner::Init(func) => {
+                let mut fut = func().into_future();
+                let ret = fut.poll();
+                self.inner = Inner::Fut(fut);
+                ret
+            },
+            _ => unreachable!("lazy state wrong"),
+        }
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,8 +1,10 @@
 mod buf;
 mod exec;
 pub(crate) mod io;
+mod lazy;
 mod never;
 
 pub(crate) use self::buf::StaticBuf;
 pub(crate) use self::exec::Exec;
+pub(crate) use self::lazy::lazy;
 pub use self::never::Never;


### PR DESCRIPTION
If a checkout wins, meaning an idle connection became available before
a connect future completed, instead of just dropping the connect future,
it spawns it into the background executor to allow being placed into
the pool on completion.

Alternative solution for #1584 