### PR TITLE
feat(body): add `body::aggregate` and `body::to_bytes` functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ required-features = ["runtime"]
 [[example]]
 name = "client_json"
 path = "examples/client_json.rs"
-required-features = ["runtime", "stream"]
+required-features = ["runtime"]
 
 [[example]]
 name = "echo"
@@ -161,6 +161,11 @@ name = "web_api"
 path = "examples/web_api.rs"
 required-features = ["runtime", "stream"]
 
+
+[[bench]]
+name = "body"
+path = "benches/body.rs"
+required-features = ["runtime", "stream"]
 
 [[bench]]
 name = "connect"

--- a/benches/body.rs
+++ b/benches/body.rs
@@ -1,0 +1,89 @@
+#![feature(test)]
+#![deny(warnings)]
+
+extern crate test;
+
+use bytes::Buf;
+use futures_util::stream;
+use futures_util::StreamExt;
+use hyper::body::Body;
+
+macro_rules! bench_stream {
+    ($bencher:ident, bytes: $bytes:expr, count: $count:expr, $total_ident:ident, $body_pat:pat, $block:expr) => {{
+        let mut rt = tokio::runtime::Builder::new()
+            .basic_scheduler()
+            .build()
+            .expect("rt build");
+
+        let $total_ident: usize = $bytes * $count;
+        $bencher.bytes = $total_ident as u64;
+        let __s: &'static [&'static [u8]] = &[&[b'x'; $bytes] as &[u8]; $count] as _;
+
+        $bencher.iter(|| {
+            rt.block_on(async {
+                let $body_pat = Body::wrap_stream(
+                    stream::iter(__s.iter()).map(|&s| Ok::<_, std::convert::Infallible>(s)),
+                );
+                $block;
+            });
+        });
+    }};
+}
+
+macro_rules! benches {
+    ($($name:ident, $bytes:expr, $count:expr;)+) => (
+        mod aggregate {
+            use super::*;
+
+            $(
+            #[bench]
+            fn $name(b: &mut test::Bencher) {
+                bench_stream!(b, bytes: $bytes, count: $count, total, body, {
+                    let buf = hyper::body::aggregate(body).await.unwrap();
+                    assert_eq!(buf.remaining(), total);
+                });
+            }
+            )+
+        }
+
+        mod manual_into_vec {
+            use super::*;
+
+            $(
+            #[bench]
+            fn $name(b: &mut test::Bencher) {
+                bench_stream!(b, bytes: $bytes, count: $count, total, mut body, {
+                    let mut vec = Vec::new();
+                    while let Some(chunk) = body.next().await {
+                        vec.extend_from_slice(&chunk.unwrap());
+                    }
+                    assert_eq!(vec.len(), total);
+                });
+            }
+            )+
+        }
+
+        mod to_bytes {
+            use super::*;
+
+            $(
+            #[bench]
+            fn $name(b: &mut test::Bencher) {
+                bench_stream!(b, bytes: $bytes, count: $count, total, body, {
+                    let bytes = hyper::body::to_bytes(body).await.unwrap();
+                    assert_eq!(bytes.len(), total);
+                });
+            }
+            )+
+        }
+    )
+}
+
+// ===== Actual Benchmarks =====
+
+benches! {
+    bytes_1_000_count_2, 1_000, 2;
+    bytes_1_000_count_10, 1_000, 10;
+    bytes_10_000_count_1, 10_000, 1;
+    bytes_10_000_count_10, 10_000, 10;
+}

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -40,6 +40,8 @@ async fn fetch_url(url: hyper::Uri) -> Result<()> {
     println!("Response: {}", res.status());
     println!("Headers: {:#?}\n", res.headers());
 
+    // Stream the body, writing each chunk to stdout as we get it
+    // (instead of buffering and printing at the end).
     while let Some(next) = res.body_mut().data().await {
         let chunk = next?;
         io::stdout().write_all(&chunk).await?;

--- a/src/body/aggregate.rs
+++ b/src/body/aggregate.rs
@@ -1,0 +1,25 @@
+use bytes::Buf;
+
+use super::HttpBody;
+use crate::common::buf::BufList;
+
+/// Aggregate the data buffers from a body asynchronously.
+///
+/// The returned `impl Buf` groups the `Buf`s from the `HttpBody` without
+/// copying them. This is ideal if you don't require a contiguous buffer.
+pub async fn aggregate<T>(body: T) -> Result<impl Buf, T::Error>
+where
+    T: HttpBody,
+{
+    let mut bufs = BufList::new();
+
+    futures_util::pin_mut!(body);
+    while let Some(buf) = body.data().await {
+        let buf = buf?;
+        if buf.has_remaining() {
+            bufs.push(buf);
+        }
+    }
+
+    Ok(bufs)
+}

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -18,11 +18,16 @@
 pub use bytes::{Buf, Bytes};
 pub use http_body::Body as HttpBody;
 
+pub use self::aggregate::aggregate;
 pub use self::body::{Body, Sender};
+pub use self::to_bytes::to_bytes;
+
 pub(crate) use self::payload::Payload;
 
+mod aggregate;
 mod body;
 mod payload;
+mod to_bytes;
 
 /// An optimization to try to take a full body if immediately available.
 ///

--- a/src/body/to_bytes.rs
+++ b/src/body/to_bytes.rs
@@ -1,0 +1,36 @@
+use bytes::{Buf, BufMut, Bytes};
+
+use super::HttpBody;
+
+/// dox
+pub async fn to_bytes<T>(body: T) -> Result<Bytes, T::Error>
+where
+    T: HttpBody,
+{
+    futures_util::pin_mut!(body);
+
+    // If there's only 1 chunk, we can just return Buf::to_bytes()
+    let mut first = if let Some(buf) = body.data().await {
+        buf?
+    } else {
+        return Ok(Bytes::new());
+    };
+
+    let second = if let Some(buf) = body.data().await {
+        buf?
+    } else {
+        return Ok(first.to_bytes());
+    };
+
+    // With more than 1 buf, we gotta flatten into a Vec first.
+    let cap = first.remaining() + second.remaining() + body.size_hint().lower() as usize;
+    let mut vec = Vec::with_capacity(cap);
+    vec.put(first);
+    vec.put(second);
+
+    while let Some(buf) = body.data().await {
+        vec.put(buf?);
+    }
+
+    Ok(vec.into())
+}

--- a/src/common/buf.rs
+++ b/src/common/buf.rs
@@ -1,0 +1,75 @@
+use std::collections::VecDeque;
+use std::io::IoSlice;
+
+use bytes::Buf;
+
+pub(crate) struct BufList<T> {
+    bufs: VecDeque<T>,
+}
+
+impl<T: Buf> BufList<T> {
+    pub(crate) fn new() -> BufList<T> {
+        BufList {
+            bufs: VecDeque::new(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn push(&mut self, buf: T) {
+        debug_assert!(buf.has_remaining());
+        self.bufs.push_back(buf);
+    }
+
+    #[inline]
+    pub(crate) fn bufs_cnt(&self) -> usize {
+        self.bufs.len()
+    }
+}
+
+impl<T: Buf> Buf for BufList<T> {
+    #[inline]
+    fn remaining(&self) -> usize {
+        self.bufs.iter().map(|buf| buf.remaining()).sum()
+    }
+
+    #[inline]
+    fn bytes(&self) -> &[u8] {
+        for buf in &self.bufs {
+            return buf.bytes();
+        }
+        &[]
+    }
+
+    #[inline]
+    fn advance(&mut self, mut cnt: usize) {
+        while cnt > 0 {
+            {
+                let front = &mut self.bufs[0];
+                let rem = front.remaining();
+                if rem > cnt {
+                    front.advance(cnt);
+                    return;
+                } else {
+                    front.advance(rem);
+                    cnt -= rem;
+                }
+            }
+            self.bufs.pop_front();
+        }
+    }
+
+    #[inline]
+    fn bytes_vectored<'t>(&'t self, dst: &mut [IoSlice<'t>]) -> usize {
+        if dst.is_empty() {
+            return 0;
+        }
+        let mut vecs = 0;
+        for buf in &self.bufs {
+            vecs += buf.bytes_vectored(&mut dst[vecs..]);
+            if vecs == dst.len() {
+                break;
+            }
+        }
+        vecs
+    }
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -7,6 +7,7 @@ macro_rules! ready {
     };
 }
 
+pub(crate) mod buf;
 pub(crate) mod drain;
 pub(crate) mod exec;
 pub(crate) mod io;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -11,12 +11,12 @@ use std::task::{Context, Poll};
 use std::thread;
 use std::time::Duration;
 
+use hyper::body::to_bytes as concat;
 use hyper::{Body, Client, Method, Request, StatusCode};
 
 use futures_channel::oneshot;
 use futures_core::{Future, Stream, TryFuture};
 use futures_util::future::{self, FutureExt, TryFutureExt};
-use futures_util::StreamExt;
 use tokio::net::TcpStream;
 use tokio::runtime::Runtime;
 
@@ -26,14 +26,6 @@ fn s(buf: &[u8]) -> &str {
 
 fn tcp_connect(addr: &SocketAddr) -> impl Future<Output = std::io::Result<TcpStream>> {
     TcpStream::connect(*addr)
-}
-
-async fn concat(mut body: Body) -> Result<bytes::Bytes, hyper::Error> {
-    let mut vec = Vec::new();
-    while let Some(chunk) = body.next().await {
-        vec.extend_from_slice(&chunk?);
-    }
-    Ok(vec.into())
 }
 
 macro_rules! test {


### PR DESCRIPTION
Adds utility functions to `hyper::body` to help asynchronously
collecting all the buffers of some `HttpBody` into one.

- `aggregate` will collect all into an `impl Buf` without copying the
  contents. This is ideal if you don't need a contiguous buffer.
- `to_bytes` will copy all the data into a single contiguous `Bytes`
  buffer.

