### PR TITLE
refactor: remove async_await feature gate

### DIFF
--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![feature(test)]
 #![deny(warnings)]
 

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![feature(test)]
 #![deny(warnings)]
 

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![feature(test)]
 #![deny(warnings)]
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 extern crate hyper;
 extern crate pretty_env_logger;

--- a/examples/client_json.rs
+++ b/examples/client_json.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 extern crate hyper;
 #[macro_use]

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 //#![deny(warnings)]
 
 use hyper::{Body, Method, Request, Response, Server, StatusCode};

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 
 use hyper::{Body, Request, Response, Server};

--- a/examples/multi_server.rs
+++ b/examples/multi_server.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 extern crate hyper;
 extern crate pretty_env_logger;

--- a/examples/params.rs
+++ b/examples/params.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 // #![deny(warnings)]  // FIXME: https://github.com/rust-lang/rust/issues/62411
 extern crate hyper;
 extern crate pretty_env_logger;

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 
 use hyper::{Client, Error, Server};

--- a/examples/send_file.rs
+++ b/examples/send_file.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 
 use tokio::io::AsyncReadExt;

--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 
 use std::cell::Cell;

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 
 use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};

--- a/examples/tower_server.rs
+++ b/examples/tower_server.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 
 use hyper::{Body, Request, Response, Server};

--- a/examples/upgrades.rs
+++ b/examples/upgrades.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 
 // Note: `hyper::upgrade` docs link to this upgrade.

--- a/examples/web_api.rs
+++ b/examples/web_api.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 
 use hyper::{Body, Chunk, Client, Method, Request, Response, Server, StatusCode, header};

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -182,7 +182,6 @@ where
     /// # Example
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # use http::header::HOST;
     /// # use hyper::client::conn::SendRequest;
     /// # use hyper::Body;

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -46,7 +46,6 @@ pub struct HttpConnector<R = GaiResolver> {
 /// # Example
 ///
 /// ```
-/// # #![feature(async_await)]
 /// # async fn doc() -> hyper::Result<()> {
 /// use hyper::Uri;
 /// use hyper::client::{Client, connect::HttpInfo};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -27,7 +27,6 @@
 //! [full client example](https://github.com/hyperium/hyper/blob/master/examples/client.rs).
 //!
 //! ```
-//! # #![feature(async_await)]
 //! use hyper::{Client, Uri};
 //!
 //! # #[cfg(feature = "runtime")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 // XXX NOOOOOOOO
 //#![cfg_attr(test, deny(warnings))]
 #![allow(warnings)]
-#![feature(async_await)]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 
 //! # hyper

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -331,7 +331,6 @@ impl<E> Http<E> {
     /// # Example
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # use hyper::{Body, Request, Response};
     /// # use hyper::service::Service;
     /// # use hyper::server::conn::Http;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -19,7 +19,6 @@
 //! ## Example
 //!
 //! ```no_run
-//! # #![feature(async_await)]
 //! use hyper::{Body, Error, Response, Server};
 //! use hyper::service::{make_service_fn, service_fn};
 //!
@@ -164,7 +163,6 @@ where
     /// # Example
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # fn main() {}
     /// # #[cfg(feature = "runtime")]
     /// # async fn run() {
@@ -360,7 +358,6 @@ impl<I, E> Builder<I, E> {
     /// # Example
     ///
     /// ```
-    /// # #![feature(async_await)]
     /// # #[cfg(not(feature = "runtime"))]
     /// # fn main() {}
     /// # #[cfg(feature = "runtime")]

--- a/src/service/make_service.rs
+++ b/src/service/make_service.rs
@@ -133,7 +133,6 @@ where
 /// # Example
 ///
 /// ```rust,no_run
-/// # #![feature(async_await)]
 /// # #[cfg(feature = "runtime")]
 /// # #[tokio::main]
 /// # async fn main() {

--- a/src/service/service.rs
+++ b/src/service/service.rs
@@ -70,7 +70,6 @@ mod sealed {
 /// # Example
 ///
 /// ```rust
-/// # #![feature(async_await)]
 /// use hyper::{Body, Request, Response, Version};
 /// use hyper::service::service_fn;
 ///

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings)]
 extern crate bytes;
 extern crate hyper;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, async_closure)]
+#![feature(async_closure)]
 #![deny(warnings)]
 extern crate http;
 extern crate hyper;


### PR DESCRIPTION
`async_await` is stabilized in https://github.com/rust-lang/rust/pull/63209.
This commit fixes `hyper` build with latest nightly compiler.