### PR TITLE
feat(client): add HttpConnector::set_global_destination_only

### DIFF
--- a/src/client/dns.rs
+++ b/src/client/dns.rs
@@ -1,6 +1,6 @@
 use std::io;
 use std::net::{
-    Ipv4Addr, Ipv6Addr,
+    IpAddr, Ipv4Addr, Ipv6Addr,
     SocketAddr, ToSocketAddrs,
     SocketAddrV4, SocketAddrV6,
 };
@@ -51,6 +51,10 @@ impl IpAddrs {
         None
     }
 
+    pub fn global_only(self) -> IpAddrs {
+        IpAddrs::new(self.iter.filter(|addr| is_global_ip(&addr.ip())).collect())
+    }
+
     pub fn split_by_preference(self) -> (IpAddrs, IpAddrs) {
         let preferring_v6 = self.iter
             .as_slice()
@@ -77,6 +81,33 @@ impl Iterator for IpAddrs {
     }
 }
 
+fn is_global_ip(addr: &IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(addr) => is_global_ipv4(addr),
+        IpAddr::V6(addr) => is_unicast_global_ipv6(addr),
+    }
+}
+
+fn is_global_ipv4(addr: &Ipv4Addr) -> bool {
+    // Based on nightly implementation of Ipv4Addr.is_global().
+    !addr.is_private() && !addr.is_loopback() && !addr.is_link_local() &&
+    !addr.is_broadcast() && !addr.is_documentation() && !addr.is_unspecified()
+}
+
+fn is_unicast_global_ipv6(addr: &Ipv6Addr) -> bool {
+    // Based on nightly implementation of Ipv6Addr.is_unicast_global().
+    let segments = addr.segments();
+    let is_unicast_link_local = (segments[0] & 0xffc0) == 0xfe80;
+    let is_unicast_site_local = (segments[0] & 0xffc0) == 0xfec0;
+    let is_unique_local = (segments[0] & 0xfe00) == 0xfc00;
+    let is_documentation = (segments[0] == 0x2001) && (segments[1] == 0xdb8);
+
+    !addr.is_multicast() && !addr.is_loopback() && !is_unicast_link_local &&
+    !is_unicast_site_local && !is_unique_local &&
+    !addr.is_unspecified() && !is_documentation &&
+    addr.to_ipv4().as_ref().map_or(true, is_global_ipv4)
+}
+
 #[cfg(test)]
 mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr};
@@ -96,5 +127,22 @@ mod tests {
             IpAddrs { iter: vec![v6_addr, v4_addr].into_iter() }.split_by_preference();
         assert!(preferred.next().unwrap().is_ipv6());
         assert!(fallback.next().unwrap().is_ipv4());
+    }
+
+    #[test]
+    fn test_global_only() {
+        let not_global: Vec<SocketAddr> = vec![
+            (Ipv4Addr::new(127, 0, 0, 1), 80).into(), // loopback
+            (Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0), 80).into(), // documentation
+            (Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0), 80).into(), // multicast
+        ];
+        let addrs = IpAddrs { iter: not_global.clone().into_iter() };
+        assert!(addrs.global_only().is_empty());
+
+        let global: Vec<SocketAddr> = vec![
+            (Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff), 80).into(),
+        ];
+        let addrs = IpAddrs { iter: global.clone().into_iter() };
+        assert_eq!(addrs.global_only().count(), global.len());
     }
 }


### PR DESCRIPTION
Allow restricting destinations to addresses that appear to be
publicly routable. This can be a useful security measure when
connecting to user defined URLs.

---

Is this something you would consider including? Or if not, is there a more elegant way to build this outside of hyper than copying the entire HttpConnector implementation?