### PR TITLE
Upgrade tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,15 +36,13 @@ log = "0.4"
 net2 = { version = "0.2.32", optional = true }
 pin-utils = "0.1.0-alpha.4"
 time = "0.1"
-tokio = { version = "0.2.0-alpha.1", optional = true, default-features = false, features = ["rt-full"] }
+tokio = { version = "0.2.0-alpha.2", optional = true, default-features = false, features = ["rt-full"] }
 tokio-buf = "0.2.0-alpha.1"
-tokio-executor = "0.2.0-alpha.1"
-tokio-io = "0.2.0-alpha.1"
-tokio-reactor = { version = "0.2.0-alpha.1", optional = true }
-tokio-sync = "0.2.0-alpha.1"
-tokio-tcp = { version = "0.2.0-alpha.1", optional = true, features = ["async-traits"] }
-tokio-threadpool = { version = "0.2.0-alpha.1", optional = true }
-tokio-timer = { version = "0.3.0-alpha.1", optional = true }
+tokio-executor = "0.2.0-alpha.2"
+tokio-io = "0.2.0-alpha.2"
+tokio-sync = "0.2.0-alpha.2"
+tokio-net = { version = "0.2.0-alpha.2", optional = true, features = ["tcp"] }
+tokio-timer = { version = "0.3.0-alpha.2", optional = true }
 want = { git = "https://github.com/seanmonstar/want", branch = "std-future" }
 
 [dev-dependencies]
@@ -55,8 +53,8 @@ spmc = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-tokio-fs = "0.2.0-alpha.1"
-tokio-test = "0.2.0-alpha.1"
+tokio-fs = "0.2.0-alpha.2"
+tokio-test = "0.2.0-alpha.2"
 url = "1.0"
 
 
@@ -68,9 +66,7 @@ default = [
 runtime = [
     "net2",
     "tokio",
-    "tokio-reactor",
-    "tokio-tcp",
-    "tokio-threadpool",
+    "tokio-net",
     "tokio-timer",
 ]
 nightly = []

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant};
 
 use http::uri::Scheme;
 use net2::TcpBuilder;
-use tokio_reactor::Handle;
-use tokio_tcp::{TcpStream/*, ConnectFuture*/};
+use tokio_net::driver::Handle;
+use tokio_net::tcp::{TcpStream/*, ConnectFuture*/};
 use tokio_timer::Delay;
 
 use crate::common::{Future, Pin, Poll, task};
@@ -623,7 +623,7 @@ mod tests {
 
         use futures::{Async, Poll};
         use tokio::runtime::current_thread::Runtime;
-        use tokio_reactor::Handle;
+        use tokio_net::driver::Handle;
 
         use super::dns;
         use super::ConnectingTcp;

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -20,7 +20,7 @@ use futures_core::Stream;
 use h2;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
 use tokio_io::{AsyncRead, AsyncWrite};
-#[cfg(feature = "runtime")] use tokio_reactor::Handle;
+#[cfg(feature = "runtime")] use tokio_net::driver::Handle;
 
 use crate::body::{Body, Payload};
 use crate::common::exec::{Exec, H2Exec, NewSvcExec};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -62,7 +62,6 @@ use std::fmt;
 use futures_core::Stream;
 use pin_utils::unsafe_pinned;
 use tokio_io::{AsyncRead, AsyncWrite};
-#[cfg(feature = "runtime")] use tokio_reactor;
 
 use crate::body::{Body, Payload};
 use crate::common::exec::{Exec, H2Exec, NewSvcExec};
@@ -132,7 +131,7 @@ impl Server<AddrIncoming, ()> {
 
     /// Create a new instance from a `std::net::TcpListener` instance.
     pub fn from_tcp(listener: StdTcpListener) -> Result<Builder<AddrIncoming>, crate::Error> {
-        let handle = tokio_reactor::Handle::default();
+        let handle = tokio_net::driver::Handle::default();
         AddrIncoming::from_std(listener, &handle)
             .map(Server::builder)
     }

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant};
 
 use futures_core::Stream;
 use futures_util::FutureExt as _;
-use tokio_reactor::Handle;
-use tokio_tcp::TcpListener;
+use tokio_net::driver::Handle;
+use tokio_net::tcp::TcpListener;
 use tokio_timer::Delay;
 
 use crate::common::{Future, Pin, Poll, task};
@@ -196,7 +196,7 @@ mod addr_stream {
     use std::io;
     use std::net::SocketAddr;
     use bytes::{Buf, BufMut};
-    use tokio_tcp::TcpStream;
+    use tokio_net::tcp::TcpStream;
     use tokio_io::{AsyncRead, AsyncWrite};
 
     use crate::common::{Pin, Poll, task};

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -7,7 +7,7 @@ extern crate net2;
 extern crate pretty_env_logger;
 extern crate tokio;
 extern crate tokio_io;
-extern crate tokio_tcp;
+extern crate tokio_net;
 extern crate tokio_timer;
 
 use std::io::{Read, Write};
@@ -25,7 +25,7 @@ use futures_util::future::{self, FutureExt};
 use futures_util::try_future::{self, TryFutureExt};
 use futures_util::try_stream::TryStreamExt;
 use tokio::runtime::current_thread::Runtime;
-use tokio_tcp::TcpStream;
+use tokio_net::tcp::TcpStream;
 
 fn s(buf: &[u8]) -> &str {
     ::std::str::from_utf8(buf).expect("from_utf8")
@@ -773,7 +773,7 @@ mod dispatch_impl {
     use futures_util::try_stream::TryStreamExt;
     use tokio::runtime::current_thread::Runtime;
     use tokio_io::{AsyncRead, AsyncWrite};
-    use tokio_tcp::TcpStream;
+    use tokio_net::tcp::TcpStream;
     use tokio_timer::Delay;
 
     use hyper::client::connect::{Connect, Connected, Destination, HttpConnector};
@@ -1635,7 +1635,7 @@ mod conn {
     use futures_util::try_stream::TryStreamExt;
     use tokio::runtime::current_thread::Runtime;
     use tokio_io::{AsyncRead, AsyncWrite};
-    use tokio_tcp::TcpStream;
+    use tokio_net::tcp::TcpStream;
     use tokio_timer::Delay;
 
     use hyper::{self, Request, Body, Method};

--- a/tests_disabled/server.rs
+++ b/tests_disabled/server.rs
@@ -10,7 +10,7 @@ extern crate spmc;
 extern crate pretty_env_logger;
 extern crate tokio;
 extern crate tokio_io;
-extern crate tokio_tcp;
+extern crate tokio_net;
 
 use std::net::{TcpStream, Shutdown, SocketAddr};
 use std::io::{self, Read, Write};
@@ -26,7 +26,7 @@ use futures::future::{self, FutureResult, Either};
 use futures::sync::oneshot;
 use futures_timer::Delay;
 use http::header::{HeaderName, HeaderValue};
-use tokio_tcp::{TcpListener, TcpStream as TkTcpStream};
+use tokio_net::tcp::{TcpListener, TcpStream as TkTcpStream};
 use tokio::runtime::current_thread::Runtime;
 use tokio::reactor::Handle;
 use tokio_io::{AsyncRead, AsyncWrite};


### PR DESCRIPTION
This is only upgrade.

`tokio-reactor` and `tokio-tcp` is merged into `tokio-net`
`tokio-threadpool` became part of `tokio-executor`