### PR TITLE
fix(http1): reduce closed connections when body is dropped

### DIFF
--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -137,7 +137,14 @@ fn checkout_win_allows_connect_future_to_be_pooled() {
             .map(|res| res.into_body().concat2());
         let srv1 = poll_fn(|| {
             try_ready!(sock1.read(&mut [0u8; 512]));
-            try_ready!(sock1.write(b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\nx"));
+            // Chunked is used so as to force 2 body reads.
+            try_ready!(sock1.write(b"\
+                HTTP/1.1 200 OK\r\n\
+                transfer-encoding: chunked\r\n\
+                \r\n\
+                1\r\nx\r\n\
+                0\r\n\r\n\
+            "));
             Ok(Async::Ready(()))
         }).map_err(|e: ::std::io::Error| panic!("srv1 poll_fn error: {}", e));
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -63,6 +63,50 @@ t! {
 }
 
 t! {
+    get_body_2_keeps_alive,
+    client:
+        request:
+            uri: "/",
+            ;
+        response:
+            status: 200,
+            headers: {
+                "content-length" => 11,
+            },
+            body: "hello world",
+            ;
+        request:
+            uri: "/",
+            ;
+        response:
+            status: 200,
+            headers: {
+                "content-length" => 11,
+            },
+            body: "hello world",
+            ;
+    server:
+        request:
+            uri: "/",
+            ;
+        response:
+            headers: {
+                "content-length" => 11,
+            },
+            body: "hello world",
+            ;
+        request:
+            uri: "/",
+            ;
+        response:
+            headers: {
+                "content-length" => 11,
+            },
+            body: "hello world",
+            ;
+}
+
+t! {
     get_strip_connection_header,
     client:
         request:


### PR DESCRIPTION
If a user makes use of `Body::is_end_stream` to optimize so as to not
need to do make a final poll just to receive `None`, previously the
connection would not have progressed its reading state to a finished
body, and so the connection would be closed.

Now, upon reading any chunk, the connection state will check if it
can know that the body would be finished, and progresses to a body
finished state sooner.

The integration tests were amplified by adding a naive hyper proxy
as a secondary test, which happens to make use of that optimization,
and thus caught the issue.

