### PR TITLE
feat(body): change `Sender::send_data` to an `async fn`.

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1748,7 +1748,7 @@ mod conn {
 
         let (mut sender, body) = Body::channel();
         let sender = thread::spawn(move || {
-            sender.send_data("hello".into()).ok().unwrap();
+            sender.try_send_data("hello".into()).expect("try_send_data");
             Runtime::new().unwrap().block_on(rx).unwrap();
             sender.abort();
         });

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -101,7 +101,7 @@ mod response_body_lengths {
             },
             Bd::Unknown(b) => {
                 let (mut tx, body) = hyper::Body::channel();
-                tx.send_data(b.into()).expect("send_data");
+                tx.try_send_data(b.into()).expect("try_send_data");
                 reply.body_stream(body);
                 b
             },


### PR DESCRIPTION
The previous version is renamed to `try_send_data`.

BREAKING CHANGE: Usage of `send_data` should either be changed to
  async/await or use `try_send_data`.

