### PR TITLE
fix(server): add `poll_ready` to `Service` and `MakeService`

### DIFF
--- a/src/service/new_service.rs
+++ b/src/service/new_service.rs
@@ -1,6 +1,6 @@
 use std::error::Error as StdError;
 
-use futures::{Future, IntoFuture};
+use futures::{Async, Future, IntoFuture, Poll};
 
 use body::Payload;
 use super::{MakeService, Service};
@@ -28,6 +28,11 @@ pub trait NewService {
 
     /// The error type that can be returned when creating a new `Service`.
     type InitError: Into<Box<StdError + Send + Sync>>;
+
+    #[doc(hidden)]
+    fn poll_ready(&mut self) -> Poll<(), Self::InitError> {
+        Ok(Async::Ready(()))
+    }
 
     /// Create a new `Service`.
     fn new_service(&self) -> Self::Future;
@@ -62,6 +67,10 @@ where
     type Service = N::Service;
     type Future = N::Future;
     type MakeError = N::InitError;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::MakeError> {
+        NewService::poll_ready(self)
+    }
 
     fn make_service(&mut self, _: Ctx) -> Self::Future {
         self.new_service()

--- a/src/service/service.rs
+++ b/src/service/service.rs
@@ -2,7 +2,7 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::marker::PhantomData;
 
-use futures::{future, Future, IntoFuture};
+use futures::{future, Async, Future, IntoFuture, Poll};
 
 use body::Payload;
 use common::Never;
@@ -25,6 +25,15 @@ pub trait Service {
 
     /// The `Future` returned by this `Service`.
     type Future: Future<Item=Response<Self::ResBody>, Error=Self::Error>;
+
+    /// Returns `Ready` when the service is able to process requests.
+    ///
+    /// The implementation of this method is allowed to return a `Ready` even if
+    /// the service is not ready to process. In this case, the future returned
+    /// from `call` will resolve to an error.
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Ok(Async::Ready(()))
+    }
 
     /// Calls this `Service` with a request, returning a `Future` of the response.
     fn call(&mut self, req: Request<Self::ReqBody>) -> Self::Future;


### PR DESCRIPTION
This PR adds the method `poll_ready` to `Service` and `MakeService`, which provides the ability to these services for notifying the readiness whether to accept connections or requests.

These methods corresponds to `tower_service::Service::poll_ready` and prevents to ignore calling this method when using tower's services in `hyper::Server` or `hyper::server::conn::Connection`.

The added methods have the default implementation and has no effect on existing code that implements `Service`/`MakeService` directly.