### PR TITLE
Add Body::to_vec() convenience method

### DIFF
--- a/src/body/body.rs
+++ b/src/body/body.rs
@@ -18,7 +18,7 @@ type BodySender = mpsc::Sender<Result<Bytes, crate::Error>>;
 
 /// A stream of `Bytes`s, used when receiving bodies.
 ///
-/// A good default `Payload` to use in many applications.
+/// A good default `HttpBody` to use in many applications.
 #[must_use = "streams do nothing unless polled"]
 pub struct Body {
     kind: Kind,

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2467,6 +2467,28 @@ mod conn {
     }
 }
 
+#[cfg(feature = "stream")]
+mod body {
+    use hyper::body::Body;
+    use tokio;
+
+    #[tokio::test]
+    async fn body_to_vec_ok() {
+        let chunks: Vec<Result<_, ::std::io::Error>> = vec![Ok("hello"), Ok(" "), Ok("world")];
+        let stream = futures_util::stream::iter(chunks);
+        let body = Body::wrap_stream(stream);
+        assert_eq!(&body.to_vec(32).await.unwrap(), b"hello world");
+    }
+
+    #[tokio::test]
+    async fn body_to_vec_err() {
+        let chunks: Vec<Result<_, ::std::io::Error>> = vec![Ok("hello"), Ok(" "), Ok("world")];
+        let stream = futures_util::stream::iter(chunks);
+        let body = Body::wrap_stream(stream);
+        assert!(&body.to_vec(8).await.is_err());
+    }
+}
+
 trait FutureHyperExt: TryFuture {
     fn expect(self, msg: &'static str) -> Pin<Box<dyn Future<Output = Self::Ok>>>;
 }


### PR DESCRIPTION
Reusing this error is a little ugly, let me know if this makes sense and how you'd want it to look.