### PR TITLE
refactor(error): improve organization of `Error` kinds

### DIFF
--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -235,7 +235,7 @@ where
             },
             Err(_req) => {
                 debug!("connection was not ready");
-                let err = ::Error::new_canceled(Some("connection was not ready"));
+                let err = ::Error::new_canceled().with("connection was not ready");
                 Either::B(future::err(err))
             }
         };
@@ -262,7 +262,7 @@ where
             },
             Err(req) => {
                 debug!("connection was not ready");
-                let err = ::Error::new_canceled(Some("connection was not ready"));
+                let err = ::Error::new_canceled().with("connection was not ready");
                 Either::B(future::err((err, Some(req))))
             }
         }
@@ -322,7 +322,7 @@ where
             },
             Err(req) => {
                 debug!("connection was not ready");
-                let err = ::Error::new_canceled(Some("connection was not ready"));
+                let err = ::Error::new_canceled().with("connection was not ready");
                 Either::B(future::err((err, Some(req))))
             }
         }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -167,7 +167,7 @@ struct Envelope<T, U>(Option<(T, Callback<T, U>)>);
 impl<T, U> Drop for Envelope<T, U> {
     fn drop(&mut self) {
         if let Some((val, cb)) = self.0.take() {
-            let _ = cb.send(Err((::Error::new_canceled(None::<::Error>), Some(val))));
+            let _ = cb.send(Err((::Error::new_canceled().with("connection closed"), Some(val))));
         }
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -498,7 +498,7 @@ where C: Connect + Sync + 'static,
             let connecting = match pool.connecting(&pool_key, ver) {
                 Some(lock) => lock,
                 None => {
-                    let canceled = ::Error::new_canceled(Some("HTTP/2 connection in progress"));
+                    let canceled = ::Error::new_canceled().with("HTTP/2 connection in progress");
                     return Either::B(future::err(canceled));
                 }
             };
@@ -517,7 +517,7 @@ where C: Connect + Sync + 'static,
                             None => {
                                 // Another connection has already upgraded,
                                 // the pool checkout should finish up for us.
-                                let canceled = ::Error::new_canceled(Some("ALPN upgraded to HTTP/2"));
+                                let canceled = ::Error::new_canceled().with("ALPN upgraded to HTTP/2");
                                 return Either::B(future::err(canceled));
                             }
                         }

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -577,14 +577,14 @@ impl<T: Poolable> Checkout<T> {
                     if value.is_open() {
                         Ok(Async::Ready(Some(self.pool.reuse(&self.key, value))))
                     } else {
-                        Err(::Error::new_canceled(Some(CANCELED)))
+                        Err(::Error::new_canceled().with(CANCELED))
                     }
                 },
                 Ok(Async::NotReady) => {
                     self.waiter = Some(rx);
                     Ok(Async::NotReady)
                 },
-                Err(_canceled) => Err(::Error::new_canceled(Some(CANCELED))),
+                Err(_canceled) => Err(::Error::new_canceled().with(CANCELED)),
             }
         } else {
             Ok(Async::Ready(None))
@@ -654,7 +654,7 @@ impl<T: Poolable> Future for Checkout<T> {
         if let Some(pooled) = self.checkout() {
             Ok(Async::Ready(pooled))
         } else if !self.pool.is_enabled() {
-            Err(::Error::new_canceled(Some("pool is disabled")))
+            Err(::Error::new_canceled().with("pool is disabled"))
         } else {
             Ok(Async::NotReady)
         }

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -103,10 +103,7 @@ fn conn_reset_after_write() {
         Ok(Async::Ready(()))
     }).map_err(|e: ::std::io::Error| panic!("srv2 poll_fn error: {}", e));
     let err = rt.block_on(res2.join(srv2)).expect_err("res2");
-    match err.kind() {
-        &::error::Kind::Incomplete => (),
-        other => panic!("expected Incomplete, found {:?}", other)
-    }
+    assert!(err.is_incomplete_message(), "{:?}", err);
 }
 
 #[test]

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -31,8 +31,21 @@ pub(crate) trait Http1Transaction {
 
     fn on_error(err: &::Error) -> Option<MessageHead<Self::Outgoing>>;
 
-    fn should_error_on_parse_eof() -> bool;
-    fn should_read_first() -> bool;
+    fn is_client() -> bool {
+        !Self::is_server()
+    }
+
+    fn is_server() -> bool {
+        !Self::is_client()
+    }
+
+    fn should_error_on_parse_eof() -> bool {
+        Self::is_client()
+    }
+
+    fn should_read_first() -> bool {
+        Self::is_server()
+    }
 
     fn update_date() {}
 }

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -294,7 +294,7 @@ impl Http1Transaction for Server {
                     if wrote_len {
                         warn!("unexpected content-length found, canceling");
                         rewind(dst);
-                        return Err(::Error::new_header());
+                        return Err(::Error::new_user_header());
                     }
                     match msg.body {
                         Some(BodyLength::Known(known_len)) => {
@@ -354,7 +354,7 @@ impl Http1Transaction for Server {
                                         if fold.0 != len {
                                             warn!("multiple Content-Length values found: [{}, {}]", fold.0, len);
                                             rewind(dst);
-                                            return Err(::Error::new_header());
+                                            return Err(::Error::new_user_header());
                                         }
                                         folded = Some(fold);
                                     } else {
@@ -363,7 +363,7 @@ impl Http1Transaction for Server {
                                 } else {
                                     warn!("illegal Content-Length value: {:?}", value);
                                     rewind(dst);
-                                    return Err(::Error::new_header());
+                                    return Err(::Error::new_user_header());
                                 }
                             }
                             if let Some((len, value)) = folded {
@@ -403,7 +403,7 @@ impl Http1Transaction for Server {
                     if wrote_len {
                         warn!("unexpected transfer-encoding found, canceling");
                         rewind(dst);
-                        return Err(::Error::new_header());
+                        return Err(::Error::new_user_header());
                     }
                     // check that we actually can send a chunked body...
                     if msg.head.version == Version::HTTP_10 || !Server::can_chunked(msg.req_method, msg.head.subject) {
@@ -531,11 +531,7 @@ impl Http1Transaction for Server {
         Some(msg)
     }
 
-    fn should_error_on_parse_eof() -> bool {
-        false
-    }
-
-    fn should_read_first() -> bool {
+    fn is_server() -> bool {
         true
     }
 
@@ -692,12 +688,8 @@ impl Http1Transaction for Client {
         None
     }
 
-    fn should_error_on_parse_eof() -> bool {
+    fn is_client() -> bool {
         true
-    }
-
-    fn should_read_first() -> bool {
-        false
     }
 }
 

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -100,7 +100,7 @@ where
                         Ok(Async::Ready(Some((req, cb)))) => {
                             // check that future hasn't been canceled already
                             if cb.is_canceled() {
-                                trace!("request canceled");
+                                trace!("request callback is canceled");
                                 continue;
                             }
                             let (head, body) = req.into_parts();
@@ -159,11 +159,11 @@ where
 
                         Ok(Async::NotReady) => return Ok(Async::NotReady),
 
-                        Ok(Async::Ready(None)) |
-                        Err(_) => {
+                        Ok(Async::Ready(None)) => {
                             trace!("client::dispatch::Sender dropped");
                             return Ok(Async::Ready(Dispatched::Shutdown));
-                        }
+                        },
+                        Err(never) => match never {},
                     }
                 },
             };

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -126,7 +126,7 @@ where
                         match try_ready!(self.body_tx.poll_capacity().map_err(::Error::new_body_write)) {
                             Some(0) => {}
                             Some(_) => break,
-                            None => return Err(::Error::new_canceled(None::<::Error>)),
+                            None => return Err(::Error::new_canceled()),
                         }
                     }
                 } else {

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -708,7 +708,7 @@ where
             Ok(Async::NotReady) => return Ok(Async::NotReady),
             Err(e) => {
                 trace!("make_service closed");
-                return Err(::Error::new_user_new_service(e));
+                return Err(::Error::new_user_make_service(e));
             }
         }
 
@@ -876,8 +876,8 @@ pub(crate) mod spawn_all {
                         let conn = try_ready!(connecting
                             .poll()
                             .map_err(|err| {
-                                let err = ::Error::new_user_new_service(err);
-                                debug!("connection error: {}", err);
+                                let err = ::Error::new_user_make_service(err);
+                                debug!("connecting error: {}", err);
                             }));
                         let connected = watcher.watch(conn.with_upgrades());
                         State::Connected(connected)

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -209,7 +209,7 @@ impl Future for OnUpgrade {
                 Ok(Async::Ready(Ok(upgraded))) => Ok(Async::Ready(upgraded)),
                 Ok(Async::Ready(Err(err))) => Err(err),
                 Err(_oneshot_canceled) => Err(
-                    ::Error::new_canceled(Some(UpgradeExpected(())))
+                    ::Error::new_canceled().with(UpgradeExpected(()))
                 ),
             },
             None => Err(::Error::new_user_no_upgrade()),

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -549,7 +549,7 @@ test! {
             method: GET,
             url: "http://{addr}/err",
         },
-        error: |err| err.to_string() == "parsed HTTP message from remote is incomplete",
+        error: |err| err.is_incomplete_message(),
 }
 
 test! {


### PR DESCRIPTION
- Placed all cases of "unexpected bytes" errors into the
  `UnexpectedMessage` variant.
- Placed all cases of "unexpected EOF" errors into the
  `IncompleteMessage` variant. Description is now generic about
  "connection closed before message completed", instead of mentioning
  "request" or "response.
- Added `Error::is_incomplete_message()` accessor to help checking for
  unexpected closures.
- Renamed some variants to be clearer when viewing the `Debug` format.
- Collected all "user" errors into an internal `User` enum, to prevent
  forgetting to update the `is_user()` method.

