### PR TITLE
feat(client, server): set stream/conn. window size

### DIFF
--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -504,12 +504,9 @@ impl Builder {
         self
     }
 
-    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
-    /// connection-level flow control.
+    /// Sets the max connection-level flow control for HTTP2
     ///
     /// Default is 65,535
-    ///
-    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
     pub fn http2_initial_connection_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         if let Some(sz) = sz.into() {
             self.h2_builder.initial_connection_window_size(sz);

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use futures::{Async, Future, Poll};
 use futures::future::{self, Either, Executor};
+use h2;
 use tokio_io::{AsyncRead, AsyncWrite};
 
 use body::Payload;
@@ -77,6 +78,7 @@ pub struct Builder {
     h1_read_buf_exact_size: Option<usize>,
     h1_max_buf_size: Option<usize>,
     http2: bool,
+    h2_builder: h2::client::Builder,
 }
 
 /// A future setting up HTTP over an IO object.
@@ -431,6 +433,9 @@ impl Builder {
     /// Creates a new connection builder.
     #[inline]
     pub fn new() -> Builder {
+        let mut h2_builder = h2::client::Builder::default();
+        h2_builder.enable_push(false);
+
         Builder {
             exec: Exec::Default,
             h1_writev: true,
@@ -438,6 +443,7 @@ impl Builder {
             h1_title_case_headers: false,
             h1_max_buf_size: None,
             http2: false,
+            h2_builder,
         }
     }
 
@@ -482,6 +488,32 @@ impl Builder {
     /// Default is false.
     pub fn http2_only(&mut self, enabled: bool) -> &mut Builder {
         self.http2 = enabled;
+        self
+    }
+
+    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
+    /// stream-level flow control.
+    ///
+    /// Default is 65,535
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    pub fn http2_initial_stream_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        if let Some(sz) = sz.into() {
+            self.h2_builder.initial_window_size(sz);
+        }
+        self
+    }
+
+    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
+    /// connection-level flow control.
+    ///
+    /// Default is 65,535
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    pub fn http2_initial_connection_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        if let Some(sz) = sz.into() {
+            self.h2_builder.initial_connection_window_size(sz);
+        }
         self
     }
 
@@ -532,7 +564,7 @@ where
             let dispatch = proto::h1::Dispatcher::new(cd, conn);
             Either::A(dispatch)
         } else {
-            let h2 = proto::h2::Client::new(io, rx, self.builder.exec.clone());
+            let h2 = proto::h2::Client::new(io, rx, &self.builder.h2_builder, self.builder.exec.clone());
             Either::B(h2)
         };
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -982,12 +982,9 @@ impl Builder {
         self
     }
 
-    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
-    /// connection-level flow control.
+    /// Sets the max connection-level flow control for HTTP2
     ///
     /// Default is 65,535
-    ///
-    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
     pub fn http2_initial_connection_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         self.conn_builder.http2_initial_connection_window_size(sz.into());
         self

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -971,6 +971,28 @@ impl Builder {
         self
     }
 
+    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
+    /// stream-level flow control.
+    ///
+    /// Default is 65,535
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    pub fn http2_initial_stream_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        self.conn_builder.http2_initial_stream_window_size(sz.into());
+        self
+    }
+
+    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
+    /// connection-level flow control.
+    ///
+    /// Default is 65,535
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    pub fn http2_initial_connection_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        self.conn_builder.http2_initial_connection_window_size(sz.into());
+        self
+    }
+
     /// Sets the maximum idle connection per host allowed in the pool.
     ///
     /// Default is `usize::MAX` (no limit).

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -37,11 +37,8 @@ where
     T: AsyncRead + AsyncWrite + Send + 'static,
     B: Payload,
 {
-    pub(crate) fn new(io: T, rx: ClientRx<B>, exec: Exec) -> Client<T, B> {
-        let handshake = Builder::new()
-            // we don't expose PUSH promises yet
-            .enable_push(false)
-            .handshake(io);
+    pub(crate) fn new(io: T, rx: ClientRx<B>, builder: &Builder, exec: Exec) -> Client<T, B> {
+        let handshake = builder.handshake(io);
 
         Client {
             executor: exec,

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -239,6 +239,32 @@ impl<E> Http<E> {
         self
     }
 
+    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
+    /// stream-level flow control.
+    ///
+    /// Default is 65,535
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    pub fn http2_initial_stream_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        if let Some(sz) = sz.into() {
+            self.h2_builder.initial_window_size(sz);
+        }
+        self
+    }
+
+    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
+    /// connection-level flow control..
+    ///
+    /// Default is 65,535
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    pub fn http2_initial_connection_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        if let Some(sz) = sz.into() {
+            self.h2_builder.initial_connection_window_size(sz);
+        }
+        self
+    }
+
     /// Sets the [`SETTINGS_MAX_CONCURRENT_STREAMS`][spec] option for HTTP2
     /// connections.
     ///

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -252,12 +252,9 @@ impl<E> Http<E> {
         self
     }
 
-    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
-    /// connection-level flow control..
+    /// Sets the max connection-level flow control for HTTP2
     ///
     /// Default is 65,535
-    ///
-    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
     pub fn http2_initial_connection_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         if let Some(sz) = sz.into() {
             self.h2_builder.initial_connection_window_size(sz);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -302,6 +302,28 @@ impl<I, E> Builder<I, E> {
         self
     }
 
+    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
+    /// stream-level flow control.
+    ///
+    /// Default is 65,535
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    pub fn http2_initial_stream_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        self.protocol.http2_initial_stream_window_size(sz.into());
+        self
+    }
+
+    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
+    /// connection-level flow control.
+    ///
+    /// Default is 65,535
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    pub fn http2_initial_connection_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        self.protocol.http2_initial_connection_window_size(sz.into());
+        self
+    }
+
     /// Sets the [`SETTINGS_MAX_CONCURRENT_STREAMS`][spec] option for HTTP2
     /// connections.
     ///

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -313,12 +313,9 @@ impl<I, E> Builder<I, E> {
         self
     }
 
-    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
-    /// connection-level flow control.
+    /// Sets the max connection-level flow control for HTTP2
     ///
     /// Default is 65,535
-    ///
-    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
     pub fn http2_initial_connection_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         self.protocol.http2_initial_connection_window_size(sz.into());
         self


### PR DESCRIPTION
Add `fn http2_initial_stream_window_size` and `fn
http2_initial_connection_window_size` for client and server.

Closes #1771 

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>

