### PR TITLE
Hyper failing with Tokio's CurrentThread executor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tokio-mockstream = "1.1.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+tokio-current-thread = "0.1"
 
 [features]
 default = [

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,12 +1,13 @@
 #![deny(warnings)]
 extern crate hyper;
 extern crate pretty_env_logger;
+extern crate tokio_current_thread;
 
 use std::env;
 use std::io::{self, Write};
 
 use hyper::Client;
-use hyper::rt::{self, Future, Stream};
+use hyper::rt::{Future, Stream};
 
 fn main() {
     pretty_env_logger::init();
@@ -32,7 +33,10 @@ fn main() {
     //
     // Note that in more complicated use cases, the runtime should probably
     // run on its own, and futures should just be spawned into it.
-    rt::run(fetch_url(url));
+    match tokio_current_thread::block_on_all(fetch_url(url)) {
+        Ok(_) => println!("DONE"),
+        Err(e) => println!("Error: {:?}", e),
+    }
 }
 
 fn fetch_url(url: hyper::Uri) -> impl Future<Item=(), Error=()> {

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -8,6 +8,7 @@ use std::io::{self, Write};
 
 use hyper::Client;
 use hyper::rt::{Future, Stream};
+use tokio_current_thread::CurrentThread;
 
 fn main() {
     pretty_env_logger::init();
@@ -33,7 +34,7 @@ fn main() {
     //
     // Note that in more complicated use cases, the runtime should probably
     // run on its own, and futures should just be spawned into it.
-    match tokio_current_thread::block_on_all(fetch_url(url)) {
+    match CurrentThread::new().spawn(fetch_url(url)).run() {
         Ok(_) => println!("DONE"),
         Err(e) => println!("Error: {:?}", e),
     }


### PR DESCRIPTION
This came up recently.

Hyper: master
tokio-current-thread: 0.1.1

When executing this modified example with: `cargo run --example client http://httpbin.org`

The connection does not happen and returns an error: `Error executor failed to spawn task`

The default runtime works, so does tokio-core. I don't know does this issue belong here or to tokio.