### PR TITLE
chore(dependencies): update tower-service to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ itoa = "0.4.1"
 log = "0.4"
 pin-project = "0.4"
 time = "0.1"
-tower-service = "=0.3.0-alpha.2"
+tower-service = "0.3"
 tokio = { version = "0.2", features = ["sync"] }
 want = "0.3"
 


### PR DESCRIPTION
This unblocks some work that I'm doing in `tracing` where I'm updating `tracing-tower` to the versions that use `std::future::Future`.