### PR TITLE
feat(client): implement rfc 6555 (happy eyeballs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-sudo: false
+sudo: true # Required for functional IPv6 (forces VM instead of Docker).
 dist: trusty
 matrix:
     fast_finish: true
@@ -17,6 +17,13 @@ matrix:
 
 cache:
     apt: true
+
+before_script:
+  # Add an IPv6 config - see the corresponding Travis issue
+  # https://github.com/travis-ci/travis-ci/issues/8361
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+    fi
 
 script:
   - ./.travis/readme.py

--- a/src/client/dns.rs
+++ b/src/client/dns.rs
@@ -35,6 +35,10 @@ pub struct IpAddrs {
 }
 
 impl IpAddrs {
+    pub fn new(addrs: Vec<SocketAddr>) -> Self {
+        IpAddrs { iter: addrs.into_iter() }
+    }
+
     pub fn try_parse(host: &str, port: u16) -> Option<IpAddrs> {
         if let Ok(addr) = host.parse::<Ipv4Addr>() {
             let addr = SocketAddrV4::new(addr, port);
@@ -46,6 +50,23 @@ impl IpAddrs {
         }
         None
     }
+
+    pub fn split_by_preference(self) -> (IpAddrs, IpAddrs) {
+        let preferring_v6 = self.iter
+            .as_slice()
+            .first()
+            .map(SocketAddr::is_ipv6)
+            .unwrap_or(false);
+
+        let (preferred, fallback) = self.iter
+            .partition::<Vec<_>, _>(|addr| addr.is_ipv6() == preferring_v6);
+
+        (IpAddrs::new(preferred), IpAddrs::new(fallback))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.iter.as_slice().is_empty()
+    }
 }
 
 impl Iterator for IpAddrs {
@@ -53,5 +74,27 @@ impl Iterator for IpAddrs {
     #[inline]
     fn next(&mut self) -> Option<SocketAddr> {
         self.iter.next()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use super::*;
+
+    #[test]
+    fn test_ip_addrs_split_by_preference() {
+        let v4_addr = (Ipv4Addr::new(127, 0, 0, 1), 80).into();
+        let v6_addr = (Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 80).into();
+
+        let (mut preferred, mut fallback) =
+            IpAddrs { iter: vec![v4_addr, v6_addr].into_iter() }.split_by_preference();
+        assert!(preferred.next().unwrap().is_ipv4());
+        assert!(fallback.next().unwrap().is_ipv6());
+
+        let (mut preferred, mut fallback) =
+            IpAddrs { iter: vec![v6_addr, v4_addr].into_iter() }.split_by_preference();
+        assert!(preferred.next().unwrap().is_ipv6());
+        assert!(fallback.next().unwrap().is_ipv4());
     }
 }


### PR DESCRIPTION
First PR, criticism welcome!

Update client connector to attempt a parallel connection using alternative address family, if connection using preferred address family takes too long.

Some questions:

* What should be a default value for timeout before we attempt other connections? Currently is 300ms.
* How to write a test for this? For manual testing I used edited /etc/hosts and iptables to simulate non-functioning IPv6. Maybe same could be done for Travis? Unsure about Appveyor.

Closes: #1316
