### PR TITLE
style(client) `HttpConnector`: use consistent naming - s/buf/buffer/

### DIFF
--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -35,8 +35,8 @@ pub struct HttpConnector<R = GaiResolver> {
     nodelay: bool,
     resolver: R,
     reuse_address: bool,
-    send_buf_size: Option<usize>,
-    recv_buf_size: Option<usize>,
+    send_buffer_size: Option<usize>,
+    recv_buffer_size: Option<usize>,
 }
 
 /// Extra information about the transport when an HttpConnector is used.
@@ -126,8 +126,8 @@ impl<R> HttpConnector<R> {
             nodelay: false,
             resolver,
             reuse_address: false,
-            send_buf_size: None,
-            recv_buf_size: None,
+            send_buffer_size: None,
+            recv_buffer_size: None,
         }
     }
 
@@ -167,14 +167,14 @@ impl<R> HttpConnector<R> {
 
     /// Sets the value of the SO_SNDBUF option on the socket.
     #[inline]
-    pub fn set_send_buf_size(&mut self, size: Option<usize>) {
-        self.send_buf_size = size;
+    pub fn set_send_buffer_size(&mut self, size: Option<usize>) {
+        self.send_buffer_size = size;
     }
 
     /// Sets the value of the SO_RCVBUF option on the socket.
     #[inline]
-    pub fn set_recv_buf_size(&mut self, size: Option<usize>) {
-        self.recv_buf_size = size;
+    pub fn set_recv_buffer_size(&mut self, size: Option<usize>) {
+        self.recv_buffer_size = size;
     }
 
     /// Set that all sockets are bound to the configured address before connection.
@@ -264,8 +264,8 @@ where
             nodelay: self.nodelay,
             port,
             reuse_address: self.reuse_address,
-            send_buf_size: self.send_buf_size,
-            recv_buf_size: self.recv_buf_size,
+            send_buffer_size: self.send_buffer_size,
+            recv_buffer_size: self.recv_buffer_size,
         }
     }
 }
@@ -287,8 +287,8 @@ fn invalid_url<R: Resolve>(err: InvalidUrl, handle: &Option<Handle>) -> HttpConn
         port: 0,
         happy_eyeballs_timeout: None,
         reuse_address: false,
-        send_buf_size: None,
-        recv_buf_size: None,
+        send_buffer_size: None,
+        recv_buffer_size: None,
     }
 }
 
@@ -324,8 +324,8 @@ pub struct HttpConnecting<R: Resolve = GaiResolver> {
     nodelay: bool,
     port: u16,
     reuse_address: bool,
-    send_buf_size: Option<usize>,
-    recv_buf_size: Option<usize>,
+    send_buffer_size: Option<usize>,
+    recv_buffer_size: Option<usize>,
 }
 
 enum State<R: Resolve> {
@@ -375,11 +375,11 @@ impl<R: Resolve> Future for HttpConnecting<R> {
                         sock.set_keepalive(Some(dur))?;
                     }
 
-                    if let Some(size) = self.send_buf_size {
+                    if let Some(size) = self.send_buffer_size {
                         sock.set_send_buffer_size(size)?;
                     }
 
-                    if let Some(size) = self.recv_buf_size {
+                    if let Some(size) = self.recv_buffer_size {
                         sock.set_recv_buffer_size(size)?;
                     }
 


### PR DESCRIPTION
Signed-off-by: Dietmar Maurer <dietmar@proxmox.com>

