### PR TITLE
Update doc tests of client to async/await

### DIFF
--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -191,16 +191,13 @@ where
     /// # Example
     ///
     /// ```
-    /// # extern crate futures;
-    /// # extern crate hyper;
-    /// # extern crate http;
+    /// # #![feature(async_await)]
     /// # use http::header::HOST;
     /// # use hyper::client::conn::SendRequest;
     /// # use hyper::Body;
-    /// use futures::Future;
     /// use hyper::Request;
     ///
-    /// # fn doc(mut tx: SendRequest<Body>) {
+    /// # async fn doc(mut tx: SendRequest<Body>) -> hyper::Result<()> {
     /// // build a Request
     /// let req = Request::builder()
     ///     .uri("/foo/bar")
@@ -208,13 +205,11 @@ where
     ///     .body(Body::empty())
     ///     .unwrap();
     ///
-    /// // send it and get a future back
-    /// let fut = tx.send_request(req)
-    ///     .map(|res| {
-    ///         // got the Response
-    ///         assert!(res.status().is_success());
-    ///     });
-    /// # drop(fut);
+    /// // send it and await a Response
+    /// let res = tx.send_request(req).await?;
+    /// // assert the Response
+    /// assert!(res.status().is_success());
+    /// # Ok(())
     /// # }
     /// # fn main() {}
     /// ```

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -46,21 +46,23 @@ pub struct HttpConnector<R = GaiResolver> {
 /// # Example
 ///
 /// ```
+/// # #![feature(async_await)]
+/// # async fn doc() -> hyper::Result<()> {
 /// use hyper::Uri;
 /// use hyper::client::{Client, connect::HttpInfo};
-/// use hyper::rt::Future;
 ///
 /// let client = Client::new();
+/// let uri = Uri::from_static("http://example.com");
 ///
-/// let fut = client.get(Uri::from_static("http://example.local"))
-///     .inspect(|resp| {
-///         resp
-///             .extensions()
-///             .get::<HttpInfo>()
-///             .map(|info| {
-///                 println!("remote addr = {}", info.remote_addr());
-///             });
+/// let res = client.get(uri).await?;
+/// res
+///     .extensions()
+///     .get::<HttpInfo>()
+///     .map(|info| {
+///         println!("remote addr = {}", info.remote_addr());
 ///     });
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Note


### PR DESCRIPTION
## What

Reference https://github.com/hyperium/hyper/issues/1850

* Remove unnecessary `extern crate`.
* Remove unnecessary import such as `futures::Future`, `hyper::rt::Future`. 
* Use `async fn` and `await` syntax instead of `futures` operators.

## How to test

- [ ] Run `cargo doc --open` to check if examples are rendered properly.
- [ ] Run `cargo test --doc -- src/client`. It should output something like

```rust
running 10 tests
test src/client/conn.rs - client::conn::SendRequest<B>::send_request (line 193) ... ok
test src/client/connect/mod.rs - client::connect::Destination::set_port (line 172) ... ok
test src/client/connect/mod.rs - client::connect::Destination::set_host (line 131) ... ok
test src/client/connect/http.rs - client::connect::http::HttpInfo (line 48) ... ok
test src/client/mod.rs - client::Client<(), Body>::builder (line 140) ... ok
test src/client/mod.rs - client::Builder (line 824) ... ok
test src/client/connect/mod.rs - client::connect::Destination::set_scheme (line 104) ... ok
test src/client/mod.rs - client (line 29) ... ok
test src/client/mod.rs - client::Client<C, B>::get (line 178) ... ok
test src/client/mod.rs - client::Client<C, B>::request (line 208) ... ok
```
