### PR TITLE
feat(client): add `Resolve`, used by `HttpConnector`

### DIFF
--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -15,6 +15,7 @@ use tokio_io::{AsyncRead, AsyncWrite};
 
 #[cfg(feature = "runtime")] mod dns;
 #[cfg(feature = "runtime")] mod http;
+#[cfg(feature = "runtime")] pub use self::dns::{GaiResolver, Name, Resolve};
 #[cfg(feature = "runtime")] pub use self::http::{HttpConnector, HttpInfo};
 
 /// Connect to a destination, returning an IO transport.

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -17,7 +17,6 @@ use hyper::{Body, Client, Method, Request, StatusCode};
 
 use futures::{Future, Stream};
 use futures::sync::oneshot;
-use tokio::reactor::Handle;
 use tokio::runtime::current_thread::Runtime;
 use tokio::net::tcp::{ConnectFuture, TcpStream};
 
@@ -226,7 +225,7 @@ macro_rules! test {
         let addr = server.local_addr().expect("local_addr");
         let mut rt = $runtime;
 
-        let connector = ::hyper::client::HttpConnector::new_with_handle(1, Handle::default());
+        let connector = ::hyper::client::HttpConnector::new(1);
         let client = Client::builder()
             .set_host($set_host)
             .http1_title_case_headers($title_case_headers)


### PR DESCRIPTION
This introduces a `Resolve` trait to describe asynchronous DNS
resolution. The `HttpConnector` can be configured with a resolver,
allowing a user to still use all the functionality of the
`HttpConnector`, while customizing the DNS resolution.

To prevent a breaking change, the `HttpConnector` has its `Resolve`
generic set by default to `GaiResolver`. This is same as the existing
resolver, which uses `getaddrinfo` inside a thread pool.

Closes #1517

