### PR TITLE
feat(server): add `http2_max_concurrent_streams` builder option

### DIFF
--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -50,9 +50,8 @@ where
     B: Payload,
     E: H2Exec<S::Future, B>,
 {
-    pub(crate) fn new(io: T, service: S, exec: E) -> Server<T, S, B, E> {
-        let handshake = Builder::new()
-            .handshake(io);
+    pub(crate) fn new(io: T, service: S, builder: &Builder, exec: E) -> Server<T, S, B, E> {
+        let handshake = builder.handshake(io);
         Server {
             exec,
             state: State::Handshaking(handshake),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -302,6 +302,17 @@ impl<I, E> Builder<I, E> {
         self
     }
 
+    /// Sets the [`SETTINGS_MAX_CONCURRENT_STREAMS`][spec] option for HTTP2
+    /// connections.
+    ///
+    /// Default is no limit (`None`).
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_MAX_CONCURRENT_STREAMS
+    pub fn http2_max_concurrent_streams(mut self, max: impl Into<Option<u32>>) -> Self {
+        self.protocol.http2_max_concurrent_streams(max.into());
+        self
+    }
+
     /// Set the maximum buffer size.
     ///
     /// Default is ~ 400kb.


### PR DESCRIPTION
Closes #1772

