### PR TITLE
refactor(lib): Use pin-project crate to perform pin projections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ iovec = "0.1"
 itoa = "0.4.1"
 log = "0.4"
 net2 = { version = "0.2.32", optional = true }
-pin-utils = "=0.1.0-alpha.4"
+pin-project = { version = "0.4.0-alpha.7", features = ["project_attr"] }
+
 time = "0.1"
 tokio = { version = "=0.2.0-alpha.4", optional = true, default-features = false, features = ["rt-full"] }
 tower-service = "=0.3.0-alpha.1"


### PR DESCRIPTION
Remove all pin-related `unsafe` code from Hyper, as well as the
now-unused 'pin-utils' dependency.

