### PR TITLE
feat(client): adds `HttpInfo` to responses when `HttpConnector` is used

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -10,7 +10,6 @@ static PHRASE: &'static [u8] = b"Hello World!";
 
 fn main() {
     pretty_env_logger::init();
-
     let addr = ([127, 0, 0, 1], 3000).into();
 
     // new_service is run for each connection, creating a 'service'


### PR DESCRIPTION
- Adds `client::connect::Connected::extra()`, which allows connectors to
  specify arbitrary custom information about a connected transport.

If a connector provides this extra value, it will be set in the
`Response` extensions.

Closes #1402

-----

This is an alternative to #1592 

