### PR TITLE
Add max_buf_size setting in the server::Builder

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -302,6 +302,14 @@ impl<I, E> Builder<I, E> {
         self
     }
 
+    /// Set the maximum buffer size.
+    ///
+    /// Default is ~ 400kb.
+    pub fn http1_max_buf_size(mut self, val: usize) -> Self {
+        self.protocol.max_buf_size(val);
+        self
+    }
+
     /// Sets the `Executor` to deal with connection tasks.
     ///
     /// Default is `tokio::spawn`.


### PR DESCRIPTION
Similarly to client::Builder::http1_max_buf_size

I am not sure for the name, should it be `http1_max_buf_size` or it applies to both h1 and h2?
