### PR TITLE
feat(service): allow `FnMut` with `service_fn`

### DIFF
--- a/src/service/make_service.rs
+++ b/src/service/make_service.rs
@@ -115,7 +115,7 @@ where
 /// ```
 pub fn make_service_fn<F, Ctx, Ret>(f: F) -> MakeServiceFn<F>
 where
-    F: Fn(&Ctx) -> Ret,
+    F: FnMut(&Ctx) -> Ret,
     Ret: IntoFuture,
 {
     MakeServiceFn {
@@ -130,7 +130,7 @@ pub struct MakeServiceFn<F> {
 
 impl<'c, F, Ctx, Ret, ReqBody, ResBody> MakeService<&'c Ctx> for MakeServiceFn<F>
 where
-    F: Fn(&Ctx) -> Ret,
+    F: FnMut(&Ctx) -> Ret,
     Ret: IntoFuture,
     Ret::Item: Service<ReqBody=ReqBody, ResBody=ResBody>,
     Ret::Error: Into<Box<StdError + Send + Sync>>,


### PR DESCRIPTION
`FnMut` is a super trait of `Fn`, so these bounds changes should not be breaking.

cc @sfackler I believe you'd asked about this before.