### PR TITLE
Update doc tests to async/await

### DIFF
--- a/src/body/body.rs
+++ b/src/body/body.rs
@@ -129,17 +129,16 @@ impl Body {
     /// # Example
     ///
     /// ```
-    /// # extern crate futures;
-    /// # extern crate hyper;
     /// # use hyper::Body;
+    /// # use futures_util;
     /// # fn main() {
-    /// let chunks = vec![
-    ///     "hello",
-    ///     " ",
-    ///     "world",
+    /// let chunks: Vec<Result<_, ::std::io::Error>> = vec![
+    ///     Ok("hello"),
+    ///     Ok(" "),
+    ///     Ok("world"),
     /// ];
     ///
-    /// let stream = futures::stream::iter_ok::<_, ::std::io::Error>(chunks);
+    /// let stream = futures_util::stream::iter(chunks);
     ///
     /// let body = Body::wrap_stream(stream);
     /// # }

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -191,16 +191,13 @@ where
     /// # Example
     ///
     /// ```
-    /// # extern crate futures;
-    /// # extern crate hyper;
-    /// # extern crate http;
+    /// # #![feature(async_await)]
     /// # use http::header::HOST;
     /// # use hyper::client::conn::SendRequest;
     /// # use hyper::Body;
-    /// use futures::Future;
     /// use hyper::Request;
     ///
-    /// # fn doc(mut tx: SendRequest<Body>) {
+    /// # async fn doc(mut tx: SendRequest<Body>) -> hyper::Result<()> {
     /// // build a Request
     /// let req = Request::builder()
     ///     .uri("/foo/bar")
@@ -208,13 +205,11 @@ where
     ///     .body(Body::empty())
     ///     .unwrap();
     ///
-    /// // send it and get a future back
-    /// let fut = tx.send_request(req)
-    ///     .map(|res| {
-    ///         // got the Response
-    ///         assert!(res.status().is_success());
-    ///     });
-    /// # drop(fut);
+    /// // send it and await a Response
+    /// let res = tx.send_request(req).await?;
+    /// // assert the Response
+    /// assert!(res.status().is_success());
+    /// # Ok(())
     /// # }
     /// # fn main() {}
     /// ```

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -46,21 +46,23 @@ pub struct HttpConnector<R = GaiResolver> {
 /// # Example
 ///
 /// ```
+/// # #![feature(async_await)]
+/// # async fn doc() -> hyper::Result<()> {
 /// use hyper::Uri;
 /// use hyper::client::{Client, connect::HttpInfo};
-/// use hyper::rt::Future;
 ///
 /// let client = Client::new();
+/// let uri = Uri::from_static("http://example.com");
 ///
-/// let fut = client.get(Uri::from_static("http://example.local"))
-///     .inspect(|resp| {
-///         resp
-///             .extensions()
-///             .get::<HttpInfo>()
-///             .map(|info| {
-///                 println!("remote addr = {}", info.remote_addr());
-///             });
+/// let res = client.get(uri).await?;
+/// res
+///     .extensions()
+///     .get::<HttpInfo>()
+///     .map(|info| {
+///         println!("remote addr = {}", info.remote_addr());
 ///     });
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Note

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -331,31 +331,25 @@ impl<E> Http<E> {
     /// # Example
     ///
     /// ```
-    /// # extern crate hyper;
-    /// # extern crate tokio_io;
-    /// # #[cfg(feature = "runtime")]
-    /// # extern crate tokio;
+    /// # #![feature(async_await)]
     /// # use hyper::{Body, Request, Response};
     /// # use hyper::service::Service;
     /// # use hyper::server::conn::Http;
+    /// # #[cfg(feature = "runtime")]
     /// # use tokio_io::{AsyncRead, AsyncWrite};
     /// # #[cfg(feature = "runtime")]
-    /// # fn run<I, S>(some_io: I, some_service: S)
+    /// # async fn run<I, S>(some_io: I, some_service: S)
     /// # where
-    /// #     I: AsyncRead + AsyncWrite + Send + 'static,
+    /// #     I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     /// #     S: Service<ReqBody=Body, ResBody=Body> + Send + 'static,
     /// #     S::Future: Send
     /// # {
-    /// # use hyper::rt::Future;
-    /// # use tokio::reactor::Handle;
     /// let http = Http::new();
     /// let conn = http.serve_connection(some_io, some_service);
     ///
-    /// let fut = conn.map_err(|e| {
+    /// if let Err(e) = conn.await {
     ///     eprintln!("server connection error: {}", e);
-    /// });
-    ///
-    /// hyper::rt::spawn(fut);
+    /// }
     /// # }
     /// # fn main() {}
     /// ```

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -378,26 +378,28 @@ impl<I, E> Builder<I, E> {
     /// # Example
     ///
     /// ```
-    /// # extern crate hyper;
+    /// # #![feature(async_await)]
+    /// # #[cfg(not(feature = "runtime"))]
     /// # fn main() {}
     /// # #[cfg(feature = "runtime")]
-    /// # fn run() {
-    /// use hyper::{Body, Response, Server};
-    /// use hyper::service::service_fn_ok;
+    /// # #[hyper::rt::main]
+    /// # async fn main() {
+    /// use hyper::{Body, Error, Response, Server};
+    /// use hyper::service::{make_service_fn, service_fn};
     ///
     /// // Construct our SocketAddr to listen on...
     /// let addr = ([127, 0, 0, 1], 3000).into();
     ///
-    /// // And a NewService to handle each connection...
-    /// let new_service = || {
-    ///     service_fn_ok(|_req| {
-    ///         Response::new(Body::from("Hello World"))
-    ///     })
-    /// };
+    /// // And a MakeService to handle each connection...
+    /// let make_svc = make_service_fn(|_| async {
+    ///     Ok::<_, Error>(service_fn(|_req| async {
+    ///         Ok::<_, Error>(Response::new(Body::from("Hello World")))
+    ///     }))
+    /// });
     ///
     /// // Then bind and serve...
     /// let server = Server::bind(&addr)
-    ///     .serve(new_service);
+    ///     .serve(make_svc);
     ///
     /// // Finally, spawn `server` onto an Executor...
     /// # }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -19,32 +19,31 @@
 //! ## Example
 //!
 //! ```no_run
-//! extern crate hyper;
-//!
-//! use hyper::{Body, Response, Server};
-//! use hyper::service::service_fn_ok;
+//! # #![feature(async_await)]
+//! use hyper::{Body, Error, Response, Server};
+//! use hyper::service::{make_service_fn, service_fn};
 //!
 //! # #[cfg(feature = "runtime")]
-//! fn main() {
-//! # use hyper::rt::Future;
+//! # #[hyper::rt::main]
+//! async fn main() {
 //!     // Construct our SocketAddr to listen on...
 //!     let addr = ([127, 0, 0, 1], 3000).into();
 //!
 //!     // And a MakeService to handle each connection...
-//!     let make_service = || {
-//!         service_fn_ok(|_req| {
-//!             Response::new(Body::from("Hello World"))
-//!         })
-//!     };
+//!     let make_service = make_service_fn(|_| async {
+//!         Ok::<_, Error>(service_fn(|_req| async {
+//!             Ok::<_, Error>(Response::new(Body::from("Hello World")))
+//!         }))
+//!     });
 //!
 //!     // Then bind and serve...
 //!     let server = Server::bind(&addr)
 //!         .serve(make_service);
 //!
 //!     // Finally, spawn `server` onto an Executor...
-//!     hyper::rt::run(server.map_err(|e| {
+//!     if let Err(e) = server.await {
 //!         eprintln!("server error: {}", e);
-//!     }));
+//!     }
 //! }
 //! # #[cfg(not(feature = "runtime"))]
 //! # fn main() {}

--- a/src/service/service.rs
+++ b/src/service/service.rs
@@ -43,10 +43,11 @@ pub trait Service {
 /// # Example
 ///
 /// ```rust
+/// # #![feature(async_await)]
 /// use hyper::{Body, Request, Response, Version};
 /// use hyper::service::service_fn;
 ///
-/// let service = service_fn(|req: Request<Body>| {
+/// let service = service_fn(|req: Request<Body>| async move{
 ///     if req.version() == Version::HTTP_11 {
 ///         Ok(Response::new(Body::from("Hello World")))
 ///     } else {


### PR DESCRIPTION
## What

Fix and update doc tests to async/await.

Reference https://github.com/hyperium/hyper/issues/1850

This PR combines two closed PRs #1867 and #1866.

## How

* Remove unnecessary `extern crate`.
* Remove unnecessary imports such as `futures::Future`, `hyper::rt::Future`. 
* Use `futures_util` instead of using `futures` crate directly.
* Use `async fn` and `await` syntax instead of `futures` operators.
* Use `async move` block to return a `Future`.
* Use `tokio::sync::oneshot` instead of the one from `futures` crate.
* Use `hyper:rt::main` (reexport of `tokio::main` macro) to wrap main function.

## How to test

- [ ] Run `cargo doc --open` to check if doc examples are rendered properly.
- [ ] Run `cargo test --doc`. All 18 doc tests should be passed.