### PR TITLE
chore(dependencies): update pin-project to 0.4.0-alpha.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ iovec = "0.1"
 itoa = "0.4.1"
 log = "0.4"
 net2 = { version = "0.2.32", optional = true }
-pin-project = { version = "=0.4.0-alpha.9", features = ["project_attr"] }
+pin-project = { version = "=0.4.0-alpha.10", features = ["project_attr"] }
 time = "0.1"
 tokio = { version = "=0.2.0-alpha.4", optional = true, default-features = false, features = ["rt-full"] }
 tower-service = "=0.3.0-alpha.1"


### PR DESCRIPTION
`pin-project` now [interoperates correctly with `#[cfg()]`](https://github.com/taiki-e/pin-project/pull/77).