### PR TITLE
(0.12.x) feat(body): identify aborted body write errors

### DIFF
--- a/src/body/body.rs
+++ b/src/body/body.rs
@@ -247,7 +247,7 @@ impl Body {
                 ref mut abort_rx,
             } => {
                 if let Ok(Async::Ready(())) = abort_rx.poll() {
-                    return Err(::Error::new_body_write("body write aborted"));
+                    return Err(::Error::new_body_write_aborted());
                 }
 
                 match rx.poll().expect("mpsc cannot error") {

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,8 @@ pub(crate) enum Kind {
     Body,
     /// Error while writing a body to connection.
     BodyWrite,
+    /// The body write was aborted.
+    BodyWriteAborted,
     /// Error calling AsyncWrite::shutdown()
     Shutdown,
 
@@ -131,6 +133,11 @@ impl Error {
     /// Returns true if the connection closed before a message could complete.
     pub fn is_incomplete_message(&self) -> bool {
         self.inner.kind == Kind::IncompleteMessage
+    }
+
+    /// Returns true if the body write was aborted.
+    pub fn is_body_write_aborted(&self) -> bool {
+        self.inner.kind == Kind::BodyWriteAborted
     }
 
     #[doc(hidden)]
@@ -250,6 +257,10 @@ impl Error {
         Error::new(Kind::BodyWrite).with(cause)
     }
 
+    pub(crate) fn new_body_write_aborted() -> Error {
+        Error::new(Kind::BodyWriteAborted)
+    }
+
     fn new_user(user: User) -> Error {
         Error::new(Kind::User(user))
     }
@@ -352,6 +363,7 @@ impl StdError for Error {
             Kind::Accept => "error accepting connection",
             Kind::Body => "error reading a body from connection",
             Kind::BodyWrite => "error writing a body to connection",
+            Kind::BodyWriteAborted => "body write aborted",
             Kind::Shutdown => "error shutting down connection",
             Kind::Http2 => "http2 error",
             Kind::Io => "connection error",


### PR DESCRIPTION
(cherry picked from commit bb365f689defcf529bf546eb684177dbe801b0ba)

