### PR TITLE
feat(client): Add connect timeout to HttpConnector

### DIFF
--- a/src/client/connect/dns.rs
+++ b/src/client/connect/dns.rs
@@ -235,6 +235,10 @@ impl IpAddrs {
     pub(super) fn is_empty(&self) -> bool {
         self.iter.as_slice().is_empty()
     }
+
+    pub(super) fn len(&self) -> usize {
+        self.iter.as_slice().len()
+    }
 }
 
 impl Iterator for IpAddrs {


### PR DESCRIPTION
This takes the same strategy as golang, where the timeout value is
divided equally between the candidate socket addresses.

If happy eyeballs is enabled, the division takes place "below" the
IPv4/IPv6 partitioning.

