### PR TITLE
feat(client): filter remote IP addresses by family of given local IP address

### DIFF
--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -501,7 +501,7 @@ impl ConnectingTcp {
         reuse_address: bool,
     ) -> ConnectingTcp {
         if let Some(fallback_timeout) = fallback_timeout {
-            let (preferred_addrs, fallback_addrs) = remote_addrs.split_by_preference();
+            let (preferred_addrs, fallback_addrs) = remote_addrs.split_by_preference(local_addr);
             if fallback_addrs.is_empty() {
                 return ConnectingTcp {
                     local_addr,


### PR DESCRIPTION
It is not possible to connect to an IPv4 address from an IPv6 address or vice-versa so don't waste time trying. If no remote addresses match then a "missing connect error" will now occur.

