### PR TITLE
add unix domain socket support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tokio-reactor = { version = "0.1", optional = true }
 tokio-tcp = { version = "0.1", optional = true }
 tokio-threadpool = { version = "0.1.3", optional = true }
 tokio-timer = { version = "0.2", optional = true }
+tokio-uds = { version = "0.2", optional = true }
 want = "0.0.6"
 
 [dev-dependencies]
@@ -64,6 +65,9 @@ runtime = [
     "tokio-tcp",
     "tokio-threadpool",
     "tokio-timer",
+]
+uds = [
+    "tokio-uds",
 ]
 nightly = []
 __internal_flaky_tests = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ tokio-reactor = { version = "0.1", optional = true }
 tokio-tcp = { version = "0.1", optional = true }
 tokio-threadpool = { version = "0.1.3", optional = true }
 tokio-timer = { version = "0.2", optional = true }
-tokio-uds = { version = "0.2", optional = true }
 want = "0.0.6"
 
 [dev-dependencies]
@@ -66,11 +65,11 @@ runtime = [
     "tokio-threadpool",
     "tokio-timer",
 ]
-uds = [
-    "tokio-uds",
-]
 nightly = []
 __internal_flaky_tests = []
+
+[target.'cfg(unix)'.dependencies]
+tokio-uds = "0.2"
 
 [profile.release]
 codegen-units = 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ extern crate time;
 #[macro_use] extern crate tokio_io;
 #[cfg(feature = "runtime")] extern crate tokio_reactor;
 #[cfg(feature = "runtime")] extern crate tokio_tcp;
-#[cfg(feature = "uds")] extern crate tokio_uds;
+#[cfg(all(unix,feature = "runtime"))] extern crate tokio_uds;
 #[cfg(feature = "runtime")] extern crate tokio_threadpool;
 #[cfg(feature = "runtime")] extern crate tokio_timer;
 extern crate want;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ extern crate time;
 #[macro_use] extern crate tokio_io;
 #[cfg(feature = "runtime")] extern crate tokio_reactor;
 #[cfg(feature = "runtime")] extern crate tokio_tcp;
+#[cfg(feature = "uds")] extern crate tokio_uds;
 #[cfg(feature = "runtime")] extern crate tokio_threadpool;
 #[cfg(feature = "runtime")] extern crate tokio_timer;
 extern crate want;

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -11,6 +11,7 @@
 use std::fmt;
 use std::mem;
 #[cfg(feature = "runtime")] use std::net::SocketAddr;
+#[cfg(feature = "uds")] use std::os::unix::net::SocketAddr as UnixSocketAddr;
 use std::sync::Arc;
 #[cfg(feature = "runtime")] use std::time::Duration;
 
@@ -34,6 +35,7 @@ pub(super) use self::spawn_all::Watcher;
 pub(super) use self::upgrades::UpgradeableConnection;
 
 #[cfg(feature = "runtime")] pub use super::tcp::AddrIncoming;
+#[cfg(feature = "uds")] pub use super::uds::UnixAddrIncoming;
 
 /// A lower-level configuration of the HTTP protocol.
 ///
@@ -651,6 +653,13 @@ where
 #[cfg(feature = "runtime")]
 impl<S, E> SpawnAll<AddrIncoming, S, E> {
     pub(super) fn local_addr(&self) -> SocketAddr {
+        self.serve.incoming.local_addr()
+    }
+}
+
+#[cfg(feature = "uds")]
+impl<S, E> SpawnAll<UnixAddrIncoming, S, E> {
+    pub(super) fn local_addr(&self) -> &UnixSocketAddr {
         self.serve.incoming.local_addr()
     }
 }

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -11,7 +11,7 @@
 use std::fmt;
 use std::mem;
 #[cfg(feature = "runtime")] use std::net::SocketAddr;
-#[cfg(feature = "uds")] use std::os::unix::net::SocketAddr as UnixSocketAddr;
+#[cfg(all(unix,feature = "runtime"))] use std::os::unix::net::SocketAddr as UnixSocketAddr;
 use std::sync::Arc;
 #[cfg(feature = "runtime")] use std::time::Duration;
 
@@ -35,7 +35,7 @@ pub(super) use self::spawn_all::Watcher;
 pub(super) use self::upgrades::UpgradeableConnection;
 
 #[cfg(feature = "runtime")] pub use super::tcp::AddrIncoming;
-#[cfg(feature = "uds")] pub use super::uds::UnixIncoming;
+#[cfg(all(unix,feature = "runtime"))] pub use super::uds::UnixIncoming;
 
 /// A lower-level configuration of the HTTP protocol.
 ///
@@ -657,7 +657,7 @@ impl<S, E> SpawnAll<AddrIncoming, S, E> {
     }
 }
 
-#[cfg(feature = "uds")]
+#[cfg(all(unix,feature = "runtime"))]
 impl<S, E> SpawnAll<UnixIncoming, S, E> {
     pub(super) fn local_addr(&self) -> &UnixSocketAddr {
         self.serve.incoming.local_addr()

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -35,7 +35,7 @@ pub(super) use self::spawn_all::Watcher;
 pub(super) use self::upgrades::UpgradeableConnection;
 
 #[cfg(feature = "runtime")] pub use super::tcp::AddrIncoming;
-#[cfg(feature = "uds")] pub use super::uds::UnixAddrIncoming;
+#[cfg(feature = "uds")] pub use super::uds::UnixIncoming;
 
 /// A lower-level configuration of the HTTP protocol.
 ///
@@ -658,7 +658,7 @@ impl<S, E> SpawnAll<AddrIncoming, S, E> {
 }
 
 #[cfg(feature = "uds")]
-impl<S, E> SpawnAll<UnixAddrIncoming, S, E> {
+impl<S, E> SpawnAll<UnixIncoming, S, E> {
     pub(super) fn local_addr(&self) -> &UnixSocketAddr {
         self.serve.incoming.local_addr()
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -53,12 +53,12 @@
 pub mod conn;
 mod shutdown;
 #[cfg(feature = "runtime")] mod tcp;
-#[cfg(feature = "uds")] mod uds;
+#[cfg(all(unix,feature = "runtime"))] mod uds;
 
 use std::fmt;
 #[cfg(feature = "runtime")] use std::net::{SocketAddr, TcpListener as StdTcpListener};
 
-#[cfg(feature = "uds")] use std::os::unix::net::{SocketAddr as UnixSocketAddr,
+#[cfg(all(unix,feature = "runtime"))] use std::os::unix::net::{SocketAddr as UnixSocketAddr,
     UnixListener as StdUnixListener};
 
 #[cfg(feature = "runtime")] use std::time::Duration;
@@ -75,8 +75,8 @@ use service::{NewService, Service};
 use self::conn::{Http as Http_, NoopWatcher, SpawnAll};
 use self::shutdown::{Graceful, GracefulWatcher};
 #[cfg(feature = "runtime")] use self::tcp::AddrIncoming;
-#[cfg(feature = "uds")] use self::uds::UnixIncoming;
-#[cfg(feature = "uds")] use std::path::Path;
+#[cfg(all(unix,feature = "runtime"))] use self::uds::UnixIncoming;
+#[cfg(all(unix,feature = "runtime"))] use std::path::Path;
 
 /// A listening HTTP server that accepts connections in both HTTP1 and HTTP2 by default.
 ///
@@ -145,7 +145,7 @@ impl<S> Server<AddrIncoming, S> {
     }
 }
 
-#[cfg(feature = "uds")]
+#[cfg(all(unix,feature = "runtime"))]
 impl Server<UnixIncoming, ()> {
     /// Binds to the provided address, and returns a [`Builder`](Builder).
     ///
@@ -175,7 +175,7 @@ impl Server<UnixIncoming, ()> {
     }
 }
 
-#[cfg(feature = "uds")]
+#[cfg(all(unix,feature = "runtime"))]
 impl<S> Server<UnixIncoming, S> {
     /// Returns the local address that this server is bound to.
     pub fn local_addr(&self) -> &UnixSocketAddr {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -75,7 +75,7 @@ use service::{NewService, Service};
 use self::conn::{Http as Http_, NoopWatcher, SpawnAll};
 use self::shutdown::{Graceful, GracefulWatcher};
 #[cfg(feature = "runtime")] use self::tcp::AddrIncoming;
-#[cfg(feature = "uds")] use self::uds::UnixAddrIncoming;
+#[cfg(feature = "uds")] use self::uds::UnixIncoming;
 #[cfg(feature = "uds")] use std::path::Path;
 
 /// A listening HTTP server that accepts connections in both HTTP1 and HTTP2 by default.
@@ -146,15 +146,15 @@ impl<S> Server<AddrIncoming, S> {
 }
 
 #[cfg(feature = "uds")]
-impl Server<UnixAddrIncoming, ()> {
+impl Server<UnixIncoming, ()> {
     /// Binds to the provided address, and returns a [`Builder`](Builder).
     ///
     /// # Panics
     ///
     /// This method will panic if binding to the address fails. For a method
     /// to bind to an address and return a `Result`, see `Server::try_bind`.
-    pub fn bind_unix<P: AsRef<Path>>(path: P) -> Builder<UnixAddrIncoming> {
-        let incoming = UnixAddrIncoming::new(path.as_ref(), None)
+    pub fn bind_unix<P: AsRef<Path>>(path: P) -> Builder<UnixIncoming> {
+        let incoming = UnixIncoming::new(path.as_ref(), None)
             .unwrap_or_else(|e| {
                 panic!("error binding to {}: {}", path.as_ref().display(), e);
             });
@@ -162,21 +162,21 @@ impl Server<UnixAddrIncoming, ()> {
     }
 
     /// Tries to bind to the provided address, and returns a [`Builder`](Builder).
-    pub fn try_bind_unix<P: AsRef<Path>>(path: P) -> ::Result<Builder<UnixAddrIncoming>> {
-        UnixAddrIncoming::new(path, None)
+    pub fn try_bind_unix<P: AsRef<Path>>(path: P) -> ::Result<Builder<UnixIncoming>> {
+        UnixIncoming::new(path, None)
             .map(Server::builder)
     }
 
     /// Create a new instance from a `std::os::unix::net::UnixListener` instance.
-    pub fn from_socket(listener: StdUnixListener) -> Result<Builder<UnixAddrIncoming>, ::Error> {
+    pub fn from_socket(listener: StdUnixListener) -> Result<Builder<UnixIncoming>, ::Error> {
         let handle = tokio_reactor::Handle::current();
-        UnixAddrIncoming::from_std(listener, &handle)
+        UnixIncoming::from_std(listener, &handle)
             .map(Server::builder)
     }
 }
 
 #[cfg(feature = "uds")]
-impl<S> Server<UnixAddrIncoming, S> {
+impl<S> Server<UnixIncoming, S> {
     /// Returns the local address that this server is bound to.
     pub fn local_addr(&self) -> &UnixSocketAddr {
         self.spawn_all.local_addr()
@@ -408,8 +408,4 @@ impl<E> Builder<AddrIncoming, E> {
         self.incoming.set_nodelay(enabled);
         self
     }
-}
-
-#[cfg(feature = "uds")]
-impl<E> Builder<AddrIncoming, E> {
 }

--- a/src/server/uds.rs
+++ b/src/server/uds.rs
@@ -1,0 +1,233 @@
+use std::fmt;
+use std::io;
+use std::os::unix::net::{SocketAddr
+    as UnixSocketAddr, UnixListener as StdUnixListener};
+use std::time::{Duration, Instant};
+
+use futures::{Async, Future, Poll, Stream};
+use tokio_reactor::Handle;
+use tokio_uds::UnixListener;
+use tokio_timer::Delay;
+use std::path::Path;
+
+use self::addr_stream::AddrStream;
+
+/// A stream of connections from binding to an address.
+#[must_use = "streams do nothing unless polled"]
+pub struct UnixAddrIncoming {
+    addr: UnixSocketAddr,
+    listener: UnixListener,
+    sleep_on_errors: bool,
+    timeout: Option<Delay>,
+}
+
+impl UnixAddrIncoming {
+    pub(super) fn new<P: AsRef<Path>>(path: P, handle: Option<&Handle>) -> ::Result<Self> {
+        let std_listener = StdUnixListener::bind(path)
+                .map_err(::Error::new_listen)?;
+
+        if let Some(handle) = handle {
+            UnixAddrIncoming::from_std(std_listener, handle)
+        } else {
+            let handle = Handle::current();
+            UnixAddrIncoming::from_std(std_listener, &handle)
+        }
+    }
+
+    pub(super) fn from_std(std_listener: StdUnixListener, handle: &Handle) -> ::Result<Self> {
+        let listener = UnixListener::from_std(std_listener, &handle)
+            .map_err(::Error::new_listen)?;
+        let addr = listener.local_addr().map_err(::Error::new_listen)?;
+        Ok(UnixAddrIncoming {
+            listener,
+            addr: addr,
+            sleep_on_errors: true,
+            timeout: None,
+        })
+    }
+
+    /// Get the local address bound to this listener.
+    pub fn local_addr(&self) -> &UnixSocketAddr {
+        &self.addr
+    }
+
+    /// Set whether to sleep on accept errors.
+    ///
+    /// A possible scenario is that the process has hit the max open files
+    /// allowed, and so trying to accept a new connection will fail with
+    /// `EMFILE`. In some cases, it's preferable to just wait for some time, if
+    /// the application will likely close some files (or connections), and try
+    /// to accept the connection again. If this option is `true`, the error
+    /// will be logged at the `error` level, since it is still a big deal,
+    /// and then the listener will sleep for 1 second.
+    ///
+    /// In other cases, hitting the max open files should be treat similarly
+    /// to being out-of-memory, and simply error (and shutdown). Setting
+    /// this option to `false` will allow that.
+    ///
+    /// Default is `true`.
+    pub fn set_sleep_on_errors(&mut self, val: bool) {
+        self.sleep_on_errors = val;
+    }
+}
+
+impl Stream for UnixAddrIncoming {
+    // currently unnameable...
+    type Item = AddrStream;
+    type Error = ::std::io::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        // Check if a previous timeout is active that was set by IO errors.
+        if let Some(ref mut to) = self.timeout {
+            match to.poll() {
+                Ok(Async::Ready(())) => {}
+                Ok(Async::NotReady) => return Ok(Async::NotReady),
+                Err(err) => {
+                    error!("sleep timer error: {}", err);
+                }
+            }
+        }
+        self.timeout = None;
+        loop {
+            match self.listener.poll_accept() {
+                Ok(Async::Ready((socket, addr))) => {
+                    return Ok(Async::Ready(Some(AddrStream::new(socket, addr))));
+                },
+                Ok(Async::NotReady) => return Ok(Async::NotReady),
+                Err(e) => {
+                    // Connection errors can be ignored directly, continue by
+                    // accepting the next request.
+                    if is_connection_error(&e) {
+                        debug!("accepted connection already errored: {}", e);
+                        continue;
+                    }
+
+                    if self.sleep_on_errors {
+                        // Sleep 1s.
+                        let delay = Instant::now() + Duration::from_secs(1);
+                        let mut timeout = Delay::new(delay);
+
+                        match timeout.poll() {
+                            Ok(Async::Ready(())) => {
+                                // Wow, it's been a second already? Ok then...
+                                error!("accept error: {}", e);
+                                continue
+                            },
+                            Ok(Async::NotReady) => {
+                                error!("accept error: {}", e);
+                                self.timeout = Some(timeout);
+                                return Ok(Async::NotReady);
+                            },
+                            Err(timer_err) => {
+                                error!("couldn't sleep on error, timer error: {}", timer_err);
+                                return Err(e);
+                            }
+                        }
+                    } else {
+                        return Err(e);
+                    }
+                },
+            }
+        }
+    }
+}
+
+/// This function defines errors that are per-connection. Which basically
+/// means that if we get this error from `accept()` system call it means
+/// next connection might be ready to be accepted.
+///
+/// All other errors will incur a timeout before next `accept()` is performed.
+/// The timeout is useful to handle resource exhaustion errors like ENFILE
+/// and EMFILE. Otherwise, could enter into tight loop.
+fn is_connection_error(e: &io::Error) -> bool {
+    match e.kind() {
+        io::ErrorKind::ConnectionRefused |
+        io::ErrorKind::ConnectionAborted |
+        io::ErrorKind::ConnectionReset => true,
+        _ => false,
+    }
+}
+
+impl fmt::Debug for UnixAddrIncoming {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("UnixAddrIncoming")
+            .field("addr", &self.addr)
+            .field("sleep_on_errors", &self.sleep_on_errors)
+            .finish()
+    }
+}
+
+mod addr_stream {
+    use std::io::{self, Read, Write};
+    use std::os::unix::net::SocketAddr;
+    use bytes::{Buf, BufMut};
+    use futures::Poll;
+    use tokio_uds::UnixStream;
+    use tokio_io::{AsyncRead, AsyncWrite};
+
+
+    #[derive(Debug)]
+    pub struct AddrStream {
+        inner: UnixStream,
+        pub(super) remote_addr: SocketAddr,
+    }
+
+    impl AddrStream {
+        pub(super) fn new(tcp: UnixStream, addr: SocketAddr) -> AddrStream {
+            AddrStream {
+                inner: tcp,
+                remote_addr: addr,
+            }
+        }
+
+        /// Returns the remote (peer) address of this connection.
+        #[inline]
+        pub fn remote_addr(&self) -> &SocketAddr {
+            &self.remote_addr
+        }
+    }
+
+    impl Read for AddrStream {
+        #[inline]
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            self.inner.read(buf)
+        }
+    }
+
+    impl Write for AddrStream {
+        #[inline]
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.inner.write(buf)
+        }
+
+        #[inline]
+        fn flush(&mut self) -> io::Result<()> {
+            // TcpStream::flush is a noop, so skip calling it...
+            Ok(())
+        }
+    }
+
+    impl AsyncRead for AddrStream {
+        #[inline]
+        unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
+            self.inner.prepare_uninitialized_buffer(buf)
+        }
+
+        #[inline]
+        fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+            self.inner.read_buf(buf)
+        }
+    }
+
+    impl AsyncWrite for AddrStream {
+        #[inline]
+        fn shutdown(&mut self) -> Poll<(), io::Error> {
+            AsyncWrite::shutdown(&mut self.inner)
+        }
+
+        #[inline]
+        fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+            self.inner.write_buf(buf)
+        }
+    }
+}


### PR DESCRIPTION
This patch adds native unix domain socket support to the existing api.

# Why:

1. Most of the time, if you're hosting a service, you're using a reverse proxy to add SSL support and friends.
2. If you're using a reverse proxy, you should be using a unix domain socket to connect to the service: 
  * It's faster (Unix domain sockets have lower overhead)
  * You can dynamically swap services by starting the new one and then "mv"ing the socket file over the original.
  * You don't need to keep track of and forget the port.

Because it should be the default, it should thus be supported by default.

# API

`Server::bind` binds to a IP address. I added `Server::bind_unix` to bind to a `Path`.

# Feature gate

The feature gate is "uds" to be consistent with the package name `tokio-uds` The feature gate is disabled by default so that the maintainers can become comfortable with the naming. There's no runtime overhead unless the feature is used, so there's little reason to not enable it by default eventually (on Unix systems).