### PR TITLE
refactor(body): make Chunk a type alias for bytes::Bytes

### DIFF
--- a/src/body/body.rs
+++ b/src/body/body.rs
@@ -3,7 +3,6 @@ use std::borrow::Cow;
 use std::error::Error as StdError;
 use std::fmt;
 
-use bytes::Bytes;
 use futures_core::Stream; // for mpsc::Receiver
 use futures_channel::{mpsc, oneshot};
 #[cfg(feature = "stream")]
@@ -421,13 +420,6 @@ impl From<Chunk> for Body {
         } else {
             Body::new(Kind::Once(Some(chunk)))
         }
-    }
-}
-
-impl From<Bytes> for Body {
-    #[inline]
-    fn from(bytes: Bytes) -> Body {
-        Body::from(Chunk::from(bytes))
     }
 }
 

--- a/src/body/chunk.rs
+++ b/src/body/chunk.rs
@@ -1,6 +1,4 @@
-use std::fmt;
-
-use bytes::{Buf, Bytes};
+use bytes::{Bytes};
 
 /// A piece of a message body.
 ///
@@ -8,150 +6,11 @@ use bytes::{Buf, Bytes};
 ///
 /// A `Chunk` can be easily created by many of Rust's standard types that
 /// represent a collection of bytes, using `Chunk::from`.
-pub struct Chunk {
-    /// The buffer of bytes making up this body.
-    bytes: Bytes,
-}
-
-// An unexported type to prevent locking `Chunk::into_iter()` to `Bytes::into_iter()`.
-#[derive(Debug)]
-pub struct IntoIter {
-    inner: <Bytes as IntoIterator>::IntoIter,
-}
-
-
-impl Chunk {
-    /// Converts this `Chunk` directly into the `Bytes` type without copies.
-    ///
-    /// This is simply an inherent alias for `Bytes::from(chunk)`, which exists,
-    /// but doesn't appear in rustdocs.
-    #[inline]
-    pub fn into_bytes(self) -> Bytes {
-        self.into()
-    }
-}
-
-impl Buf for Chunk {
-    #[inline]
-    fn remaining(&self) -> usize {
-        //perf: Bytes::len() isn't inline yet,
-        //so it's slightly slower than checking
-        //the length of the slice.
-        self.bytes().len()
-    }
-
-    #[inline]
-    fn bytes(&self) -> &[u8] {
-        &self.bytes
-    }
-
-    #[inline]
-    fn advance(&mut self, cnt: usize) {
-        self.bytes.advance(cnt);
-    }
-}
-
-impl From<Vec<u8>> for Chunk {
-    #[inline]
-    fn from(v: Vec<u8>) -> Chunk {
-        Chunk::from(Bytes::from(v))
-    }
-}
-
-impl From<&'static [u8]> for Chunk {
-    #[inline]
-    fn from(slice: &'static [u8]) -> Chunk {
-        Chunk::from(Bytes::from_static(slice))
-    }
-}
-
-impl From<String> for Chunk {
-    #[inline]
-    fn from(s: String) -> Chunk {
-        s.into_bytes().into()
-    }
-}
-
-impl From<&'static str> for Chunk {
-    #[inline]
-    fn from(slice: &'static str) -> Chunk {
-        slice.as_bytes().into()
-    }
-}
-
-impl From<Bytes> for Chunk {
-    #[inline]
-    fn from(bytes: Bytes) -> Chunk {
-        Chunk {
-            bytes: bytes,
-        }
-    }
-}
-
-impl From<Chunk> for Bytes {
-    #[inline]
-    fn from(chunk: Chunk) -> Bytes {
-        chunk.bytes
-    }
-}
-
-impl ::std::ops::Deref for Chunk {
-    type Target = [u8];
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        self.as_ref()
-    }
-}
-
-impl AsRef<[u8]> for Chunk {
-    #[inline]
-    fn as_ref(&self) -> &[u8] {
-        &self.bytes
-    }
-}
-
-impl fmt::Debug for Chunk {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&self.bytes, f)
-    }
-}
-
-impl Default for Chunk {
-    #[inline]
-    fn default() -> Chunk {
-        Chunk::from(Bytes::new())
-    }
-}
-
-impl IntoIterator for Chunk {
-    type Item = u8;
-    type IntoIter = IntoIter;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        IntoIter {
-            inner: self.bytes.into_iter(),
-        }
-    }
-}
-
-impl Iterator for IntoIter {
-    type Item = u8;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
-    }
-}
-
-impl ExactSizeIterator for IntoIter {}
+///
+/// Compatibility note: in Hyper v0.13 this type was changed from a
+/// newtype wrapper around `bytes::Bytes` to being merely a type alias.
+/// In future releases this type may be removed entirely in favor of `Bytes`.
+pub type Chunk = Bytes;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Closes #1931

Now I don't know the first thing about Hyper's codebase, but the change itself appears to have been quite simple to achieve. `cargo test` passes, and `cargo +nightly test --all-features`, while it doesn't pass, fails in the same way it does on master, so that gives me a bit of confidence. :)