### PR TITLE
Mention / link to reqwest in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A **fast** and **correct** HTTP implementation for Rust.
 
 **Get started** by looking over the [guides](https://hyper.rs/guides).
 
+**Hyper is a relatively low-level library, if you are looking for simple high-level HTTP client, then you may wish to consider [reqwest](https://github.com/seanmonstar/reqwest), which is built on top of this library.**
+
 ## Overview
 
 hyper is a fast, safe HTTP implementation written in and for Rust.


### PR DESCRIPTION
Many people will find `hyper` when searching for a Rust HTTP crate. Reqwest is not nearly so easy to find unless you know what you are looking for, but is what a lot of people looking for a rust http library need. Let's point them in the right direction.

I recently came across a new Rust user on Reddit who had found the hyper crate, but was trying to use libcurl bindings to make http requests because they hadn't managed to find reqwest.

