### PR TITLE
publicize connection pool api

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -99,7 +99,7 @@ use self::pool::{Key as PoolKey, Pool, Poolable, Pooled, Reservation};
 pub mod conn;
 pub mod connect;
 pub(crate) mod dispatch;
-mod pool;
+pub mod pool;
 #[cfg(test)]
 mod tests;
 
@@ -395,7 +395,8 @@ where C: Connect + Sync + 'static,
         })
     }
 
-    fn connection_for(&self, uri: Uri, pool_key: PoolKey)
+    /// FIXME: document me
+    pub fn connection_for(&self, uri: Uri, pool_key: PoolKey)
         -> impl Future<Item=Pooled<PoolClient<B>>, Error=ClientError<B>>
     {
         // This actually races 2 different futures to try to get a ready
@@ -615,8 +616,9 @@ impl Future for ResponseFuture {
 }
 
 // FIXME: allow() required due to `impl Trait` leaking types to this lint
+/// FIXME: document me
 #[allow(missing_debug_implementations)]
-struct PoolClient<B> {
+pub struct PoolClient<B> {
     conn_info: Connected,
     tx: PoolTx<B>,
 }
@@ -661,7 +663,8 @@ impl<B> PoolClient<B> {
 }
 
 impl<B: Payload + 'static> PoolClient<B> {
-    fn send_request_retryable(&mut self, req: Request<B>) -> impl Future<Item = Response<Body>, Error = (::Error, Option<Request<B>>)>
+    /// FIXME: document me
+    pub fn send_request_retryable(&mut self, req: Request<B>) -> impl Future<Item = Response<Body>, Error = (::Error, Option<Request<B>>)>
     where
         B: Send,
     {
@@ -709,10 +712,9 @@ where
         self.is_http2()
     }
 }
-
-// FIXME: allow() required due to `impl Trait` leaking types to this lint
-#[allow(missing_debug_implementations)]
-enum ClientError<B> {
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub enum ClientError<B> {
     Normal(::Error),
     Canceled {
         connection_reused: bool,

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -1,3 +1,5 @@
+//! HTTP Client Pool
+
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::ops::{Deref, DerefMut};
@@ -19,17 +21,21 @@ pub(super) struct Pool<T> {
     inner: Option<Arc<Mutex<PoolInner<T>>>>,
 }
 
-// Before using a pooled connection, make sure the sender is not dead.
-//
-// This is a trait to allow the `client::pool::tests` to work for `i32`.
-//
-// See https://github.com/hyperium/hyper/issues/1429
-pub(super) trait Poolable: Send + Sized + 'static {
+/// Before using a pooled connection, make sure the sender is not dead.
+///
+/// This is a trait to allow the `client::pool::tests` to work for `i32`.
+///
+/// See https://github.com/hyperium/hyper/issues/1429
+pub trait Poolable: Send + Sized + 'static {
+    /// FIXME: document me
     fn is_open(&self) -> bool;
+
     /// Reserve this connection.
     ///
     /// Allows for HTTP/2 to return a shared reservation.
     fn reserve(self) -> Reservation<Self>;
+
+    /// FIXME: document me
     fn can_share(&self) -> bool;
 }
 
@@ -40,7 +46,7 @@ pub(super) trait Poolable: Send + Sized + 'static {
 /// used for multiple requests.
 // FIXME: allow() required due to `impl Trait` leaking types to this lint
 #[allow(missing_debug_implementations)]
-pub(super) enum Reservation<T> {
+pub enum Reservation<T> {
     /// This connection could be used multiple times, the first one will be
     /// reinserted into the `idle` pool, and the second will be given to
     /// the `Checkout`.
@@ -487,7 +493,7 @@ impl<T> Clone for Pool<T> {
 
 /// A wrapped poolable value that tries to reinsert to the Pool on Drop.
 // Note: The bounds `T: Poolable` is needed for the Drop impl.
-pub(super) struct Pooled<T: Poolable> {
+pub struct Pooled<T: Poolable> {
     value: Option<T>,
     is_reused: bool,
     key: Key,
@@ -495,10 +501,12 @@ pub(super) struct Pooled<T: Poolable> {
 }
 
 impl<T: Poolable> Pooled<T> {
+    /// FIXME: document me
     pub fn is_reused(&self) -> bool {
         self.is_reused
     }
 
+    /// FIXME: document me
     pub fn is_pool_enabled(&self) -> bool {
         self.pool.0.is_some()
     }


### PR DESCRIPTION
Can we make this stuff public? It's useful! I'm using it here: https://github.com/nlevitt/monie
Or is there a better way?

If you are amenable to this change, I can take a pass at documenting the "FIXME: document me" stuff.