### PR TITLE
fix(server): worked-around deprecation of `poll_accept` method in tokio

### DIFF
--- a/examples/send_file.rs
+++ b/examples/send_file.rs
@@ -2,7 +2,7 @@
 #![deny(warnings)]
 
 use tokio::io::AsyncReadExt;
-use tokio_fs::file::File;
+use tokio_fs::File;
 
 use hyper::{Body, Method, Result, Request, Response, Server, StatusCode};
 use hyper::service::{make_service_fn, service_fn};

--- a/src/common/drain.rs
+++ b/src/common/drain.rs
@@ -3,6 +3,7 @@ use std::mem;
 use tokio_sync::{mpsc, watch};
 
 use super::{Future, Never, Poll, Pin, task};
+use futures_util::FutureExt as _;
 
 // Sentinel value signaling that the watch is still open
 enum Action {
@@ -99,7 +100,9 @@ where
         loop {
             match mem::replace(&mut me.state, State::Draining) {
                 State::Watch(on_drain) => {
-                    match me.watch.rx.poll_ref(cx) {
+                    let mut recv_fut = me.watch.rx.recv_ref().boxed();
+
+                    match recv_fut.poll_unpin(cx) {
                         Poll::Ready(None) => {
                             // Drain has been triggered!
                             on_drain(unsafe { Pin::new_unchecked(&mut me.future) });


### PR DESCRIPTION
This fixes building with the tokio master branch head.
Refactoring will be required to actually use the new `accept` async fn.
Build was broken by: https://github.com/tokio-rs/tokio/commit/6d8cc4e4755abbd0baac9abf154837b9be011a07
