### PR TITLE
feat(client): expose `hyper::client::connect::Connect` trait alias

### DIFF
--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -637,10 +637,13 @@ mod tests {
 
     use ::http::Uri;
 
-    use super::super::sealed::Connect;
+    use super::super::sealed::{Connect, ConnectSvc};
     use super::HttpConnector;
 
-    async fn connect<C>(connector: C, dst: Uri) -> Result<C::Transport, C::Error>
+    async fn connect<C>(
+        connector: C,
+        dst: Uri,
+    ) -> Result<<C::_Svc as ConnectSvc>::Connection, <C::_Svc as ConnectSvc>::Error>
     where
         C: Connect,
     {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -150,8 +150,6 @@ impl Client<(), Body> {
 impl<C, B> Client<C, B>
 where
     C: Connect + Clone + Send + Sync + 'static,
-    C::Transport: Unpin + Send + 'static,
-    C::Future: Unpin + Send + 'static,
     B: Payload + Send + 'static,
     B::Data: Send,
 {
@@ -548,8 +546,6 @@ where
 impl<C, B> tower_service::Service<Request<B>> for Client<C, B>
 where
     C: Connect + Clone + Send + Sync + 'static,
-    C::Transport: Unpin + Send + 'static,
-    C::Future: Unpin + Send + 'static,
     B: Payload + Send + 'static,
     B::Data: Send,
 {


### PR DESCRIPTION
This is *just* a "trait alias". It is automatically implemented for all
`Service<Uri>`s that have the required bounds. It's purpose being public
is to ease setting trait bounds outside of hyper. Therefore, it doesn't
have any exposed associated types, to prevent otherwise relying on any
super-traits that hyper requires.

