### PR TITLE
feat(server): introduce `Accept` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,11 @@ runtime = [
     "tokio-net",
     "tokio-timer",
 ]
+
+# unstable features
+stream = []
+
+# internal features used in CI
 nightly = []
 __internal_flaky_tests = []
 __internal_happy_eyeballs_tests = []

--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -1,0 +1,99 @@
+//! The `Accept` trait and supporting types.
+//!
+//! This module contains:
+//!
+//! - The [`Accept`](Accept) trait used to asynchronously accept incoming
+//!   connections.
+//! - Utilities like `poll_fn` to ease creating a custom `Accept`.
+
+#[cfg(feature = "stream")]
+use futures_core::Stream;
+
+use crate::common::{Pin, task::{self, Poll}};
+
+/// Asynchronously accept incoming connections.
+pub trait Accept {
+    /// The connection type that can be accepted.
+    type Conn;
+    /// The error type that can occur when accepting a connection.
+    type Error;
+
+    /// Poll to accept the next connection.
+    fn poll_accept(self: Pin<&mut Self>, cx: &mut task::Context<'_>)
+        -> Poll<Option<Result<Self::Conn, Self::Error>>>;
+}
+
+/// Create an `Accept` with a polling function.
+///
+/// # Example
+///
+/// ```
+/// use std::task::Poll;
+/// use hyper::server::{accept, Server};
+///
+/// # let mock_conn = ();
+/// // If we created some mocked connection...
+/// let mut conn = Some(mock_conn);
+///
+/// // And accept just the mocked conn once...
+/// let once = accept::poll_fn(move |cx| {
+///     Poll::Ready(conn.take().map(Ok::<_, ()>))
+/// });
+///
+/// let builder = Server::builder(once);
+/// ```
+pub fn poll_fn<F, IO, E>(func: F) -> impl Accept<Conn = IO, Error = E>
+where
+    F: FnMut(&mut task::Context<'_>) -> Poll<Option<Result<IO, E>>>,
+{
+    struct PollFn<F>(F);
+
+    impl<F, IO, E> Accept for PollFn<F>
+    where
+        F: FnMut(&mut task::Context<'_>) -> Poll<Option<Result<IO, E>>>,
+    {
+        type Conn = IO;
+        type Error = E;
+        fn poll_accept(self: Pin<&mut Self>, cx: &mut task::Context<'_>)
+            -> Poll<Option<Result<Self::Conn, Self::Error>>>
+        {
+            unsafe {
+                (self.get_unchecked_mut().0)(cx)
+            }
+        }
+    }
+
+    PollFn(func)
+}
+
+/// Adapt a `Stream` of incoming connections into an `Accept`.
+///
+/// # Unstable
+///
+/// This function requires enabling the unstable `stream` feature in your
+/// `Cargo.toml`.
+#[cfg(feature = "stream")]
+pub fn from_stream<S, IO, E>(stream: S) -> impl Accept<Conn = IO, Error = E>
+where
+    S: Stream<Item = Result<IO, E>>,
+{
+    struct FromStream<S>(S);
+
+    impl<S, IO, E> Accept for FromStream<S>
+    where
+        S: Stream<Item = Result<IO, E>>,
+    {
+        type Conn = IO;
+        type Error = E;
+        fn poll_accept(self: Pin<&mut Self>, cx: &mut task::Context<'_>)
+            -> Poll<Option<Result<Self::Conn, Self::Error>>>
+        {
+            unsafe {
+                Pin::new_unchecked(&mut self.get_unchecked_mut().0)
+                    .poll_next(cx)
+            }
+        }
+    }
+
+    FromStream(stream)
+}

--- a/src/server/shutdown.rs
+++ b/src/server/shutdown.rs
@@ -1,6 +1,5 @@
 use std::error::Error as StdError;
 
-use futures_core::Stream;
 use tokio_io::{AsyncRead, AsyncWrite};
 use pin_project::{pin_project, project};
 
@@ -9,6 +8,7 @@ use crate::common::drain::{self, Draining, Signal, Watch, Watching};
 use crate::common::exec::{H2Exec, NewSvcExec};
 use crate::common::{Future, Pin, Poll, Unpin, task};
 use crate::service::{MakeServiceRef, Service};
+use super::Accept;
 use super::conn::{SpawnAll, UpgradeableConnection, Watcher};
 
 #[allow(missing_debug_implementations)]
@@ -46,7 +46,7 @@ impl<I, S, F, E> Graceful<I, S, F, E> {
 
 impl<I, IO, IE, S, B, F, E> Future for Graceful<I, S, F, E>
 where
-    I: Stream<Item=Result<IO, IE>>,
+    I: Accept<Conn=IO, Error=IE>,
     IE: Into<Box<dyn StdError + Send + Sync>>,
     IO: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     S: MakeServiceRef<IO, Body, ResBody=B>,

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -3,7 +3,6 @@ use std::io;
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::time::Duration;
 
-use futures_core::Stream;
 use futures_util::FutureExt as _;
 use tokio_net::driver::Handle;
 use tokio_net::tcp::TcpListener;
@@ -11,6 +10,7 @@ use tokio_timer::Delay;
 
 use crate::common::{Future, Pin, Poll, task};
 
+use super::Accept;
 pub use self::addr_stream::AddrStream;
 
 /// A stream of connections from binding to an address.
@@ -156,10 +156,22 @@ impl AddrIncoming {
     }
 }
 
+/*
 impl Stream for AddrIncoming {
     type Item = io::Result<AddrStream>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        let result = ready!(self.poll_next_(cx));
+        Poll::Ready(Some(result))
+    }
+}
+*/
+
+impl Accept for AddrIncoming {
+    type Conn = AddrStream;
+    type Error = io::Error;
+
+    fn poll_accept(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
         let result = ready!(self.poll_next_(cx));
         Poll::Ready(Some(result))
     }


### PR DESCRIPTION
The `Accept` trait is used by the server types to asynchronously accept
incoming connections. This replaces the previous usage of `Stream`.

Part of #1920

BREAKING CHANGE: Passing a `Stream` to `Server::builder` or
  `Http::serve_incoming` must be changed to pass an `Accept` instead. The
  `stream` optional feature can be enabled, and the a stream can be
  converted using `hyper::server::accept::from_stream`.

