### PR TITLE
refactor(lib): replace Vec::set_len(0) with clear

### DIFF
--- a/src/body/chunk.rs
+++ b/src/body/chunk.rs
@@ -179,7 +179,7 @@ mod tests {
             let chunk = ::Chunk::from(s);
             dst.put(chunk);
             ::test::black_box(&dst);
-            unsafe { dst.set_len(0); }
+            dst.clear();
         })
     }
 }

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -275,9 +275,7 @@ impl<T: AsRef<[u8]>> Cursor<T> {
 impl Cursor<Vec<u8>> {
     fn reset(&mut self) {
         self.pos = 0;
-        unsafe {
-            self.bytes.set_len(0);
-        }
+        self.bytes.clear();
     }
 }
 
@@ -717,9 +715,7 @@ mod tests {
             let chunk = ::Chunk::from(s);
             write_buf.buffer(chunk);
             ::test::black_box(&write_buf);
-            unsafe {
-                write_buf.headers.bytes.set_len(0);
-            }
+            write_buf.headers.bytes.clear();
         })
     }
 }

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1525,10 +1525,7 @@ mod tests {
             assert_eq!(vec.len(), len);
             ::test::black_box(&vec);
 
-            // reset Vec<u8> to 0 (always safe)
-            unsafe {
-                vec.set_len(0);
-            }
+            vec.clear();
         })
     }
 }


### PR DESCRIPTION
These were trivially safe, but it's still a good idea to avoid `unsafe` here, even if just for PR purposes.