### PR TITLE
docs(examples): Fix typo in client_json example comment

### DIFF
--- a/examples/client_json.rs
+++ b/examples/client_json.rs
@@ -64,7 +64,7 @@ struct User {
     name: String,
 }
 
-// Define a type so we can return multile types of errors
+// Define a type so we can return multiple types of errors
 enum FetchError {
     Http(hyper::Error),
     Json(serde_json::Error),


### PR DESCRIPTION
Fixes typo on comment about error types in client_json example.

