### PR TITLE
feat(client): change `Resolve` to be `Service<Name>`

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1722,7 +1722,7 @@ mod dispatch_impl {
 
     impl hyper::service::Service<Destination> for DebugConnector {
         type Response = (DebugStream, Connected);
-        type Error = io::Error;
+        type Error = <HttpConnector as hyper::service::Service<Destination>>::Error;
         type Future = Pin<Box<dyn Future<
             Output = Result<Self::Response, Self::Error>
         > + Send>>;


### PR DESCRIPTION
Closes #1903

BREAKING CHANGE: The `Resolve` trait is gone. All custom resolves should
  implement `tower::Service` instead.

  The error type of `HttpConnector` has been changed away from
  `std::io::Error`.

