### PR TITLE
WIP: Windows (+macOS) builds on Travis-CI (addresses #1673)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,34 @@
 language: rust
-sudo: true # Required for functional IPv6 (forces VM instead of Docker).
-dist: trusty
+# sudo: true # Required for functional IPv6 (forces VM instead of Docker).
+# dist: trusty
 matrix:
     fast_finish: true
     include:
         - rust: nightly
+          os: linux
+          dist: trusty
+          sudo: required
           env: FEATURES="--no-default-features --features runtime,nightly"
         - rust: beta
+          os: linux
+          dist: trusty
+          sudo: required
           env: FEATURES="--no-default-features --features runtime,__internal_happy_eyeballs_tests"
         - rust: stable
+          os: linux
+          dist: trusty
+          sudo: required
           env: FEATURES="--no-default-features --features runtime,__internal_happy_eyeballs_tests"
         - rust: stable
+          os: linux
+          dist: trusty
+          sudo: required
           env: FEATURES="--no-default-features"
         # Minimum Supported Rust Version
         - rust: 1.26.0
+          os: linux
+          dist: trusty
+          sudo: required
           env: FEATURES="--no-default-features --features runtime" BUILD_ONLY="1"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,14 @@ matrix:
           dist: trusty
           sudo: required
           env: FEATURES="--no-default-features --features runtime" BUILD_ONLY="1"
+        # Stable on Windows
+        - rust: stable
+          os: windows
+          env: FEATURES="--no-default-features --features runtime"
+        # Stable on macOS
+        - rust: stable
+          os: osx
+          env: FEATURES="--no-default-features --features runtime"
 
 before_script:
   # Add an IPv6 config - see the corresponding Travis issue

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: rust
-# sudo: true # Required for functional IPv6 (forces VM instead of Docker).
-# dist: trusty
 matrix:
     fast_finish: true
     include:
@@ -54,4 +52,3 @@ script:
 env:
     global:
         - RUST_BACKTRACE=1
-        - secure: KipdEhZsGIrb2W0HsDbC95x8FJ1RKEWPq8uSK8wSZwGw6MtvoZDX0edfrtf4o3/skA0h84yn35ZWF/rpo1ZEesgFY1g+l+me+jtyGvMwEsXTGjNP4oNR2MrDizjO8eYDm4hRUCLEmJVvsq4j7oNVdLGHfdrcnwqk8/NxJsRzqXM=


### PR DESCRIPTION
**WIP for discussion - not working, complete, or ready to merge!**

_NOTE: This contains a number of atomic "WIP" commits that are not properly formatted as per the Contribution Guidelines, since it is necessary to push often to see what Travis-CI does with the results. My intention would be to squash this into a single properly formatted commit once we get it working, and this way it's enforced that I do so and avoids accidental merges. See the detailed commit message in each for what I was attempting at the time._

This is an attempt at working towards something that closes #1673, by moving all builds to Travis-CI. This isn't entirely working yet, but I wanted to braindump what I've found so far to avoid duplicate work in the future.

Current state as of opening this PR:

- [x] build matrixes across multiple OSes working
- [x] confirm removal of secret env variable with @seanmonstar
- [ ] get simple case windows tests passing!
- [ ] determine desired HOST and FEATURES matrix for windows (from build output, Travis Windows Rust seems to auto-rustup with `x86_64-pc-windows-msvc` based on `language: rust`, so we might have to install the others after the fact as a custom install stage if needed.)
- [ ] investigate whether `cache: cargo` can speed things up ("cache your dependencies so they are only recompiled if they or the compiler were upgraded")

0. (macOS "just works" -- yay!)

1. On the above, "confirm removal of secret env variable" relates to a a [known][1] [issue][2] with Travis-CI windows support where VMs will currently not even start if the config has a secret variable. However, it appears the secret env variable was left over from a github pages push to docs in `.travis/docs.sh`.  I *think* this may no longer be the case, as the hyper.rs website now points to docs.rs for API documentation.  (If that's the case, the script should potentially be removed as well?) I wanted to confirm this.

[1]: https://travis-ci.community/t/current-known-issues-please-read-this-before-posting-a-new-topic/264
[2]: https://travis-ci.community/t/windows-instances-hanging-before-install/250/3

2. Windows VM builds appear to be very slow. It's taking ~15 minutes to get the point where the tests even begin. So swapping over might not actually be _that_ much faster, unless we benefit greatly from increased parallelism of builds.

3. Tests on Travis Windows (at least with these feature flags) seem to have a lot of instability, haven't gotten passing just yet, and they are dying with a panic/stall/timeout rather than gracefully. I "restarted" the build a number of times (on my `mroth/hyper` fork prior to PR, so output won't appear in the travis logs for this PR), and it seems to have died at different locations. Waiting ~25 minutes each time for the error makes debugging this slow. I'm a bit stumped as to where to go next with approaching this.
