### PR TITLE
fix(http1): fix response with non-chunked transfer-encoding to be close-delimited

### DIFF
--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -47,7 +47,7 @@ pub(crate) enum Dispatched {
 mod body_length {
     use std::fmt;
 
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[derive(Clone, Copy, PartialEq, Eq)]
     pub(crate) struct DecodedLength(u64);
 
     const MAX_LEN: u64 = ::std::u64::MAX - 2;
@@ -88,6 +88,16 @@ mod body_length {
             } else {
                 warn!("content-length bigger than maximum: {} > {}", len, MAX_LEN);
                 Err(crate::error::Parse::TooLarge)
+            }
+        }
+    }
+
+    impl fmt::Debug for DecodedLength {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match *self {
+                DecodedLength::CLOSE_DELIMITED => f.write_str("CLOSE_DELIMITED"),
+                DecodedLength::CHUNKED => f.write_str("CHUNKED"),
+                DecodedLength(n) => f.debug_tuple("DecodedLength").field(&n).finish(),
             }
         }
     }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -656,6 +656,35 @@ test! {
 }
 
 test! {
+    name: client_response_transfer_encoding_not_chunked,
+
+    server:
+        expected: "\
+            GET /te-not-chunked HTTP/1.1\r\n\
+            host: {addr}\r\n\
+            \r\n\
+            ",
+        reply: "\
+            HTTP/1.1 200 OK\r\n\
+            transfer-encoding: yolo\r\n\
+            \r\n\
+            hallo\
+            ",
+
+    client:
+        request: {
+            method: GET,
+            url: "http://{addr}/te-not-chunked",
+        },
+        response:
+            status: OK,
+            headers: {
+                "transfer-encoding" => "yolo",
+            },
+            body: &b"hallo"[..],
+}
+
+test! {
     name: client_pipeline_responses_extra,
 
     server:


### PR DESCRIPTION
Closes #2058

