### PR TITLE
chore(lib): add `dyn` keyword to trait objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
         - rust: stable
           env: FEATURES="--no-default-features"
         # Minimum Supported Rust Version
-        - rust: 1.26.0
+        - rust: 1.27.0
           env: FEATURES="--no-default-features --features runtime" BUILD_ONLY="1"
 
 before_script:

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,3 +1,4 @@
+#![deny(warnings)]
 extern crate futures;
 extern crate hyper;
 
@@ -12,7 +13,7 @@ use hyper::{Body, Method, Request, Response, Server, StatusCode};
 ///
 /// A boxed Future (trait object) is used as it is easier to understand
 /// and extend with more types. Advanced users could switch to `Either`.
-type BoxFut = Box<Future<Item = Response<Body>, Error = hyper::Error> + Send>;
+type BoxFut = Box<dyn Future<Item = Response<Body>, Error = hyper::Error> + Send>;
 
 /// This is our service handler. It receives a Request, routes on its
 /// path, and returns a Future of a Response.

--- a/examples/params.rs
+++ b/examples/params.rs
@@ -17,7 +17,7 @@ static MISSING: &[u8] = b"Missing field";
 static NOTNUMERIC: &[u8] = b"Number field is not numeric";
 
 // Using service_fn, we can turn this function into a `Service`.
-fn param_example(req: Request<Body>) -> Box<Future<Item=Response<Body>, Error=hyper::Error> + Send> {
+fn param_example(req: Request<Body>) -> Box<dyn Future<Item=Response<Body>, Error=hyper::Error> + Send> {
     match (req.method(), req.uri().path()) {
         (&Method::GET, "/") | (&Method::GET, "/post") => {
             Box::new(future::ok(Response::new(INDEX.into())))

--- a/examples/send_file.rs
+++ b/examples/send_file.rs
@@ -30,7 +30,7 @@ fn main() {
     hyper::rt::run(server);
 }
 
-type ResponseFuture = Box<Future<Item=Response<Body>, Error=io::Error> + Send>;
+type ResponseFuture = Box<dyn Future<Item=Response<Body>, Error=io::Error> + Send>;
 
 fn response_examples(req: Request<Body>) -> ResponseFuture {
     match (req.method(), req.uri().path()) {

--- a/examples/web_api.rs
+++ b/examples/web_api.rs
@@ -16,7 +16,7 @@ static INDEX: &[u8] = b"<a href=\"test.html\">test.html</a>";
 static POST_DATA: &str = r#"{"original": "data"}"#;
 
 type GenericError = Box<dyn std::error::Error + Send + Sync>;
-type ResponseFuture = Box<Future<Item=Response<Body>, Error=GenericError> + Send>;
+type ResponseFuture = Box<dyn Future<Item=Response<Body>, Error=GenericError> + Send>;
 
 fn client_request_response(client: &Client<HttpConnector>) -> ResponseFuture {
      let req = Request::builder()

--- a/src/body/payload.rs
+++ b/src/body/payload.rs
@@ -1,3 +1,5 @@
+use std::error::Error as StdError;
+
 use bytes::Buf;
 use futures::{Async, Poll};
 use http::HeaderMap;
@@ -13,7 +15,7 @@ pub trait Payload: Send + 'static {
     type Data: Buf + Send;
 
     /// The error type of this stream.
-    type Error: Into<Box<::std::error::Error + Send + Sync>>;
+    type Error: Into<Box<dyn StdError + Send + Sync>>;
 
     /// Poll for a `Data` buffer.
     ///

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -98,7 +98,7 @@ pub struct Handshake<T, B> {
 pub struct ResponseFuture {
     // for now, a Box is used to hide away the internal `B`
     // that can be returned if canceled
-    inner: Box<Future<Item=Response<Body>, Error=::Error> + Send>,
+    inner: Box<dyn Future<Item=Response<Body>, Error=::Error> + Send>,
 }
 
 /// Deconstructed parts of a `Connection`.
@@ -464,7 +464,7 @@ impl Builder {
     /// Provide an executor to execute background HTTP2 tasks.
     pub fn executor<E>(&mut self, exec: E) -> &mut Builder
     where
-        E: Executor<Box<Future<Item=(), Error=()> + Send>> + Send + Sync + 'static,
+        E: Executor<Box<dyn Future<Item=(), Error=()> + Send>> + Send + Sync + 'static,
     {
         self.exec = Exec::Executor(Arc::new(exec));
         self

--- a/src/client/connect/dns.rs
+++ b/src/client/connect/dns.rs
@@ -184,7 +184,7 @@ impl fmt::Debug for GaiAddrs {
 }
 
 #[derive(Clone)]
-struct GaiExecutor(Arc<Executor<GaiTask> + Send + Sync>);
+struct GaiExecutor(Arc<dyn Executor<GaiTask> + Send + Sync>);
 
 impl Executor<oneshot::Execute<GaiBlocking>> for GaiExecutor {
     fn execute(&self, future: oneshot::Execute<GaiBlocking>) -> Result<(), ExecuteError<oneshot::Execute<GaiBlocking>>> {

--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -27,7 +27,7 @@ pub trait Connect: Send + Sync {
     /// The connected IO Stream.
     type Transport: AsyncRead + AsyncWrite + Send + 'static;
     /// An error occured when trying to connect.
-    type Error: Into<Box<StdError + Send + Sync>>;
+    type Error: Into<Box<dyn StdError + Send + Sync>>;
     /// A Future that will resolve to the connected Transport.
     type Future: Future<Item=(Self::Transport, Connected), Error=Self::Error> + Send;
     /// Connect to a destination.
@@ -53,7 +53,7 @@ pub struct Connected {
     pub(super) extra: Option<Extra>,
 }
 
-pub(super) struct Extra(Box<ExtraInner>);
+pub(super) struct Extra(Box<dyn ExtraInner>);
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) enum Alpn {
@@ -344,7 +344,7 @@ impl fmt::Debug for Extra {
 }
 
 trait ExtraInner: Send + Sync {
-    fn clone_box(&self) -> Box<ExtraInner>;
+    fn clone_box(&self) -> Box<dyn ExtraInner>;
     fn set(&self, res: &mut Response<::Body>);
 }
 
@@ -358,7 +358,7 @@ impl<T> ExtraInner for ExtraEnvelope<T>
 where
     T: Clone + Send + Sync + 'static
 {
-    fn clone_box(&self) -> Box<ExtraInner> {
+    fn clone_box(&self) -> Box<dyn ExtraInner> {
         Box::new(self.clone())
     }
 
@@ -367,7 +367,7 @@ where
     }
 }
 
-struct ExtraChain<T>(Box<ExtraInner>, T);
+struct ExtraChain<T>(Box<dyn ExtraInner>, T);
 
 impl<T: Clone> Clone for ExtraChain<T> {
     fn clone(&self) -> Self {
@@ -379,7 +379,7 @@ impl<T> ExtraInner for ExtraChain<T>
 where
     T: Clone + Send + Sync + 'static
 {
-    fn clone_box(&self) -> Box<ExtraInner> {
+    fn clone_box(&self) -> Box<dyn ExtraInner> {
         Box::new(self.clone())
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -583,11 +583,11 @@ impl<C, B> fmt::Debug for Client<C, B> {
 /// This is returned by `Client::request` (and `Client::get`).
 #[must_use = "futures do nothing unless polled"]
 pub struct ResponseFuture {
-    inner: Box<Future<Item=Response<Body>, Error=::Error> + Send>,
+    inner: Box<dyn Future<Item=Response<Body>, Error=::Error> + Send>,
 }
 
 impl ResponseFuture {
-    fn new(fut: Box<Future<Item=Response<Body>, Error=::Error> + Send>) -> Self {
+    fn new(fut: Box<dyn Future<Item=Response<Body>, Error=::Error> + Send>) -> Self {
         Self {
             inner: fut,
         }
@@ -1030,7 +1030,7 @@ impl Builder {
     /// Provide an executor to execute background `Connection` tasks.
     pub fn executor<E>(&mut self, exec: E) -> &mut Self
     where
-        E: Executor<Box<Future<Item=(), Error=()> + Send>> + Send + Sync + 'static,
+        E: Executor<Box<dyn Future<Item=(), Error=()> + Send>> + Send + Sync + 'static,
     {
         self.conn_builder.executor(exec);
         self

--- a/src/common/exec.rs
+++ b/src/common/exec.rs
@@ -21,7 +21,7 @@ pub trait NewSvcExec<I, N, S: Service, E, W: Watcher<I, S, E>>: Clone {
 #[derive(Clone)]
 pub enum Exec {
     Default,
-    Executor(Arc<Executor<Box<Future<Item=(), Error=()> + Send>> + Send + Sync>),
+    Executor(Arc<dyn Executor<Box<dyn Future<Item=(), Error=()> + Send>> + Send + Sync>),
 }
 
 // ===== impl Exec =====

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ use h2;
 /// Result type often returned from methods that can have hyper `Error`s.
 pub type Result<T> = ::std::result::Result<T, Error>;
 
-type Cause = Box<StdError + Send + Sync>;
+type Cause = Box<dyn StdError + Send + Sync>;
 
 /// Represents errors that can occur handling HTTP streams.
 pub struct Error {
@@ -135,12 +135,12 @@ impl Error {
 
     #[doc(hidden)]
     #[cfg_attr(error_source, deprecated(note = "use Error::source instead"))]
-    pub fn cause2(&self) -> Option<&(StdError + 'static + Sync + Send)> {
+    pub fn cause2(&self) -> Option<&(dyn StdError + 'static + Sync + Send)> {
         self.inner.cause.as_ref().map(|e| &**e)
     }
 
     /// Consumes the error, returning its cause.
-    pub fn into_cause(self) -> Option<Box<StdError + Sync + Send>> {
+    pub fn into_cause(self) -> Option<Box<dyn StdError + Sync + Send>> {
         self.inner.cause
     }
 
@@ -380,12 +380,12 @@ impl StdError for Error {
     }
 
     #[cfg(error_source)]
-    fn source(&self) -> Option<&(StdError + 'static)> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         self
             .inner
             .cause
             .as_ref()
-            .map(|cause| &**cause as &(StdError + 'static))
+            .map(|cause| &**cause as &(dyn StdError + 'static))
     }
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -435,7 +435,7 @@ impl Drop for DuplexHandle {
 }
 
 #[cfg(feature = "runtime")]
-type BoxedConnectFut = Box<Future<Item=(Duplex, Connected), Error=io::Error> + Send>;
+type BoxedConnectFut = Box<dyn Future<Item=(Duplex, Connected), Error=io::Error> + Send>;
 
 #[cfg(feature = "runtime")]
 #[derive(Clone)]

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -186,15 +186,15 @@ impl ChunkedState {
         trace!("Read chunk hex size");
         let radix = 16;
         match byte!(rdr) {
-            b @ b'0'...b'9' => {
+            b @ b'0'..=b'9' => {
                 *size *= radix;
                 *size += (b - b'0') as u64;
             }
-            b @ b'a'...b'f' => {
+            b @ b'a'..=b'f' => {
                 *size *= radix;
                 *size += (b + 10 - b'a') as u64;
             }
-            b @ b'A'...b'F' => {
+            b @ b'A'..=b'F' => {
                 *size *= radix;
                 *size += (b + 10 - b'A') as u64;
             }

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -1,3 +1,5 @@
+use std::error::Error as StdError;
+
 use bytes::{Buf, Bytes};
 use futures::{Async, Future, Poll, Stream};
 use http::{Request, Response, StatusCode};
@@ -44,7 +46,7 @@ type ClientRx<B> = ::client::dispatch::Receiver<Request<B>, Response<Body>>;
 impl<D, Bs, I, T> Dispatcher<D, Bs, I, T>
 where
     D: Dispatch<PollItem=MessageHead<T::Outgoing>, PollBody=Bs, RecvItem=MessageHead<T::Incoming>>,
-    D::PollError: Into<Box<::std::error::Error + Send + Sync>>,
+    D::PollError: Into<Box<dyn StdError + Send + Sync>>,
     I: AsyncRead + AsyncWrite,
     T: Http1Transaction,
     Bs: Payload,
@@ -334,7 +336,7 @@ where
 impl<D, Bs, I, T> Future for Dispatcher<D, Bs, I, T>
 where
     D: Dispatch<PollItem=MessageHead<T::Outgoing>, PollBody=Bs, RecvItem=MessageHead<T::Incoming>>,
-    D::PollError: Into<Box<::std::error::Error + Send + Sync>>,
+    D::PollError: Into<Box<dyn StdError + Send + Sync>>,
     I: AsyncRead + AsyncWrite,
     T: Http1Transaction,
     Bs: Payload,
@@ -365,7 +367,7 @@ impl<S> Server<S> where S: Service {
 impl<S, Bs> Dispatch for Server<S>
 where
     S: Service<ReqBody=Body, ResBody=Bs>,
-    S::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    S::Error: Into<Box<dyn StdError + Send + Sync>>,
     Bs: Payload,
 {
     type PollItem = MessageHead<StatusCode>;

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -717,7 +717,7 @@ impl Client {
             101 => {
                 return Ok(Some((DecodedLength::ZERO, true)));
             },
-            100...199 => {
+            100..=199 => {
                 trace!("ignoring informational response: {}", inc.subject.as_u16());
                 return Ok(None);
             },
@@ -729,7 +729,7 @@ impl Client {
             Some(Method::HEAD) => {
                 return Ok(Some((DecodedLength::ZERO, false)));
             }
-            Some(Method::CONNECT) => if let 200...299 = inc.subject.as_u16() {
+            Some(Method::CONNECT) => if let 200..=299 = inc.subject.as_u16() {
                 return Ok(Some((DecodedLength::ZERO, true)));
             }
             Some(_) => {},

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -1,3 +1,5 @@
+use std::error::Error as StdError;
+
 use futures::{Async, Future, Poll, Stream};
 use h2::Reason;
 use h2::server::{Builder, Connection, Handshake, SendResponse};
@@ -46,7 +48,7 @@ impl<T, S, B, E> Server<T, S, B, E>
 where
     T: AsyncRead + AsyncWrite,
     S: Service<ReqBody=Body, ResBody=B>,
-    S::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    S::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: Payload,
     E: H2Exec<S::Future, B>,
 {
@@ -83,7 +85,7 @@ impl<T, S, B, E> Future for Server<T, S, B, E>
 where
     T: AsyncRead + AsyncWrite,
     S: Service<ReqBody=Body, ResBody=B>,
-    S::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    S::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: Payload,
     E: H2Exec<S::Future, B>,
 {
@@ -126,7 +128,7 @@ where
             ReqBody=Body,
             ResBody=B,
         >,
-        S::Error: Into<Box<::std::error::Error + Send + Sync>>,
+        S::Error: Into<Box<dyn StdError + Send + Sync>>,
         E: H2Exec<S::Future, B>,
     {
         if self.closing.is_none() {
@@ -203,7 +205,7 @@ where
 impl<F, B> H2Stream<F, B>
 where
     F: Future<Item=Response<B>>,
-    F::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    F::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: Payload,
 {
     fn new(fut: F, respond: SendResponse<SendBuf<B::Data>>) -> H2Stream<F, B> {
@@ -296,7 +298,7 @@ where
 impl<F, B> Future for H2Stream<F, B>
 where
     F: Future<Item=Response<B>>,
-    F::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    F::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: Payload,
 {
     type Item = ();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -54,6 +54,7 @@ pub mod conn;
 mod shutdown;
 #[cfg(feature = "runtime")] mod tcp;
 
+use std::error::Error as StdError;
 use std::fmt;
 #[cfg(feature = "runtime")] use std::net::{SocketAddr, TcpListener as StdTcpListener};
 
@@ -142,10 +143,10 @@ impl<S> Server<AddrIncoming, S> {
 impl<I, S, E, B> Server<I, S, E>
 where
     I: Stream,
-    I::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    I::Error: Into<Box<dyn StdError + Send + Sync>>,
     I::Item: AsyncRead + AsyncWrite + Send + 'static,
     S: MakeServiceRef<I::Item, ReqBody=Body, ResBody=B>,
-    S::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    S::Error: Into<Box<dyn StdError + Send + Sync>>,
     S::Service: 'static,
     B: Payload,
     E: H2Exec<<S::Service as Service>::Future, B>,
@@ -201,10 +202,10 @@ where
 impl<I, S, B, E> Future for Server<I, S, E>
 where
     I: Stream,
-    I::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    I::Error: Into<Box<dyn StdError + Send + Sync>>,
     I::Item: AsyncRead + AsyncWrite + Send + 'static,
     S: MakeServiceRef<I::Item, ReqBody=Body, ResBody=B>,
-    S::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    S::Error: Into<Box<dyn StdError + Send + Sync>>,
     S::Service: 'static,
     B: Payload,
     E: H2Exec<<S::Service as Service>::Future, B>,
@@ -398,10 +399,10 @@ impl<I, E> Builder<I, E> {
     pub fn serve<S, B>(self, new_service: S) -> Server<I, S, E>
     where
         I: Stream,
-        I::Error: Into<Box<::std::error::Error + Send + Sync>>,
+        I::Error: Into<Box<dyn StdError + Send + Sync>>,
         I::Item: AsyncRead + AsyncWrite + Send + 'static,
         S: MakeServiceRef<I::Item, ReqBody=Body, ResBody=B>,
-        S::Error: Into<Box<::std::error::Error + Send + Sync>>,
+        S::Error: Into<Box<dyn StdError + Send + Sync>>,
         S::Service: 'static,
         B: Payload,
         E: NewSvcExec<I::Item, S::Future, S::Service, E, NoopWatcher>,

--- a/src/server/shutdown.rs
+++ b/src/server/shutdown.rs
@@ -1,3 +1,5 @@
+use std::error::Error as StdError;
+
 use futures::{Async, Future, Stream, Poll};
 use tokio_io::{AsyncRead, AsyncWrite};
 
@@ -38,11 +40,11 @@ impl<I, S, F, E> Graceful<I, S, F, E> {
 impl<I, S, B, F, E> Future for Graceful<I, S, F, E>
 where
     I: Stream,
-    I::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    I::Error: Into<Box<dyn StdError + Send + Sync>>,
     I::Item: AsyncRead + AsyncWrite + Send + 'static,
     S: MakeServiceRef<I::Item, ReqBody=Body, ResBody=B>,
     S::Service: 'static,
-    S::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    S::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: Payload,
     F: Future<Item=()>,
     E: H2Exec<<S::Service as Service>::Future, B>,
@@ -109,7 +111,7 @@ where
 fn on_drain<I, S, E>(conn: &mut UpgradeableConnection<I, S, E>)
 where
     S: Service<ReqBody=Body>,
-    S::Error: Into<Box<::std::error::Error + Send + Sync>>,
+    S::Error: Into<Box<dyn StdError + Send + Sync>>,
     I: AsyncRead + AsyncWrite,
     S::ResBody: Payload + 'static,
     E: H2Exec<S::Future, S::ResBody>,

--- a/src/service/make_service.rs
+++ b/src/service/make_service.rs
@@ -15,7 +15,7 @@ pub trait MakeService<Ctx> {
     type ResBody: Payload;
 
     /// The error type that can be returned by `Service`s.
-    type Error: Into<Box<StdError + Send + Sync>>;
+    type Error: Into<Box<dyn StdError + Send + Sync>>;
 
     /// The resolved `Service` from `new_service()`.
     type Service: Service<
@@ -28,7 +28,7 @@ pub trait MakeService<Ctx> {
     type Future: Future<Item=Self::Service, Error=Self::MakeError>;
 
     /// The error type that can be returned when creating a new `Service`.
-    type MakeError: Into<Box<StdError + Send + Sync>>;
+    type MakeError: Into<Box<dyn StdError + Send + Sync>>;
 
     /// Returns `Ready` when the constructor is ready to create a new `Service`.
     ///
@@ -49,13 +49,13 @@ pub trait MakeService<Ctx> {
 pub trait MakeServiceRef<Ctx>: self::sealed::Sealed<Ctx> {
     type ReqBody: Payload;
     type ResBody: Payload;
-    type Error: Into<Box<StdError + Send + Sync>>;
+    type Error: Into<Box<dyn StdError + Send + Sync>>;
     type Service: Service<
         ReqBody=Self::ReqBody,
         ResBody=Self::ResBody,
         Error=Self::Error,
     >;
-    type MakeError: Into<Box<StdError + Send + Sync>>;
+    type MakeError: Into<Box<dyn StdError + Send + Sync>>;
     type Future: Future<Item=Self::Service, Error=Self::MakeError>;
 
     // Acting like a #[non_exhaustive] for associated types of this trait.
@@ -77,8 +77,8 @@ pub trait MakeServiceRef<Ctx>: self::sealed::Sealed<Ctx> {
 impl<T, Ctx, E, ME, S, F, IB, OB> MakeServiceRef<Ctx> for T
 where
     T: for<'a> MakeService<&'a Ctx, Error=E, MakeError=ME, Service=S, Future=F, ReqBody=IB, ResBody=OB>,
-    E: Into<Box<StdError + Send + Sync>>,
-    ME: Into<Box<StdError + Send + Sync>>,
+    E: Into<Box<dyn StdError + Send + Sync>>,
+    ME: Into<Box<dyn StdError + Send + Sync>>,
     S: Service<ReqBody=IB, ResBody=OB, Error=E>,
     F: Future<Item=S, Error=ME>,
     IB: Payload,
@@ -105,8 +105,8 @@ where
 impl<T, Ctx, E, ME, S, F, IB, OB> self::sealed::Sealed<Ctx> for T
 where
     T: for<'a> MakeService<&'a Ctx, Error=E, MakeError=ME, Service=S, Future=F, ReqBody=IB, ResBody=OB>,
-    E: Into<Box<StdError + Send + Sync>>,
-    ME: Into<Box<StdError + Send + Sync>>,
+    E: Into<Box<dyn StdError + Send + Sync>>,
+    ME: Into<Box<dyn StdError + Send + Sync>>,
     S: Service<ReqBody=IB, ResBody=OB, Error=E>,
     F: Future<Item=S, Error=ME>,
     IB: Payload,
@@ -166,7 +166,7 @@ where
     F: FnMut(&Ctx) -> Ret,
     Ret: IntoFuture,
     Ret::Item: Service<ReqBody=ReqBody, ResBody=ResBody>,
-    Ret::Error: Into<Box<StdError + Send + Sync>>,
+    Ret::Error: Into<Box<dyn StdError + Send + Sync>>,
     ReqBody: Payload,
     ResBody: Payload,
 {

--- a/src/service/new_service.rs
+++ b/src/service/new_service.rs
@@ -14,7 +14,7 @@ pub trait NewService {
     type ResBody: Payload;
 
     /// The error type that can be returned by `Service`s.
-    type Error: Into<Box<StdError + Send + Sync>>;
+    type Error: Into<Box<dyn StdError + Send + Sync>>;
 
     /// The resolved `Service` from `new_service()`.
     type Service: Service<
@@ -27,7 +27,7 @@ pub trait NewService {
     type Future: Future<Item=Self::Service, Error=Self::InitError>;
 
     /// The error type that can be returned when creating a new `Service`.
-    type InitError: Into<Box<StdError + Send + Sync>>;
+    type InitError: Into<Box<dyn StdError + Send + Sync>>;
 
     #[doc(hidden)]
     fn poll_ready(&mut self) -> Poll<(), Self::InitError> {
@@ -42,7 +42,7 @@ impl<F, R, S> NewService for F
 where
     F: Fn() -> R,
     R: IntoFuture<Item=S>,
-    R::Error: Into<Box<StdError + Send + Sync>>,
+    R::Error: Into<Box<dyn StdError + Send + Sync>>,
     S: Service,
 {
     type ReqBody = S::ReqBody;

--- a/src/service/service.rs
+++ b/src/service/service.rs
@@ -21,7 +21,7 @@ pub trait Service {
     /// Note: Returning an `Error` to a hyper server will cause the connection
     /// to be abruptly aborted. In most cases, it is better to return a `Response`
     /// with a 4xx or 5xx status code.
-    type Error: Into<Box<StdError + Send + Sync>>;
+    type Error: Into<Box<dyn StdError + Send + Sync>>;
 
     /// The `Future` returned by this `Service`.
     type Future: Future<Item=Response<Self::ResBody>, Error=Self::Error>;
@@ -104,7 +104,7 @@ where
     F: FnMut(Request<ReqBody>) -> Ret,
     ReqBody: Payload,
     Ret: IntoFuture<Item=Response<ResBody>>,
-    Ret::Error: Into<Box<StdError + Send + Sync>>,
+    Ret::Error: Into<Box<dyn StdError + Send + Sync>>,
     ResBody: Payload,
 {
     type ReqBody = ReqBody;

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -26,7 +26,7 @@ use common::io::Rewind;
 /// Alternatively, if the exact type is known, this can be deconstructed
 /// into its parts.
 pub struct Upgraded {
-    io: Rewind<Box<Io + Send>>,
+    io: Rewind<Box<dyn Io + Send>>,
 }
 
 /// A future for a possible HTTP upgrade.
@@ -85,7 +85,7 @@ pub(crate) trait Io: AsyncRead + AsyncWrite + 'static {
     }
 }
 
-impl Io + Send {
+impl dyn Io + Send {
     fn __hyper_is<T: Io>(&self) -> bool {
         let t = TypeId::of::<T>();
         self.__hyper_type_id() == t
@@ -95,7 +95,7 @@ impl Io + Send {
         if self.__hyper_is::<T>() {
             // Taken from `std::error::Error::downcast()`.
             unsafe {
-                let raw: *mut Io = Box::into_raw(self);
+                let raw: *mut dyn Io = Box::into_raw(self);
                 Ok(Box::from_raw(raw as *mut T))
             }
         } else {
@@ -109,7 +109,7 @@ impl<T: AsyncRead + AsyncWrite + 'static> Io for T {}
 // ===== impl Upgraded =====
 
 impl Upgraded {
-    pub(crate) fn new(io: Box<Io + Send>, read_buf: Bytes) -> Self {
+    pub(crate) fn new(io: Box<dyn Io + Send>, read_buf: Bytes) -> Self {
         Upgraded {
             io: Rewind::new_buffered(io, read_buf),
         }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1565,7 +1565,7 @@ mod dispatch_impl {
     impl Connect for DebugConnector {
         type Transport = DebugStream;
         type Error = io::Error;
-        type Future = Box<Future<Item = (DebugStream, Connected), Error = io::Error> + Send>;
+        type Future = Box<dyn Future<Item = (DebugStream, Connected), Error = io::Error> + Send>;
 
         fn connect(&self, dst: Destination) -> Self::Future {
             self.connects.fetch_add(1, Ordering::SeqCst);
@@ -2178,7 +2178,7 @@ mod conn {
 }
 
 trait FutureHyperExt: Future {
-    fn expect<E>(self, msg: &'static str) -> Box<Future<Item=Self::Item, Error=E>>;
+    fn expect<E>(self, msg: &'static str) -> Box<dyn Future<Item=Self::Item, Error=E>>;
 }
 
 impl<F> FutureHyperExt for F
@@ -2186,7 +2186,7 @@ where
     F: Future + 'static,
     F::Error: ::std::fmt::Debug,
 {
-    fn expect<E>(self, msg: &'static str) -> Box<Future<Item=Self::Item, Error=E>> {
+    fn expect<E>(self, msg: &'static str) -> Box<dyn Future<Item=Self::Item, Error=E>> {
         Box::new(self.map_err(move |e| panic!("expect: {}; error={:?}", msg, e)))
     }
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1779,7 +1779,7 @@ impl Serve {
     }
 }
 
-type BoxError = Box<::std::error::Error + Send + Sync>;
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 struct ReplyBuilder<'a> {
     tx: &'a spmc::Sender<Reply>,
@@ -1853,7 +1853,7 @@ enum Msg {
 }
 
 impl TestService {
-    fn call(&self, req: Request<Body>) -> Box<Future<Item=Response<Body>, Error=BoxError> + Send> {
+    fn call(&self, req: Request<Body>) -> Box<dyn Future<Item=Response<Body>, Error=BoxError> + Send> {
         let tx1 = self.tx.clone();
         let tx2 = self.tx.clone();
         let replies = self.reply.clone();

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -212,7 +212,7 @@ macro_rules! __internal_headers_eq {
                 $pat => (),
                 other => panic!("headers[{}] was not {}: {:?}", stringify!($name), stringify!($pat), other),
             }
-        }) as ::std::sync::Arc<Fn(&::hyper::HeaderMap) + Send + Sync>
+        }) as ::std::sync::Arc<dyn Fn(&::hyper::HeaderMap) + Send + Sync>
     };
     (@val $name: expr, NONE) => {
         __internal_headers_eq!(@pat $name, None);
@@ -228,7 +228,7 @@ macro_rules! __internal_headers_eq {
             } else {
                 assert_eq!(__hdrs.get($name), None, stringify!($name));
             }
-        }) as ::std::sync::Arc<Fn(&::hyper::HeaderMap) + Send + Sync>
+        }) as ::std::sync::Arc<dyn Fn(&::hyper::HeaderMap) + Send + Sync>
     });
     ($headers:ident, { $($name:expr => $val:tt,)* }) => {
         $(
@@ -289,7 +289,7 @@ pub struct __SRes {
     pub headers: HeaderMap,
 }
 
-pub type __HeadersEq = Vec<Arc<Fn(&HeaderMap) + Send + Sync>>;
+pub type __HeadersEq = Vec<Arc<dyn Fn(&HeaderMap) + Send + Sync>>;
 
 pub struct __TestConfig {
     pub client_version: usize,
@@ -426,7 +426,7 @@ pub fn __run_test(cfg: __TestConfig) {
     });
 
 
-    let client_futures: Box<Future<Item=(), Error=()> + Send> = if cfg.parallel {
+    let client_futures: Box<dyn Future<Item=(), Error=()> + Send> = if cfg.parallel {
         let mut client_futures = vec![];
         for (creq, cres) in cfg.client_msgs {
             client_futures.push(make_request(&client, creq, cres));
@@ -434,7 +434,7 @@ pub fn __run_test(cfg: __TestConfig) {
         drop(client);
         Box::new(future::join_all(client_futures).map(|_| ()))
     } else {
-        let mut client_futures: Box<Future<Item=Client<HttpConnector>, Error=()> + Send> =
+        let mut client_futures: Box<dyn Future<Item=Client<HttpConnector>, Error=()> + Send> =
             Box::new(future::ok(client));
         for (creq, cres) in cfg.client_msgs {
             let mk_request = make_request.clone();


### PR DESCRIPTION
Requires Rust 1.27.

