### PR TITLE
feat(client): Implement Tower's Service for Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tokio-reactor = { version = "0.1", optional = true }
 tokio-tcp = { version = "0.1", optional = true }
 tokio-threadpool = { version = "0.1.3", optional = true }
 tokio-timer = { version = "0.2", optional = true }
+tower-service = "0.2"
 want = "0.0.6"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ extern crate time;
 #[cfg(feature = "runtime")] extern crate tokio_tcp;
 #[cfg(feature = "runtime")] extern crate tokio_threadpool;
 #[cfg(feature = "runtime")] extern crate tokio_timer;
+extern crate tower_service;
 extern crate want;
 
 #[cfg(all(test, feature = "nightly"))]


### PR DESCRIPTION
This is _relatively_ small. Open questions: 

- Should this behind a feature flag?
    - Until `DirectService` is the default in Tower?
    - ...past that point?

I _think_ additional middleware implementations should be [tower-rs/tower-hyper](https://github.com/tower-rs/tower-hyper), such as specific timeouts and retry policies. Building on that, I wonder if it makes sense to have a “batteries-included” middleware crate—I know my employer has specific best-practices around retries that are typically followed-company wide, but that probably doesn't belong in that crate.

Still to do before merging:

- [ ] Documentation and examples for Tower in Hyper