### PR TITLE
feat(server): change `http1_half_close` option default to disabled

### DIFF
--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -194,7 +194,7 @@ impl Http {
 
         Http {
             exec: Exec::Default,
-            h1_half_close: true,
+            h1_half_close: false,
             h1_writev: true,
             h2_builder,
             mode: ConnectionMode::Fallback,
@@ -221,12 +221,11 @@ impl<E> Http<E> {
     /// Set whether HTTP/1 connections should support half-closures.
     ///
     /// Clients can chose to shutdown their write-side while waiting
-    /// for the server to respond. Setting this to `false` will
-    /// automatically close any connection immediately if `read`
-    /// detects an EOF.
+    /// for the server to respond. Setting this to `true` will
+    /// prevent closing the connection immediately if `read`
+    /// detects an EOF in the middle of a request.
     ///
-    /// Default is `true`.
-    #[inline]
+    /// Default is `false`.
     pub fn http1_half_close(&mut self, val: bool) -> &mut Self {
         self.h1_half_close = val;
         self
@@ -390,8 +389,8 @@ impl<E> Http<E> {
                 if !self.keep_alive {
                     conn.disable_keep_alive();
                 }
-                if !self.h1_half_close {
-                    conn.set_disable_half_close();
+                if self.h1_half_close {
+                    conn.set_allow_half_close();
                 }
                 if !self.h1_writev {
                     conn.set_write_strategy_flatten();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -252,11 +252,11 @@ impl<I, E> Builder<I, E> {
     /// Set whether HTTP/1 connections should support half-closures.
     ///
     /// Clients can chose to shutdown their write-side while waiting
-    /// for the server to respond. Setting this to `false` will
-    /// automatically close any connection immediately if `read`
-    /// detects an EOF.
+    /// for the server to respond. Setting this to `true` will
+    /// prevent closing the connection immediately if `read`
+    /// detects an EOF in the middle of a request.
     ///
-    /// Default is `true`.
+    /// Default is `false`.
     pub fn http1_half_close(mut self, val: bool) -> Self {
         self.protocol.http1_half_close(val);
         self


### PR DESCRIPTION
Detecting a read hangup is a useful way to determine that a connection
has closed. It's also possible that a client shuts down its read half
without closing the connection, but this is rarer. Thus, by default,
hyper will now assume a read EOF means the connection has closed.

BREAKING CHANGE: The server's behavior will now by default close
  connections when receiving a read EOF. To allow for clients to close
  the read half, call `http1_half_close(true)` when configuring a
  server.

Closes #1764 

