### PR TITLE
feat(dns): tokio_threadpool::blocking resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tokio-io = "0.1"
 tokio-reactor = { version = "0.1", optional = true }
 tokio-tcp = { version = "0.1", optional = true }
 tokio-timer = { version = "0.2", optional = true }
+tokio-threadpool = { version = "0.1", optional = true }
 want = "0.0.6"
 
 [dev-dependencies]
@@ -62,6 +63,7 @@ runtime = [
     "tokio-reactor",
     "tokio-tcp",
     "tokio-timer",
+    "tokio-threadpool",
 ]
 nightly = []
 __internal_flaky_tests = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ extern crate time;
 #[cfg(feature = "runtime")] extern crate tokio_reactor;
 #[cfg(feature = "runtime")] extern crate tokio_tcp;
 #[cfg(feature = "runtime")] extern crate tokio_timer;
+#[cfg(feature = "runtime")] extern crate tokio_threadpool;
 extern crate want;
 
 #[cfg(all(test, feature = "nightly"))]


### PR DESCRIPTION
Unlike the default resolver, this avoids spawning extra dedicated
threads but only works on the multi-threaded Tokio runtime.

Closes #1676

