### PR TITLE
[Blocked] Update end_to_end benchmark to async/await

### DIFF
--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -64,14 +64,18 @@ fn http1_parallel_x10_req_10mb(b: &mut test::Bencher) {
 }
 
 #[bench]
+#[ignore]
 fn http2_get(b: &mut test::Bencher) {
+    // FIXME: re-implement tests when `h2` upgrades to `async/await`
     opts()
         .http2()
         .bench(b)
 }
 
 #[bench]
+#[ignore]
 fn http2_post(b: &mut test::Bencher) {
+    // FIXME: re-implement tests when `h2` upgrades to `async/await`
     opts()
         .http2()
         .method(Method::POST)
@@ -80,7 +84,9 @@ fn http2_post(b: &mut test::Bencher) {
 }
 
 #[bench]
+#[ignore]
 fn http2_req_100kb(b: &mut test::Bencher) {
+    // FIXME: re-implement tests when `h2` upgrades to `async/await`
     let body = &[b'x'; 1024 * 100];
     opts()
         .http2()
@@ -90,7 +96,9 @@ fn http2_req_100kb(b: &mut test::Bencher) {
 }
 
 #[bench]
+#[ignore]
 fn http2_parallel_x10_empty(b: &mut test::Bencher) {
+    // FIXME: re-implement tests when `h2` upgrades to `async/await`
     opts()
         .http2()
         .parallel(10)
@@ -98,7 +106,9 @@ fn http2_parallel_x10_empty(b: &mut test::Bencher) {
 }
 
 #[bench]
+#[ignore]
 fn http2_parallel_x10_req_10mb(b: &mut test::Bencher) {
+    // FIXME: re-implement tests when `h2` upgrades to `async/await`
     let body = &[b'x'; 1024 * 1024 * 10];
     opts()
         .http2()

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -1,6 +1,6 @@
 #![feature(async_await)]
 #![feature(test)]
-//#![deny(warnings)]
+#![deny(warnings)]
 
 extern crate test;
 


### PR DESCRIPTION
## What

Ref #1848 

Update `end_to_end` benchmark to async/await version

## Could it be merged?

❌ 

**No.** 

All benchmarks related to `h2` client did not pass. Need an update of `h2` client implementation.

## How to test

- [ ] Run `cargo bench --bench end_to_end` and check if all benches pass.

## Benchmark results

This pull request

```bash
running 11 tests
test http1_body_both_100kb       ... bench:      69,467 ns/iter (+/- 8,586) = 2948 MB/s
test http1_body_both_10mb        ... bench:   5,035,217 ns/iter (+/- 939,403) = 4164 MB/s
test http1_get                   ... bench:      38,466 ns/iter (+/- 5,911)
test http1_parallel_x10_empty    ... bench:     241,262 ns/iter (+/- 50,905)
test http1_parallel_x10_req_10mb ... bench:  33,437,364 ns/iter (+/- 2,445,027) = 313 MB/s
test http1_post                  ... bench:      39,928 ns/iter (+/- 7,916)
test http2_get                   ... FAILED
test http2_parallel_x10_empty    ... FAILED
test http2_parallel_x10_req_10mb ... FAILED
test http2_post                  ... FAILED
test http2_req_100kb             ... FAILED

```

v.0.12.33

```bash
running 11 tests
test http1_body_both_100kb       ... bench:      77,478 ns/iter (+/- 13,041) = 2643 MB/s
test http1_body_both_10mb        ... bench:   5,580,250 ns/iter (+/- 908,449) = 3758 MB/s
test http1_get                   ... bench:      41,548 ns/iter (+/- 5,671)
test http1_parallel_x10_empty    ... bench:     263,817 ns/iter (+/- 28,066)
test http1_parallel_x10_req_10mb ... bench:  34,968,643 ns/iter (+/- 4,167,229) = 299 MB/s
test http1_post                  ... bench:      43,573 ns/iter (+/- 13,708)
test http2_get                   ... bench:      67,831 ns/iter (+/- 6,584)
test http2_parallel_x10_empty    ... bench:     213,693 ns/iter (+/- 33,844)
test http2_parallel_x10_req_10mb ... bench:  53,703,755 ns/iter (+/- 12,931,064) = 195 MB/s
test http2_post                  ... bench:      72,077 ns/iter (+/- 11,919)
test http2_req_100kb             ... bench:     150,630 ns/iter (+/- 38,512) = 679 MB/s
```
