### PR TITLE
feat(service): export `hyper::service::MakeServiceRef`

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -65,10 +65,10 @@ use tokio_io::{AsyncRead, AsyncWrite};
 
 use body::{Body, Payload};
 use common::exec::{Exec, H2Exec, NewSvcExec};
-use service::Service;
+use service::{MakeServiceRef, Service};
 // Renamed `Http` as `Http_` for now so that people upgrading don't see an
 // error that `hyper::server::Http` is private...
-use self::conn::{Http as Http_, MakeServiceRef, NoopWatcher, SpawnAll};
+use self::conn::{Http as Http_, NoopWatcher, SpawnAll};
 use self::shutdown::{Graceful, GracefulWatcher};
 #[cfg(feature = "runtime")] use self::tcp::AddrIncoming;
 

--- a/src/server/shutdown.rs
+++ b/src/server/shutdown.rs
@@ -4,8 +4,8 @@ use tokio_io::{AsyncRead, AsyncWrite};
 use body::{Body, Payload};
 use common::drain::{self, Draining, Signal, Watch, Watching};
 use common::exec::{H2Exec, NewSvcExec};
-use service::Service;
-use super::conn::{MakeServiceRef, SpawnAll, UpgradeableConnection, Watcher};
+use service::{MakeServiceRef, Service};
+use super::conn::{SpawnAll, UpgradeableConnection, Watcher};
 
 #[allow(missing_debug_implementations)]
 pub struct Graceful<I, S, F, E> {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -33,7 +33,8 @@ mod make_service;
 mod new_service;
 mod service;
 
-pub use self::make_service::{make_service_fn, MakeService};
+pub use self::make_service::{make_service_fn, MakeService, MakeServiceRef};
+// NewService is soft-deprecated.
 #[doc(hidden)]
 pub use self::new_service::NewService;
 pub use self::service::{service_fn, service_fn_ok, Service};


### PR DESCRIPTION
It's sealed, and has a blanket implementation, and so should only be
used as bounds. Even still, its hidden from the docs.

Closes #1727 

cc @vorner

