### PR TITLE
cargo: bump minimum versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ include = [
 ]
 
 [dependencies]
-bytes = "0.4.4"
+bytes = "0.4.6"
 futures = "0.1.21"
 futures-cpupool = { version = "0.1.6", optional = true }
 http = "0.1.15"
 http-body = "0.1"
 httparse = "1.0"
-h2 = "0.1.10"
+h2 = "0.1.13"
 iovec = "0.1"
 itoa = "0.4.1"
 log = "0.4"
@@ -37,7 +37,7 @@ tokio-executor = { version = "0.1.0", optional = true }
 tokio-io = "0.1"
 tokio-reactor = { version = "0.1", optional = true }
 tokio-tcp = { version = "0.1", optional = true }
-tokio-threadpool = { version = "0.1.3", optional = true }
+tokio-threadpool = { version = "0.1.16", optional = true }
 tokio-timer = { version = "0.2", optional = true }
 want = "0.2"
 


### PR DESCRIPTION
`bytes` is bumped due to the addition of `Bytes::advance` in 0.4.6. `h2`
0.1.13 introduced the `.is_io()` and `into_io()` methods.

Bumping `tokio-threadpool` to 0.1.16 removes a dependency on `rand` from
the crate which reduces the size and avoids minimum version dependency
issues in that dependency tree.

---
Trying to make `-Z minimum-versions` work on some of my crates. Will bump `bytes` on `master` as well since I suspect it is necessary there too.