### PR TITLE
feat(client): add interface to clear connection pool

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -163,6 +163,14 @@ where C: Connect + Clone + Send + Sync + 'static,
       B: Payload + Unpin + Send + 'static,
       B::Data: Send + Unpin,
 {
+    /// Clear connection pool
+    ///
+    /// This is useful when network situation change,
+    /// e.g. Wi-Fi to cellular, or vice versa
+    pub fn clear_pool(&self) {
+        self.pool.clear();
+    }
+
     /// Send a `GET` request to the supplied `Uri`.
     ///
     /// # Note

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -118,6 +118,20 @@ impl<T> Pool<T> {
         self.inner.is_some()
     }
 
+    pub(super) fn clear(&self) {
+        if let Some(ref enabled) = self.inner {
+            debug!("clear connection pool");
+            let mut inner = enabled.lock().unwrap();
+            inner.connecting.clear();
+            inner.idle.clear();
+            #[cfg(feature = "runtime")]
+            {
+                inner.idle_interval_ref = None;
+            }
+            inner.waiters.clear();
+        }
+    }
+
     #[cfg(test)]
     pub(super) fn no_timer(&self) {
         // Prevent an actual interval from being created for this pool...


### PR DESCRIPTION
This patch adds an interface to clear client connection pool for downstream users.  This is useful when the network situation changes, such as from Wi-Fi to cellular network. 

If we do not clear the connection pool when the network situation changes, the network may be temporarily unavailable.
