### PR TITLE
add Server::from_tcp()

### DIFF
--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -44,6 +44,20 @@ impl AddrIncoming {
         })
     }
 
+    pub(super) fn from_tcp(std_listener: StdTcpListener, handle: &Handle) -> ::Result<Self>{
+        let listener = TcpListener::from_std(std_listener, &handle)
+            .map_err(::Error::new_listen)?;
+        let addr = listener.local_addr().map_err(::Error::new_listen)?;
+        Ok(AddrIncoming {
+            listener,
+            addr: addr,
+            sleep_on_errors: true,
+            tcp_keepalive_timeout: None,
+            tcp_nodelay: false,
+            timeout: None,
+        })
+    }
+
     /// Get the local address bound to this listener.
     pub fn local_addr(&self) -> SocketAddr {
         self.addr


### PR DESCRIPTION
Heya :wave:, this implements https://github.com/hyperium/hyper/issues/1602. I'm pretty sure there's a few rough edges to this PR, but I wanted to kick things off anyway.

## Questions
### Error handling
The result type for `from_tcp()` is now:
```rust
Result<Builder<tokio_tcp::Incoming>, Box<dyn error::Error>> {
```
I wasn't sure what the best way to approach the errors was; any pointers here would be fantastic!

### Runtime Features
I wasn't sure what the runtime features are for (`no_std` related perhaps?), but figured I'd follow the prior art and add them where it seemed appropriate.

### Rustfmt
Rustfmt tends to run on every save; sorry if it changed things it shouldn't have. Happy to go back in and revert changes - but also happy to leave it if it doesn't matter :grin:

### Method name
I ended up going with `.from_tcp()` because I felt it was the most descriptive, but happy to change it to any other method if people feel that's more appropriate!

### Tests
I only tested this on an example application to make sure it works. What would be the best way to test this?

---

Hope this is helpful! :tada: