### PR TITLE
fix(client): fix deprecated errors on port from http

### DIFF
--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -234,8 +234,8 @@ where
             Some(s) => s,
             None => return invalid_url(InvalidUrl::MissingAuthority, &self.handle),
         };
-        let port = match dst.uri.port() {
-            Some(port) => port,
+        let port = match dst.uri.port_part() {
+            Some(port) => port.as_u16(),
             None => if dst.uri.scheme_part() == Some(&Scheme::HTTPS) { 443 } else { 80 },
         };
 

--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -79,7 +79,10 @@ impl Destination {
     /// Get the port, if specified.
     #[inline]
     pub fn port(&self) -> Option<u16> {
-        self.uri.port()
+         match self.uri.port_part() {
+            Some(port) => Some(port.as_u16()),
+            None => None
+        }
     }
 
     /// Update the scheme of this destination.
@@ -140,7 +143,7 @@ impl Destination {
                 .map_err(::error::Parse::from)?
         } else {
             let auth = host.parse::<uri::Authority>().map_err(::error::Parse::from)?;
-            if auth.port().is_some() {
+            if auth.port_part().is_some() { // std::uri::Authority::Uri
                 return Err(::error::Parse::Uri.into());
             }
             auth

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -212,8 +212,9 @@ where C: Connect + Sync + 'static,
                 format!("{}://{}", scheme, auth)
             }
             (None, Some(auth)) if is_http_connect => {
-                let scheme = match auth.port() {
-                    Some(443) => {
+                let port = auth.port_part().unwrap();
+                let scheme = match port.as_str() {
+                    "443" => {
                         set_scheme(req.uri_mut(), Scheme::HTTPS);
                         "https"
                     },
@@ -278,7 +279,7 @@ where C: Connect + Sync + 'static,
                         .expect("HOST is always valid header name")
                         .or_insert_with(|| {
                             let hostname = uri.host().expect("authority implies host");
-                            if let Some(port) = uri.port() {
+                            if let Some(port) = uri.port_part() {
                                 let s = format!("{}:{}", hostname, port);
                                 HeaderValue::from_str(&s)
                             } else {


### PR DESCRIPTION
## Contribution to  #1720

### Scope 

`client` module

### Subject

* Change port to port_part
* Keep tests as is and make test work 

### Body

The port function is deprecated so the function is port_part now. 
Keep same behavior using new function.

![image](https://user-images.githubusercontent.com/9425955/48976001-91da8c80-f04c-11e8-8d04-3da3409176c7.png)
