### PR TITLE
fix(cargo): require bytes 0.4.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 ]
 
 [dependencies]
-bytes = "0.4.4"
+bytes = "0.4.6"
 futures-core-preview = "=0.3.0-alpha.19"
 futures-channel-preview = "=0.3.0-alpha.19"
 futures-util-preview = "=0.3.0-alpha.19"


### PR DESCRIPTION
`Bytes::advance` was introduced in this version.

---
`master`-oriented version of #1974. Probably not the end of the story here; `tokio` needs a similar sweep for the versions required on `master`.