### PR TITLE
Bugfix/1720

### DIFF
--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -234,8 +234,8 @@ where
             Some(s) => s,
             None => return invalid_url(InvalidUrl::MissingAuthority, &self.handle),
         };
-        let port = match dst.uri.port() {
-            Some(port) => port,
+        let port = match dst.uri.port_part() {
+            Some(port) => port.as_u16(),
             None => if dst.uri.scheme_part() == Some(&Scheme::HTTPS) { 443 } else { 80 },
         };
 

--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -79,13 +79,15 @@ impl Destination {
     /// Get the port, if specified.
     #[inline]
     pub fn port(&self) -> Option<u16> {
-        let uri_str = match self.uri.port_part() {
-            Some(port) => String::from(port.as_str()),
-            None => String::from("80")
-        };
-        match uri_str.parse::<u16>() {
-            Ok(p) => Some(p),
-            Err(_err) => None
+         match self.uri.port_part() {
+            Some(port) => {
+                let string_port = port.as_str();
+                match string_port.parse::<u16>() {
+                    Ok(p) => Some(p),
+                    Err(_err) => None
+                }
+            },
+            None => None
         }
     }
 

--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -79,7 +79,14 @@ impl Destination {
     /// Get the port, if specified.
     #[inline]
     pub fn port(&self) -> Option<u16> {
-        self.uri.port()
+        let uri_str = match self.uri.port_part() {
+            Some(port) => String::from(port.as_str()),
+            None => String::from("80")
+        };
+        match uri_str.parse::<u16>() {
+            Ok(p) => Some(p),
+            Err(_err) => None
+        }
     }
 
     /// Update the scheme of this destination.
@@ -140,7 +147,7 @@ impl Destination {
                 .map_err(::error::Parse::from)?
         } else {
             let auth = host.parse::<uri::Authority>().map_err(::error::Parse::from)?;
-            if auth.port().is_some() {
+            if auth.port_part().is_some() { // std::uri::Authority::Uri
                 return Err(::error::Parse::Uri.into());
             }
             auth

--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -80,13 +80,7 @@ impl Destination {
     #[inline]
     pub fn port(&self) -> Option<u16> {
          match self.uri.port_part() {
-            Some(port) => {
-                let string_port = port.as_str();
-                match string_port.parse::<u16>() {
-                    Ok(p) => Some(p),
-                    Err(_err) => None
-                }
-            },
+            Some(port) => Some(port.as_u16()),
             None => None
         }
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -212,8 +212,9 @@ where C: Connect + Sync + 'static,
                 format!("{}://{}", scheme, auth)
             }
             (None, Some(auth)) if is_http_connect => {
-                let scheme = match auth.port() {
-                    Some(443) => {
+                let port = auth.port_part().unwrap();
+                let scheme = match port.as_str() {
+                    "443" => {
                         set_scheme(req.uri_mut(), Scheme::HTTPS);
                         "https"
                     },
@@ -278,7 +279,7 @@ where C: Connect + Sync + 'static,
                         .expect("HOST is always valid header name")
                         .or_insert_with(|| {
                             let hostname = uri.host().expect("authority implies host");
-                            if let Some(port) = uri.port() {
+                            if let Some(port) = uri.port_part() {
                                 let s = format!("{}:{}", hostname, port);
                                 HeaderValue::from_str(&s)
                             } else {


### PR DESCRIPTION
## Contribution

### Scope 

`client` module

### Subject

* Change port to port_part
* Keep tests as is and make test work 

### Body

The port function is deprecated so the function is port_part now. 
Keep same behavior using new function.

![image](https://user-images.githubusercontent.com/9425955/48976001-91da8c80-f04c-11e8-8d04-3da3409176c7.png)
