### PR TITLE
Added basic azure pipelines configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,49 @@
+trigger: ["master"]
+pr: ["master"]
+
+variables:
+  features: ''
+  bench: 'false'
+
+strategy:
+  matrix:
+    windows-nightly:
+      imageName: 'vs2017-win2016'
+      rust: nightly
+    mac-nightly:
+      imageName: 'macos-10.13'
+      rust: nightly
+      bench: 'true'
+    # linux-stable:
+    #   imageName: 'ubuntu-16.04'
+    #   rust: stable
+    #   features: '--no-default-features --features runtime,__internal_happy_eyeballs_tests'
+    # linux-stable-no-features:
+    #   imageName: 'ubuntu-16.04'
+    #   rust: stable
+    #   features: '--no-default-features'
+    # linux-beta:
+    #   imageName: 'ubuntu-16.04'
+    #   rust: beta
+    #   features: '--no-default-features --features runtime,__internal_happy_eyeballs_tests'
+    linux-nightly:
+      imageName: 'ubuntu-16.04'
+      rust: nightly
+      features: '--no-default-features --features runtime,nightly'
+      bench: 'true'
+    # linux-minimum-supported-version:
+    #   imageName: 'ubuntu-16.04'
+    #   rust: stable
+    #   features: '--no-default-features --features runtime'
+
+pool:
+  vmImage: $(imageName)
+
+steps:
+  - template: ci/azure-install-rust.yml
+    parameters:
+      rust_version: $(rust)
+  - template: ci/azure-test.yml
+    parameters:
+      features: $(features)
+      bench: $(bench)

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -1,0 +1,33 @@
+steps:
+  # Linux and macOS.
+  - script: |
+      set -e
+      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
+      export PATH=$PATH:$HOME/.cargo/bin
+      rustup toolchain install $RUSTUP_TOOLCHAIN
+      rustup default $RUSTUP_TOOLCHAIN
+      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+    env:
+      RUSTUP_TOOLCHAIN: ${{parameters.rust_version}}
+    displayName: "Install rust (*nix)"
+    condition: ne( variables['Agent.OS'], 'Windows_NT' )
+
+  # Windows.
+  - script: |
+      curl -sSf -o rustup-init.exe https://win.rustup.rs
+      rustup-init.exe -y --default-toolchain none
+      set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+      rustup toolchain install %RUSTUP_TOOLCHAIN%
+      rustup default %RUSTUP_TOOLCHAIN%
+      echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
+    env:
+      RUSTUP_TOOLCHAIN: ${{parameters.rust_version}}
+    displayName: "Install rust (Windows)"
+    condition: eq( variables['Agent.OS'], 'Windows_NT' )
+
+  # All platforms.
+  - script: |
+        rustup toolchain list
+        rustc -Vv
+        cargo -V
+    displayName: Query rust and cargo versions

--- a/ci/azure-test.yml
+++ b/ci/azure-test.yml
@@ -1,0 +1,36 @@
+steps:
+  # Linux and macOS.
+  - script: |
+      set -e
+      cargo build $FEATURES
+      cargo test $FEATURES
+    env:
+      FEATURES: ${{parameters.features}}
+    displayName: "Build & Test (*nix)"
+    condition: ne( variables['Agent.OS'], 'Windows_NT' )
+
+  # Windows.
+  - script: |
+      cargo build %FEATURES%
+      cargo test %FEATURES%
+    env:
+      FEATURES: ${{parameters.features}}
+    displayName: "Build & Test (Windows)"
+    condition: eq( variables['Agent.OS'], 'Windows_NT' )
+
+
+  # Linux and macOS.
+  - ${{ if eq(parameters.bench, 'true') }}:
+    - script: cargo bench $FEATURES
+      env:
+        FEATURES: ${{parameters.features}}
+      displayName: "Benchmark (*nix)"
+      condition: ne( variables['Agent.OS'], 'Windows_NT' )
+
+  # Windows.
+  - ${{ if eq(parameters.bench, 'true') }}:
+    - script: cargo bench %FEATURES%
+      env:
+        FEATURES: ${{parameters.features}}
+      displayName: "Benchmark (Windows)"
+      condition: eq( variables['Agent.OS'], 'Windows_NT' )


### PR DESCRIPTION
References #1673 

I've added a fairly basic azure pipelines configuration that tests stable on windows, and mac, and tests stable, beta, and nightly on linux.

I ran a manual build in a test azure project and there were 2 failures:
* linux-nightly: Looks like a trivial fix. Just some deprecation warnings.
* windows: 2 tests hung. I'm not sure what the cause was exactly, I'm going to do some more investigating. The failing test were:
    * http2_body_user_error_sends_reset_reason
    * http2_service_error_sends_reset_reason
