### PR TITLE
introduce Accceptor for representing the conversion of incoming I/Os

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,10 @@ name = "upgrades"
 path = "examples/upgrades.rs"
 required-features = ["runtime"]
 
+[[example]]
+name = "custom_acceptor"
+path = "examples/custom_acceptor.rs"
+required-features = ["runtime"]
 
 [[example]]
 name = "web_api"

--- a/examples/custom_acceptor.rs
+++ b/examples/custom_acceptor.rs
@@ -1,0 +1,71 @@
+#![deny(warnings)]
+extern crate hyper;
+#[macro_use]
+extern crate log;
+extern crate pretty_env_logger;
+extern crate tokio;
+
+use hyper::{Body, Response, Server};
+use hyper::service::service_fn_ok;
+use hyper::rt::{self, Future};
+
+fn main() {
+    pretty_env_logger::init();
+
+    let addr = ([127, 0, 0, 1], 3000).into();
+
+    let server = Server::bind(&addr)
+        .acceptor(acceptor::accept)
+        .serve(|| {
+            service_fn_ok(|_| {
+                Response::new(Body::from("Hello World!"))
+            })
+        })
+        .map_err(|e| eprintln!("server error: {}", e));
+
+    println!("Listening on http://{}", addr);
+
+    rt::run(server);
+}
+
+mod acceptor {
+    use std::io::{self, Read, Write};
+    use tokio::io::{AsyncRead, AsyncWrite};
+    use tokio::prelude::Poll;
+
+    pub struct WrappedIO<T>(T);
+
+    impl<T: Read> Read for WrappedIO<T> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            trace!("WrappedIO::read");
+            self.0.read(buf)
+        }
+    }
+
+    impl<T: Write> Write for WrappedIO<T> {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            trace!("WrappedIO::write");
+            self.0.write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.0.flush()
+        }
+    }
+
+    impl<T: AsyncRead> AsyncRead for WrappedIO<T> {
+    }
+
+    impl<T: AsyncWrite> AsyncWrite for WrappedIO<T> {
+        fn shutdown(&mut self) -> Poll<(), io::Error> {
+            self.0.shutdown()
+        }
+    }
+
+    pub fn accept<T>(io: T) -> io::Result<WrappedIO<T>>
+    where
+        T: AsyncRead + AsyncWrite,
+    {
+        Ok(WrappedIO(io))
+    }
+}

--- a/src/server/acceptor.rs
+++ b/src/server/acceptor.rs
@@ -1,0 +1,52 @@
+use std::io;
+
+use futures::{future, IntoFuture, Future};
+use tokio_io::{AsyncRead, AsyncWrite};
+
+pub trait Acceptor<Io> {
+    type Item: AsyncRead + AsyncWrite;
+    type Error: Into<Box<::std::error::Error + Send + Sync>>;
+    type Accept: Future<Item = Self::Item, Error = Self::Error>;
+
+    fn accept(&self, io: Io) -> Self::Accept;
+}
+
+impl<F, T, R> Acceptor<T> for F
+where
+    F: Fn(T) -> R,
+    R: IntoFuture,
+    R::Item: AsyncRead + AsyncWrite,
+    R::Error: Into<Box<::std::error::Error + Send + Sync>>,
+{
+    type Item = R::Item;
+    type Error = R::Error;
+    type Accept = R::Future;
+
+    #[inline]
+    fn accept(&self, io: T) -> Self::Accept {
+        (*self)(io).into_future()
+    }
+}
+
+#[derive(Debug)]
+pub struct Raw(());
+
+impl Raw {
+    pub(super) fn new() -> Raw {
+        Raw(())
+    }
+}
+
+impl<I> Acceptor<I> for Raw
+where
+    I: AsyncRead + AsyncWrite,
+{
+    type Item = I;
+    type Error = io::Error;
+    type Accept = future::FutureResult<Self::Item, Self::Error>;
+
+    #[inline]
+    fn accept(&self, io: I) -> Self::Accept {
+        future::ok(io)
+    }
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -375,7 +375,6 @@ pub fn __run_test(cfg: __TestConfig) {
                 cnt
             );
             let fut = connecting
-                .map_err(|never| -> hyper::Error { match never {} })
                 .flatten()
                 .map_err(|e| panic!("server connection error: {}", e));
             ::tokio::spawn(fut);


### PR DESCRIPTION
Currently, the server API takes the stream of incoming connections as a `Stream` that returns an asynchronous I/O *directly*. This means that spawning of the task per connection will be done *after* the preparation of connection was completed (here, the "preparation" of connection is some *asynchronous* computation for acquiring a value that implements `AsyncRead+AsyncWrite` from a "raw" connection, such as TLS handshake). If the preparation of establishing a connection takes many time, the process for successor connections cannot be started.
This PR solves this problem by explicitly handling the preparation process within the implementation of `SpawnAll` and so on. In order to abstract the preparation process, a trait `Acceptor` is newly introduced.

### Alternatives
* does not change. the "parallelization"of preparation tasks are emulated by using [`FuturesUnordered`](https://docs.rs/futures/0.1/futures/stream/futures_unordered/struct.FuturesUnordered.html) or else.
    - in this case, preparations are handled within the same task and hence they cannot be scheduled by the background.
* replaces the trait bound of incoming stream with `I::Item: Future<Item = impl AsyncRead+AsyncWrite>`.
   - it affects existing code which assumes that `I::Item: AsyncRead + AsyncWrite`.

### Compatibility Notes
It includes some *breaking* changes in the low-level server API in `hyper::server::conn`.
* add type parameters
* the associated type `<Connection<I, F, E> as Future>::Error` will be changed from `F::Error` to `hyper::Error`.