### PR TITLE
Update doc tests of service to async/await

### DIFF
--- a/src/service/service.rs
+++ b/src/service/service.rs
@@ -43,10 +43,11 @@ pub trait Service {
 /// # Example
 ///
 /// ```rust
+/// # #![feature(async_await)]
 /// use hyper::{Body, Request, Response, Version};
 /// use hyper::service::service_fn;
 ///
-/// let service = service_fn(|req: Request<Body>| {
+/// let service = service_fn(|req: Request<Body>| async move{
 ///     if req.version() == Version::HTTP_11 {
 ///         Ok(Response::new(Body::from("Hello World")))
 ///     } else {


### PR DESCRIPTION
Ref: https://github.com/hyperium/hyper/issues/1850

* Use `hyper:rt::main` (reexport of `tokio::main` macro) to wrap main function.
* Use `async move` block to return a `Future`.

## How to test

- [ ] Run `cargo doc --open` to check if examples are rendered properly.
- [ ] Run `cargo test --doc -- service`. It should output something like

```
running 2 tests
test src/service/make_service.rs - service::make_service::make_service_fn (line 120) ... ok
test src/service/service.rs - service::service::service_fn (line 45) ... ok
```
