### PR TITLE
pin h2 to specific commit instead of deleted branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ http = "0.1.15"
 http-body = "=0.2.0-alpha.1"
 httparse = "1.0"
 # h2 = "=0.2.0-alpha.2"
-h2 = { version = "=0.2.0-alpha.2", git = "https://github.com/hyperium/h2", branch = "lucio/update-alpha6" }
+h2 = { version = "=0.2.0-alpha.2", git = "https://github.com/hyperium/h2", rev = "02de0d161d6df258d2699e0a778c17dfbdcfa7ea" }
 iovec = "0.1"
 itoa = "0.4.1"
 log = "0.4"


### PR DESCRIPTION
Hyper master doesn't build right now because the `lucio/update-alpha6` branch of h2 was deleted after it was merged. This PR pins h2 to a specific revision for now.