### PR TITLE
feat(ext): introduce extensions, starting with ConnectionInfo

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -10,7 +10,6 @@ static PHRASE: &'static [u8] = b"Hello World!";
 
 fn main() {
     pretty_env_logger::init();
-
     let addr = ([127, 0, 0, 1], 3000).into();
 
     // new_service is run for each connection, creating a 'service'

--- a/src/ext/conn_info.rs
+++ b/src/ext/conn_info.rs
@@ -1,0 +1,57 @@
+use std::net::SocketAddr;
+
+use super::Ext;
+
+/// dox
+#[derive(Debug)]
+pub struct ConnectionInfo {
+    pub(crate) remote_addr: Option<SocketAddr>,
+}
+
+// The private type that gets put into extensions()
+//
+// The reason for the public and private types is to, for now, prevent
+// a public API contract that crates could depend on. If the public type
+// were inserted into the Extensions directly, a user could depend on
+// `req.extensions().get::<ConnectionInfo>()`, and it's not clear that
+// we want this contract yet.
+#[derive(Copy, Clone, Default)]
+struct ConnInfo {
+    remote_addr: Option<SocketAddr>,
+}
+
+impl ConnectionInfo {
+    /// dox
+    pub fn get<E>(extend: &E) -> ConnectionInfo
+    where
+        E: Ext,
+    {
+        let info = extend
+            .ext()
+            .get::<ConnInfo>()
+            .map(|&info| info)
+            .unwrap_or_default();
+
+        ConnectionInfo {
+            remote_addr: info.remote_addr,
+        }
+    }
+
+    /// dox
+    pub(crate) fn set<E>(self, extend: &mut E)
+    where
+        E: Ext,
+    {
+        let info = ConnInfo {
+            remote_addr: self.remote_addr,
+        };
+
+        extend.ext_mut().insert(info);
+    }
+
+    /// dox
+    pub fn remote_addr(&self) -> Option<SocketAddr> {
+        self.remote_addr
+    }
+}
+

--- a/src/ext/mod.rs
+++ b/src/ext/mod.rs
@@ -1,0 +1,44 @@
+//! dox
+use http::{Extensions, Request, Response};
+
+use self::sealed::{Ext, Sealed};
+
+mod conn_info;
+
+pub use self::conn_info::ConnectionInfo;
+
+
+mod sealed {
+    use http::Extensions;
+
+    pub trait Sealed {
+        fn ext(&self) -> &Extensions;
+        fn ext_mut(&mut self) -> &mut Extensions;
+    }
+
+    pub trait Ext: Sealed {}
+}
+
+impl<B> Sealed for Request<B> {
+    fn ext(&self) -> &Extensions {
+        self.extensions()
+    }
+
+    fn ext_mut(&mut self) -> &mut Extensions {
+        self.extensions_mut()
+    }
+}
+
+impl<B> Ext for Request<B> {}
+
+impl<B> Sealed for Response<B> {
+    fn ext(&self) -> &Extensions {
+        self.extensions()
+    }
+
+    fn ext_mut(&mut self) -> &mut Extensions {
+        self.extensions_mut()
+    }
+}
+
+impl<B> Ext for Response<B> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ mod mock;
 pub mod body;
 pub mod client;
 pub mod error;
+pub mod ext;
 mod headers;
 mod proto;
 pub mod server;


### PR DESCRIPTION
- Adds `client::Builder::set_conn_info` to opt-in to having connection
  info added to `Response`s from clients.
- Adds `ext::ConnectionInfo` that allows querying types (like a
  `Response`) for connection info.

Closes #1402 

------

Still WIP...

