### PR TITLE
feat(client): change `GaiResolver` to use a global blocking threadpool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ pin-utils = "=0.1.0-alpha.4"
 time = "0.1"
 tokio = { version = "=0.2.0-alpha.4", optional = true, default-features = false, features = ["rt-full"] }
 tower-service = "=0.3.0-alpha.1"
-tokio-executor = "=0.2.0-alpha.4"
+tokio-executor = { version = "=0.2.0-alpha.4", features = ["blocking"] }
 tokio-io = "=0.2.0-alpha.4"
 tokio-sync = "=0.2.0-alpha.4"
 tokio-net = { version = "=0.2.0-alpha.4", optional = true, features = ["tcp"] }

--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -179,7 +179,7 @@ impl Opts {
 
         let addr = spawn_server(&mut rt, &self);
 
-        let connector = HttpConnector::new(1);
+        let connector = HttpConnector::new();
         let client = hyper::Client::builder()
             .http2_only(self.http2)
             .http2_initial_stream_window_size(self.http2_stream_window)

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -77,9 +77,8 @@ impl HttpConnector {
     /// Construct a new HttpConnector.
     ///
     /// Takes number of DNS worker threads.
-    #[inline]
-    pub fn new(threads: usize) -> HttpConnector {
-        HttpConnector::new_with_resolver(GaiResolver::new(threads))
+    pub fn new() -> HttpConnector {
+        HttpConnector::new_with_resolver(GaiResolver::new())
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1023,7 +1023,7 @@ impl Builder {
         B: Payload + Send,
         B::Data: Send,
     {
-        let mut connector = HttpConnector::new(4);
+        let mut connector = HttpConnector::new();
         if self.pool_config.enabled {
             connector.set_keepalive(self.pool_config.keep_alive_timeout);
         }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -213,7 +213,7 @@ macro_rules! test {
         let addr = server.local_addr().expect("local_addr");
         let rt = $runtime;
 
-        let connector = ::hyper::client::HttpConnector::new(1);
+        let connector = ::hyper::client::HttpConnector::new();
         let client = Client::builder()
             .set_host($set_host)
             .http1_title_case_headers($title_case_headers)
@@ -781,7 +781,7 @@ mod dispatch_impl {
         let mut rt = Runtime::new().unwrap();
         let (closes_tx, closes) = mpsc::channel(10);
         let client = Client::builder()
-            .build(DebugConnector::with_http_and_closes(HttpConnector::new(1), closes_tx));
+            .build(DebugConnector::with_http_and_closes(HttpConnector::new(), closes_tx));
 
         let (tx1, rx1) = oneshot::channel();
 
@@ -837,7 +837,7 @@ mod dispatch_impl {
 
         let res = {
             let client = Client::builder()
-                .build(DebugConnector::with_http_and_closes(HttpConnector::new(1), closes_tx));
+                .build(DebugConnector::with_http_and_closes(HttpConnector::new(), closes_tx));
 
             let req = Request::builder()
                 .uri(&*format!("http://{}/a", addr))
@@ -889,7 +889,7 @@ mod dispatch_impl {
         });
 
         let client = Client::builder()
-            .build(DebugConnector::with_http_and_closes(HttpConnector::new(1), closes_tx));
+            .build(DebugConnector::with_http_and_closes(HttpConnector::new(), closes_tx));
 
         let req = Request::builder()
             .uri(&*format!("http://{}/a", addr))
@@ -948,7 +948,7 @@ mod dispatch_impl {
 
         let res = {
             let client = Client::builder()
-                .build(DebugConnector::with_http_and_closes(HttpConnector::new(1), closes_tx));
+                .build(DebugConnector::with_http_and_closes(HttpConnector::new(), closes_tx));
 
             let req = Request::builder()
                 .uri(&*format!("http://{}/a", addr))
@@ -996,7 +996,7 @@ mod dispatch_impl {
 
         let res = {
             let client = Client::builder()
-                .build(DebugConnector::with_http_and_closes(HttpConnector::new(1), closes_tx));
+                .build(DebugConnector::with_http_and_closes(HttpConnector::new(), closes_tx));
 
             let req = Request::builder()
                 .uri(&*format!("http://{}/a", addr))
@@ -1046,7 +1046,7 @@ mod dispatch_impl {
 
         let client = Client::builder()
             .keep_alive(false)
-            .build(DebugConnector::with_http_and_closes(HttpConnector::new(1), closes_tx));
+            .build(DebugConnector::with_http_and_closes(HttpConnector::new(), closes_tx));
 
         let req = Request::builder()
             .uri(&*format!("http://{}/a", addr))
@@ -1090,7 +1090,7 @@ mod dispatch_impl {
         });
 
         let client = Client::builder()
-            .build(DebugConnector::with_http_and_closes(HttpConnector::new(1), closes_tx));
+            .build(DebugConnector::with_http_and_closes(HttpConnector::new(), closes_tx));
 
         let req = Request::builder()
             .uri(&*format!("http://{}/a", addr))
@@ -1527,7 +1527,7 @@ mod dispatch_impl {
 
     impl DebugConnector {
         fn new() -> DebugConnector {
-            let http = HttpConnector::new(1);
+            let http = HttpConnector::new();
             let (tx, _) = mpsc::channel(10);
             DebugConnector::with_http_and_closes(http, tx)
         }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -313,7 +313,7 @@ pub fn __run_test(cfg: __TestConfig) {
         Version::HTTP_11
     };
 
-    let connector = HttpConnector::new(1);
+    let connector = HttpConnector::new();
     let client = Client::builder()
         .keep_alive_timeout(Duration::from_secs(10))
         .http2_only(cfg.client_version == 2)


### PR DESCRIPTION
BREAKING CHANGE: Calls to `GaiResolver::new` and `HttpConnector::new` no
  longer should pass an integer argument for the number of threads.

