### PR TITLE
fix(http2): allow TE "trailers" request headers

### DIFF
--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -108,7 +108,7 @@ where
                             }
                             let (head, body) = req.into_parts();
                             let mut req = ::http::Request::from_parts(head, ());
-                            super::strip_connection_headers(req.headers_mut());
+                            super::strip_connection_headers(req.headers_mut(), true);
                             if let Some(len) = body.content_length() {
                                 headers::set_content_length_if_missing(req.headers_mut(), len);
                             }

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -192,7 +192,7 @@ where
 
                     let (head, body) = res.into_parts();
                     let mut res = ::http::Response::from_parts(head, ());
-                    super::strip_connection_headers(res.headers_mut());
+                    super::strip_connection_headers(res.headers_mut(), false);
                     if let Some(len) = body.content_length() {
                         headers::set_content_length_if_missing(res.headers_mut(), len);
                     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -185,6 +185,30 @@ t! {
 }
 
 t! {
+    get_allow_te_trailers_header,
+    client:
+        request:
+            uri: "/",
+            headers: {
+                // http2 strips connection headers other than TE "trailers"
+                "te" => "trailers",
+            },
+            ;
+        response:
+            status: 200,
+            ;
+    server:
+        request:
+            uri: "/",
+            headers: {
+                "te" => "trailers",
+            },
+            ;
+        response:
+            ;
+}
+
+t! {
     get_body_chunked,
     client:
         request:


### PR DESCRIPTION
The HTTP/2 spec allows TE headers in requests if the value is
"trailers". Other TE headers are still stripped.

Closes #1642

