### PR TITLE
Add `Destination::try_from_uri` to allow external clients to use `Connect`

### DIFF
--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -61,6 +61,18 @@ pub(super) enum Alpn {
 }
 
 impl Destination {
+    /// Try to convert a `Uri` into a `Destination`
+    ///
+    /// # Error
+    ///
+    /// Returns an error if the uri contains no authority or
+    /// no scheme.
+    pub fn try_from_uri(uri: Uri) -> ::Result<Self> {
+        uri.authority_part().ok_or(::error::Parse::Uri)?;
+        uri.scheme_part().ok_or(::error::Parse::Uri)?;
+        Ok(Destination { uri })
+    }
+
     /// Get the protocol scheme.
     #[inline]
     pub fn scheme(&self) -> &str {
@@ -590,4 +602,3 @@ mod tests {
         assert_eq!(res2.extensions().get::<Ex2>(), Some(&Ex2("hiccup")));
     }
 }
-


### PR DESCRIPTION
This change adds a constructor field for `Destination` this allows the `Connect` trait implementors like `HttpConnector` to be used with the lower level `hyper::client::conn::*`. This was mostly needed for the first pass at the `tower-hyper` implementation and to allow it to use `HttpConnector` and other `Connect` impls as a way to build `tower_hyper::client::Connection`'s.

library for ref usage: https://github.com/LucioFranco/tower-hyper