### PR TITLE
Update Client API using async-await

### DIFF
--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -26,12 +26,15 @@ async fn main() {
             // `service_fn` is a helper to convert a function that
             // returns a Response into a `Service`.
             Ok::<_, Error>(service_fn(move |mut req| {
-                let uri_string = format!("http://{}/{}",
-                                         out_addr_clone,
-                                         req.uri().path_and_query().map(|x| x.as_str()).unwrap_or(""));
-                let uri = uri_string.parse().unwrap();
-                *req.uri_mut() = uri;
-                client.request(req)
+                let client = client.clone();
+                async move {
+                    let uri_string = format!("http://{}/{}",
+                                                out_addr_clone,
+                                                req.uri().path_and_query().map(|x| x.as_str()).unwrap_or(""));
+                    let uri = uri_string.parse().unwrap();
+                    *req.uri_mut() = uri;
+                    client.request(req).await
+                }
             }))
         }
     });

--- a/examples/upgrades.rs
+++ b/examples/upgrades.rs
@@ -91,8 +91,9 @@ async fn client_upgrade_request(addr: SocketAddr) -> Result<()> {
         .header(UPGRADE, "foobar")
         .body(Body::empty())
         .unwrap();
-
-    let res = Client::new().request(req).await?;
+    
+    let client = Client::new();
+    let res = client.request(req).await?;
     if res.status() != StatusCode::SWITCHING_PROTOCOLS {
         panic!("Our server didn't upgrade: {}", res.status());
     }


### PR DESCRIPTION
The code becomes much cleaner with this approach (No polls, Eithers (nested sometimes))

Main difference now is that:
1. No cloning is done inside `retryably_send_request`.
2. Future returned by `get` and `request` methods now ties to lifetime of `self`. So the client has to be alive for lifetime of request future. User will have clone the client instance if needed.

@seanmonstar Please let me know what you think?