### PR TITLE
feat(body): replace the `Payload` trait with `HttpBody`

### DIFF
--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -7,20 +7,19 @@
 //!
 //! There are two pieces to this in hyper:
 //!
-//! - The [`Payload`](body::Payload) trait the describes all possible bodies. hyper
-//!   allows any body type that implements `Payload`, allowing applications to
-//!   have fine-grained control over their streaming.
-//! - The [`Body`](Body) concrete type, which is an implementation of `Payload`,
-//!  and returned by hyper as a "receive stream" (so, for server requests and
-//!  client responses). It is also a decent default implementation if you don't
-//!  have very custom needs of your send streams.
+//! - The [`HttpBody`](body::HttpBody) trait the describes all possible bodies.
+//!   hyper allows any body type that implements `HttpBody`, allowing
+//!   applications to have fine-grained control over their streaming.
+//! - The [`Body`](Body) concrete type, which is an implementation of
+//!   `HttpBody`, and returned by hyper as a "receive stream" (so, for server
+//!   requests and client responses). It is also a decent default implementation
+//!   if you don't have very custom needs of your send streams.
 
-#[doc(hidden)]
 pub use http_body::Body as HttpBody;
 
 pub use self::body::{Body, Sender};
 pub use self::chunk::Chunk;
-pub use self::payload::Payload;
+pub(crate) use self::payload::Payload;
 
 mod body;
 mod chunk;


### PR DESCRIPTION
The `hyper::body::HttpBody` trait is a re-export from the `http-body`
crate. This allows libraries to accept "HTTP bodies" without needing to
depend on hyper.

BREAKING CHANGE: All usage of `hyper::body::Payload` should be replaced
  with `hyper::body::HttpBody`.

