### PR TITLE
refactor(examples): remove lifetime workaround in send_file example

### DIFF
--- a/examples/send_file.rs
+++ b/examples/send_file.rs
@@ -61,12 +61,10 @@ fn internal_server_error() -> Response<Body> {
         .unwrap()
 }
 
-async fn simple_file_send(f: &str) -> Result<Response<Body>> {
+async fn simple_file_send(filename: &str) -> Result<Response<Body>> {
     // Serve a file by asynchronously reading it entirely into memory.
     // Uses tokio_fs to open file asynchronously, then tokio::io::AsyncReadExt
     // to read into memory asynchronously.
-
-    let filename = f.to_string(); // we need to copy for lifetime issues
 
     if let Ok(mut file) = File::open(filename).await {
         let mut buf = Vec::new();


### PR DESCRIPTION
The lifetime workaround is no longer required due to changes in
rustc. This removes the line and comment from the example.

Tested on `rustc 1.39.0-nightly (34e82a7b7 2019-09-10)`