### PR TITLE
chore(*): enable `#[deny(warnings)]` at only testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc(html_root_url = "https://docs.rs/hyper/0.12.7")]
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![deny(missing_debug_implementations)]
+#![cfg_attr(test, deny(warnings))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 
 //! # hyper


### PR DESCRIPTION
This PR intends to fix the error at `cargo doc` caused by warnings.