### PR TITLE
feat(client): remove `Destination` for `http::Uri` in connectors

### DIFF
--- a/benches/connect.rs
+++ b/benches/connect.rs
@@ -5,7 +5,7 @@ extern crate test;
 
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
-use hyper::client::connect::{Destination, HttpConnector};
+use hyper::client::connect::{HttpConnector};
 use hyper::service::Service;
 use http::Uri;
 
@@ -19,8 +19,7 @@ fn http_connector(b: &mut test::Bencher) {
         .expect("rt build");
     let mut listener = rt.block_on(TcpListener::bind(&SocketAddr::from(([127, 0, 0, 1], 0)))).expect("bind");
     let addr = listener.local_addr().expect("local_addr");
-    let uri: Uri = format!("http://{}/", addr).parse().expect("uri parse");
-    let dst = Destination::try_from_uri(uri).expect("destination");
+    let dst: Uri = format!("http://{}/", addr).parse().expect("uri parse");
     let mut connector = HttpConnector::new();
 
     rt.spawn(async move {

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -3,8 +3,7 @@
 use std::env;
 use std::io::{self, Write};
 
-use hyper::Client;
-use futures_util::StreamExt;
+use hyper::{Client, body::HttpBody as _};
 
 // A simple type alias so as to DRY.
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;

--- a/src/client/connect/dns.rs
+++ b/src/client/connect/dns.rs
@@ -391,11 +391,10 @@ mod tests {
 
     #[test]
     fn ip_addrs_try_parse_v6() {
-        let uri = ::http::Uri::from_static("http://[::1]:8080/");
-        let dst = super::super::Destination { uri };
+        let dst = ::http::Uri::from_static("http://[::1]:8080/");
 
         let mut addrs =
-            IpAddrs::try_parse(dst.host(), dst.port().expect("port")).expect("try_parse");
+            IpAddrs::try_parse(dst.host().expect("host"), dst.port_u16().expect("port")).expect("try_parse");
 
         let expected = "[::1]:8080".parse::<SocketAddr>().expect("expected");
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -71,7 +71,7 @@ use http::uri::Scheme;
 
 use crate::body::{Body, Payload};
 use crate::common::{lazy as hyper_lazy, BoxSendFuture, Executor, Lazy, Future, Pin, Poll, task};
-use self::connect::{Alpn, sealed::Connect, Connected, Destination};
+use self::connect::{Alpn, sealed::Connect, Connected};
 use self::pool::{Key as PoolKey, Pool, Poolable, Pooled, Reservation};
 
 #[cfg(feature = "tcp")] pub use self::connect::HttpConnector;
@@ -462,9 +462,7 @@ where C: Connect + Clone + Send + Sync + 'static,
         let ver = self.config.ver;
         let is_ver_h2 = ver == Ver::Http2;
         let connector = self.connector.clone();
-        let dst = Destination {
-            uri,
-        };
+        let dst = uri;
         hyper_lazy(move || {
             // Try to take a "connecting lock".
             //

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -940,11 +940,12 @@ mod dispatch_impl {
     use futures_channel::{mpsc, oneshot};
     use futures_util::future::{FutureExt, TryFutureExt};
     use futures_util::stream::{StreamExt};
+    use http::Uri;
     use tokio::runtime::Runtime;
     use tokio::io::{AsyncRead, AsyncWrite};
     use tokio::net::TcpStream;
 
-    use hyper::client::connect::{Connected, Destination, HttpConnector};
+    use hyper::client::connect::{Connected, HttpConnector};
     use hyper::Client;
 
     #[test]
@@ -1738,19 +1739,19 @@ mod dispatch_impl {
         }
     }
 
-    impl hyper::service::Service<Destination> for DebugConnector {
+    impl hyper::service::Service<Uri> for DebugConnector {
         type Response = (DebugStream, Connected);
-        type Error = <HttpConnector as hyper::service::Service<Destination>>::Error;
+        type Error = <HttpConnector as hyper::service::Service<Uri>>::Error;
         type Future = Pin<Box<dyn Future<
             Output = Result<Self::Response, Self::Error>
         > + Send>>;
 
         fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             // don't forget to check inner service is ready :)
-            hyper::service::Service::<Destination>::poll_ready(&mut self.http, cx)
+            hyper::service::Service::<Uri>::poll_ready(&mut self.http, cx)
         }
 
-        fn call(&mut self, dst: Destination) -> Self::Future {
+        fn call(&mut self, dst: Uri) -> Self::Future {
             self.connects.fetch_add(1, Ordering::SeqCst);
             let closes = self.closes.clone();
             let is_proxy = self.is_proxy;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1779,7 +1779,7 @@ impl tower_service::Service<Request<Body>> for TestService {
         let replies = self.reply.clone();
 
         Box::pin(async move {
-            while let Some(chunk) = req.body_mut().next().await {
+            while let Some(chunk) = hyper::body::HttpBody::next(req.body_mut()).await {
                 match chunk {
                     Ok(chunk) => {
                         tx.send(Msg::Chunk(chunk.to_vec())).unwrap();


### PR DESCRIPTION
This changes "connectors" to be called with a `Uri` instead of `Destination`. The `Destination` type wasn't providing anything extra over an `http::Uri`.
