### PR TITLE
Remove `FutureExt::boxed` to unify project style

### DIFF
--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -106,10 +106,11 @@ impl AddrIncoming {
         }
         self.timeout = None;
 
-        let mut accept_fut = self.listener.accept().boxed();
+        let accept = self.listener.accept();
+        futures_util::pin_mut!(accept);
 
         loop {
-            match accept_fut.poll_unpin(cx) {
+            match accept.poll_unpin(cx) {
                 Poll::Ready(Ok((socket, addr))) => {
                     if let Some(dur) = self.tcp_keepalive_timeout {
                         if let Err(e) = socket.set_keepalive(Some(dur)) {


### PR DESCRIPTION
introduced by #1890 while `Pin::new_unchecked` is used across this project which is more efficient