### PR TITLE
Fix error-handling state bug in SizedWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### v0.10.16 (2019-04-26)
+
+#### Bug Fixes
+
+* **server** HttpWriter::SizedWriter would record bytes as sent even if writing failed. It now only records successful bytes, allowing retries to work.
+
+
 ### v0.10.10 (2017-05-08)
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "hyper"
-version = "0.10.15" # remember to update html_root_url
+version = "0.10.16" # remember to update html_root_url
 description = "A modern HTTP library."
 readme = "README.md"
 homepage = "http://hyper.rs"

--- a/src/http/h1.rs
+++ b/src/http/h1.rs
@@ -820,12 +820,12 @@ impl<W: Write> Write for HttpWriter<W> {
                 let len = msg.len() as u64;
                 if len > *remaining {
                     let len = *remaining;
-                    *remaining = 0;
                     try!(w.write_all(&msg[..len as usize]));
+                    *remaining = 0;
                     Ok(len as usize)
                 } else {
-                    *remaining -= len;
                     try!(w.write_all(msg));
+                    *remaining -= len;
                     Ok(len as usize)
                 }
             },


### PR DESCRIPTION
Not sure if you still care about 0.10.x at all, but because the Iron framework uses it, and we have an app still using Iron, I've fixed a bug that was causing data truncation on slow connections.

If socket writes ever failed (e.g. with ErrorKind::WouldBlock), HttpWriter::SizedWriter would still record those bytes as sent, which would result in a truncated write. Reordering those lines as per my commit allows higher layers to properly retry writing.