### PR TITLE
feat(rt): introduce `rt::Executor` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ default = [
 ]
 runtime = [
     "tcp",
-    "tokio/time",
+    "tokio/rt-core",
 ]
 tcp = [
     "net2",

--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -1,5 +1,3 @@
-fn main() {}
-/*
 #![deny(warnings)]
 
 use std::cell::Cell;
@@ -74,4 +72,3 @@ where
         tokio::task::spawn_local(fut);
     }
 }
-*/

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -5,4 +5,4 @@
 //! If the `runtime` feature is disabled, the types in this module can be used
 //! to plug in other runtimes.
 
-//pub use crate::common::Executor;
+pub use crate::common::Executor;


### PR DESCRIPTION
The `hyper::rt::Executor` trait allows defining custom executors to be
used with hyper's `Client` and `Server`.

Closes #1944

BREAKING CHANGE: Any type passed to the `executor` builder methods must
  now implement `hyper::rt::Executor`.

  `hyper::rt::spawn` usage should be replaced with `tokio::task::spawn`.

  `hyper::rt::run` usage should be replaced with `#[tokio::main]` or
  managing a `tokio::runtime::Runtime` manually.

