### PR TITLE
feat(lib): add optional `tcp` feature, split from `runtime`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ futures-util-preview = { version = "=0.3.0-alpha.19" }
 http = "0.1.15"
 http-body = "=0.2.0-alpha.1"
 httparse = "1.0"
-# h2 = "=0.2.0-alpha.2"
 h2 = "=0.2.0-alpha.3"
 iovec = "0.1"
 itoa = "0.4.1"
@@ -35,15 +34,19 @@ log = "0.4"
 net2 = { version = "0.2.32", optional = true }
 pin-project = "0.4"
 time = "0.1"
-tokio = { version = "=0.2.0-alpha.6", optional = true, default-features = false, features = ["rt-full"] }
 tower-service = "=0.3.0-alpha.2"
 tower-make = { version = "=0.3.0-alpha.2a", features = ['io'] }
-tokio-executor = { version = "=0.2.0-alpha.6", features = ["blocking"] }
+tokio-executor = "=0.2.0-alpha.6"
 tokio-io = "=0.2.0-alpha.6"
 tokio-sync = "=0.2.0-alpha.6"
+want = "0.3"
+
+# Optional
+
+tokio = { version = "=0.2.0-alpha.6", optional = true, default-features = false, features = ["rt-full"] }
 tokio-net = { version = "=0.2.0-alpha.6", optional = true, features = ["tcp"] }
 tokio-timer = { version = "=0.3.0-alpha.6", optional = true }
-want = "0.3"
+
 
 [dev-dependencies]
 matches = "0.1"
@@ -64,8 +67,12 @@ default = [
     "runtime",
 ]
 runtime = [
-    "net2",
+    "tcp",
     "tokio",
+]
+tcp = [
+    "net2",
+    "tokio-executor/blocking",
     "tokio-net",
     "tokio-timer",
 ]

--- a/src/client/connect/dns.rs
+++ b/src/client/connect/dns.rs
@@ -249,15 +249,18 @@ impl Iterator for IpAddrs {
 ///
 /// Unlike the `GaiResolver` this will not spawn dedicated threads, but only works when running on the
 /// multi-threaded Tokio runtime.
+#[cfg(feature = "runtime")]
 #[derive(Clone, Debug)]
 pub struct TokioThreadpoolGaiResolver(());
 
 /// The future returned by `TokioThreadpoolGaiResolver`.
+#[cfg(feature = "runtime")]
 #[derive(Debug)]
 pub struct TokioThreadpoolGaiFuture {
     name: Name,
 }
 
+#[cfg(feature = "runtime")]
 impl TokioThreadpoolGaiResolver {
     /// Creates a new DNS resolver that will use tokio threadpool's blocking
     /// feature.
@@ -268,6 +271,7 @@ impl TokioThreadpoolGaiResolver {
     }
 }
 
+#[cfg(feature = "runtime")]
 impl Resolve for TokioThreadpoolGaiResolver {
     type Addrs = GaiAddrs;
     type Future = TokioThreadpoolGaiFuture;
@@ -277,6 +281,7 @@ impl Resolve for TokioThreadpoolGaiResolver {
     }
 }
 
+#[cfg(feature = "runtime")]
 impl Future for TokioThreadpoolGaiFuture {
     type Output = Result<GaiAddrs, io::Error>;
 

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -14,7 +14,8 @@ use tokio_timer::Delay;
 
 use crate::common::{Future, Pin, Poll, task};
 use super::{Connect, Connected, Destination};
-use super::dns::{self, GaiResolver, Resolve, TokioThreadpoolGaiResolver};
+use super::dns::{self, GaiResolver, Resolve};
+#[cfg(feature = "runtime")] use super::dns::TokioThreadpoolGaiResolver;
 
 // TODO: unbox me?
 type ConnectFuture = Pin<Box<dyn Future<Output = io::Result<TcpStream>> + Send>>;
@@ -81,6 +82,7 @@ impl HttpConnector {
     }
 }
 
+#[cfg(feature = "runtime")]
 impl HttpConnector<TokioThreadpoolGaiResolver> {
     /// Construct a new HttpConnector using the `TokioThreadpoolGaiResolver`.
     ///

--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -15,9 +15,9 @@ use tokio_io::{AsyncRead, AsyncWrite};
 
 use crate::common::{Future, Unpin};
 
-#[cfg(feature = "runtime")] pub mod dns;
-#[cfg(feature = "runtime")] mod http;
-#[cfg(feature = "runtime")] pub use self::http::{HttpConnector, HttpInfo};
+#[cfg(feature = "tcp")] pub mod dns;
+#[cfg(feature = "tcp")] mod http;
+#[cfg(feature = "tcp")] pub use self::http::{HttpConnector, HttpInfo};
 
 /// Connect to a destination, returning an IO transport.
 ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -29,7 +29,7 @@
 //! ```
 //! use hyper::{Client, Uri};
 //!
-//! # #[cfg(feature = "runtime")]
+//! # #[cfg(feature = "tcp")]
 //! # async fn fetch_httpbin() -> hyper::Result<()> {
 //! let client = Client::new();
 //!
@@ -75,7 +75,7 @@ use crate::common::{lazy as hyper_lazy, Lazy, Future, Pin, Poll, task};
 use self::connect::{Alpn, Connect, Connected, Destination};
 use self::pool::{Key as PoolKey, Pool, Poolable, Pooled, Reservation};
 
-#[cfg(feature = "runtime")] pub use self::connect::HttpConnector;
+#[cfg(feature = "tcp")] pub use self::connect::HttpConnector;
 
 pub mod conn;
 pub mod connect;
@@ -110,7 +110,7 @@ pub struct ResponseFuture {
 
 // ===== impl Client =====
 
-#[cfg(feature = "runtime")]
+#[cfg(feature = "tcp")]
 impl Client<HttpConnector, Body> {
     /// Create a new Client with the default [config](Builder).
     ///
@@ -125,7 +125,7 @@ impl Client<HttpConnector, Body> {
     }
 }
 
-#[cfg(feature = "runtime")]
+#[cfg(feature = "tcp")]
 impl Default for Client<HttpConnector, Body> {
     fn default() -> Client<HttpConnector, Body> {
         Client::new()
@@ -1018,7 +1018,7 @@ impl Builder {
     }
 
     /// Builder a client with this configuration and the default `HttpConnector`.
-    #[cfg(feature = "runtime")]
+    #[cfg(feature = "tcp")]
     pub fn build_http<B>(&self) -> Client<HttpConnector, B>
     where
         B: Payload + Send,

--- a/src/common/exec.rs
+++ b/src/common/exec.rs
@@ -50,7 +50,7 @@ impl Exec {
     {
         match *self {
             Exec::Default => {
-                #[cfg(feature = "runtime")]
+                #[cfg(feature = "tcp")]
                 {
                     use std::error::Error as StdError;
 
@@ -81,7 +81,7 @@ impl Exec {
                             crate::Error::new_execute(TokioSpawnError)
                         })
                 }
-                #[cfg(not(feature = "runtime"))]
+                #[cfg(not(feature = "tcp"))]
                 {
                     // If no runtime, we need an executor!
                     panic!("executor must be set")

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ pub(crate) enum Kind {
     /// Error occurred while connecting.
     Connect,
     /// Error creating a TcpListener.
-    #[cfg(feature = "runtime")]
+    #[cfg(feature = "tcp")]
     Listen,
     /// Error accepting on an Incoming stream.
     Accept,
@@ -200,7 +200,7 @@ impl Error {
         Error::new(Kind::Io).with(cause)
     }
 
-    #[cfg(feature = "runtime")]
+    #[cfg(feature = "tcp")]
     pub(crate) fn new_listen<E: Into<Cause>>(cause: E) -> Error {
         Error::new(Kind::Listen).with(cause)
     }
@@ -326,7 +326,7 @@ impl StdError for Error {
             Kind::ChannelClosed => "channel closed",
             Kind::Connect => "error trying to connect",
             Kind::Canceled => "operation was canceled",
-            #[cfg(feature = "runtime")]
+            #[cfg(feature = "tcp")]
             Kind::Listen => "error creating server listener",
             Kind::Accept => "error accepting connection",
             Kind::Body => "error reading a body from connection",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,8 @@
 //! - `runtime` (*enabled by default*): Enables convenient integration with
 //!   `tokio`, providing connectors and acceptors for TCP, and a default
 //!   executor.
+//! - `tcp` (*enabled by default*): Enables convenient implementations over
+//!   TCP (using tokio).
 //! - `unstable-stream` (*unstable*): Provides `futures::Stream` capabilities.
 //!
 //!   Due to the `Stream` trait not being stable, this feature is also

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -11,14 +11,14 @@
 use std::error::Error as StdError;
 use std::fmt;
 use std::mem;
-#[cfg(feature = "runtime")] use std::net::SocketAddr;
-#[cfg(feature = "runtime")] use std::time::Duration;
+#[cfg(feature = "tcp")] use std::net::SocketAddr;
+#[cfg(feature = "tcp")] use std::time::Duration;
 
 use bytes::Bytes;
 use futures_core::Stream;
 use tokio_io::{AsyncRead, AsyncWrite};
 use pin_project::{pin_project, project};
-#[cfg(feature = "runtime")] use tokio_net::driver::Handle;
+#[cfg(feature = "tcp")] use tokio_net::driver::Handle;
 
 use crate::body::{Body, Payload};
 use crate::common::exec::{Exec, H2Exec, NewSvcExec};
@@ -35,7 +35,7 @@ use self::spawn_all::NewSvcTask;
 pub(super) use self::spawn_all::Watcher;
 pub(super) use self::upgrades::UpgradeableConnection;
 
-#[cfg(feature = "runtime")] pub use super::tcp::{AddrIncoming, AddrStream};
+#[cfg(feature = "tcp")] pub use super::tcp::{AddrIncoming, AddrStream};
 
 /// A lower-level configuration of the HTTP protocol.
 ///
@@ -341,9 +341,7 @@ impl<E> Http<E> {
     /// # use hyper::{Body, Request, Response};
     /// # use hyper::service::Service;
     /// # use hyper::server::conn::Http;
-    /// # #[cfg(feature = "runtime")]
     /// # use tokio_io::{AsyncRead, AsyncWrite};
-    /// # #[cfg(feature = "runtime")]
     /// # async fn run<I, S>(some_io: I, some_service: S)
     /// # where
     /// #     I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
@@ -404,7 +402,7 @@ impl<E> Http<E> {
         }
     }
 
-    #[cfg(feature = "runtime")]
+    #[cfg(feature = "tcp")]
     #[doc(hidden)]
     #[deprecated]
     #[allow(deprecated)]
@@ -426,7 +424,7 @@ impl<E> Http<E> {
         Ok(self.serve_incoming(incoming, make_service))
     }
 
-    #[cfg(feature = "runtime")]
+    #[cfg(feature = "tcp")]
     #[doc(hidden)]
     #[deprecated]
     #[allow(deprecated)]
@@ -792,7 +790,7 @@ where
 
 // ===== impl SpawnAll =====
 
-#[cfg(feature = "runtime")]
+#[cfg(feature = "tcp")]
 impl<S, E> SpawnAll<AddrIncoming, S, E> {
     pub(super) fn local_addr(&self) -> SocketAddr {
         self.serve.incoming.local_addr()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -23,7 +23,7 @@
 //! use hyper::service::{make_service_fn, service_fn};
 //!
 //! # #[cfg(feature = "runtime")]
-//! # #[tokio::main]
+//! #[tokio::main]
 //! async fn main() {
 //!     // Construct our SocketAddr to listen on...
 //!     let addr = ([127, 0, 0, 1], 3000).into();
@@ -51,13 +51,13 @@
 pub mod accept;
 pub mod conn;
 mod shutdown;
-#[cfg(feature = "runtime")] mod tcp;
+#[cfg(feature = "tcp")] mod tcp;
 
 use std::error::Error as StdError;
 use std::fmt;
-#[cfg(feature = "runtime")] use std::net::{SocketAddr, TcpListener as StdTcpListener};
+#[cfg(feature = "tcp")] use std::net::{SocketAddr, TcpListener as StdTcpListener};
 
-#[cfg(feature = "runtime")] use std::time::Duration;
+#[cfg(feature = "tcp")] use std::time::Duration;
 
 use tokio_io::{AsyncRead, AsyncWrite};
 use pin_project::pin_project;
@@ -71,7 +71,7 @@ use self::accept::Accept;
 // error that `hyper::server::Http` is private...
 use self::conn::{Http as Http_, NoopWatcher, SpawnAll};
 use self::shutdown::{Graceful, GracefulWatcher};
-#[cfg(feature = "runtime")] use self::tcp::AddrIncoming;
+#[cfg(feature = "tcp")] use self::tcp::AddrIncoming;
 
 /// A listening HTTP server that accepts connections in both HTTP1 and HTTP2 by default.
 ///
@@ -104,7 +104,7 @@ impl<I> Server<I, ()> {
     }
 }
 
-#[cfg(feature = "runtime")]
+#[cfg(feature = "tcp")]
 impl Server<AddrIncoming, ()> {
     /// Binds to the provided address, and returns a [`Builder`](Builder).
     ///
@@ -134,7 +134,7 @@ impl Server<AddrIncoming, ()> {
     }
 }
 
-#[cfg(feature = "runtime")]
+#[cfg(feature = "tcp")]
 impl<S> Server<AddrIncoming, S> {
     /// Returns the local address that this server is bound to.
     pub fn local_addr(&self) -> SocketAddr {
@@ -162,7 +162,7 @@ where
     ///
     /// ```
     /// # fn main() {}
-    /// # #[cfg(feature = "runtime")]
+    /// # #[cfg(feature = "tcp")]
     /// # async fn run() {
     /// # use hyper::{Body, Response, Server, Error};
     /// # use hyper::service::{make_service_fn, service_fn};
@@ -356,11 +356,8 @@ impl<I, E> Builder<I, E> {
     /// # Example
     ///
     /// ```
-    /// # #[cfg(not(feature = "runtime"))]
-    /// # fn main() {}
-    /// # #[cfg(feature = "runtime")]
-    /// # #[tokio::main]
-    /// # async fn main() {
+    /// # #[cfg(feature = "tcp")]
+    /// # async fn run() {
     /// use hyper::{Body, Error, Response, Server};
     /// use hyper::service::{make_service_fn, service_fn};
     ///
@@ -378,7 +375,10 @@ impl<I, E> Builder<I, E> {
     /// let server = Server::bind(&addr)
     ///     .serve(make_svc);
     ///
-    /// // Finally, spawn `server` onto an Executor...
+    /// // Run forever-ish...
+    /// if let Err(err) = server.await {
+    ///     eprintln!("server error: {}", err);
+    /// }
     /// # }
     /// ```
     pub fn serve<S, B>(self, new_service: S) -> Server<I, S, E>
@@ -402,7 +402,7 @@ impl<I, E> Builder<I, E> {
     }
 }
 
-#[cfg(feature = "runtime")]
+#[cfg(feature = "tcp")]
 impl<E> Builder<AddrIncoming, E> {
     /// Set whether TCP keepalive messages are enabled on accepted connections.
     ///


### PR DESCRIPTION
The `HttpConnector` and `AddrListener` types which make use of
`tokio::tcp` have been made their own optional feature. This allows
using them without requiring the *full* tokio runtime.

