### PR TITLE
Chunk method to detect if it is the final part of real http-chunk or not

### DIFF
--- a/src/body/chunk.rs
+++ b/src/body/chunk.rs
@@ -9,6 +9,7 @@ use bytes::{Buf, Bytes};
 /// A `Chunk` can be easily created by many of Rust's standard types that
 /// represent a collection of bytes, using `Chunk::from`.
 pub struct Chunk {
+    is_final: bool,
     /// The buffer of bytes making up this body.
     bytes: Bytes,
 }
@@ -29,6 +30,16 @@ impl Chunk {
     pub fn into_bytes(self) -> Bytes {
         self.into()
     }
+
+    #[inline]
+    pub(crate) fn set_end_of_chunk(&mut self, complete: bool) {
+        self.is_final = complete;
+    }
+
+    /// Hyper can return just part of the `Chunk`.
+    /// This mark shows if it is the final part of the `Chunk` or not.
+    #[inline]
+    pub fn is_end_of_chunk(&self) -> bool { self.is_final }
 }
 
 impl Buf for Chunk {
@@ -83,6 +94,7 @@ impl From<Bytes> for Chunk {
     #[inline]
     fn from(bytes: Bytes) -> Chunk {
         Chunk {
+            is_final: false,
             bytes: bytes,
         }
     }

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -209,7 +209,7 @@ where I: AsyncRead + AsyncWrite,
                             (Reading::Closed, None)
                         } else {
                             let mut chunk = Chunk::from(slice);
-                            chunk.set_end_of_chunk(dbg!(decoder.is_end_of_chunk()));
+                            chunk.set_end_of_chunk(decoder.is_end_of_chunk());
                             return Ok(Async::Ready(Some(chunk)));
                         };
                         (reading, Ok(Async::Ready(chunk)))

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -208,7 +208,9 @@ where I: AsyncRead + AsyncWrite,
                             // an empty slice...
                             (Reading::Closed, None)
                         } else {
-                            return Ok(Async::Ready(Some(Chunk::from(slice))));
+                            let mut chunk = Chunk::from(slice);
+                            chunk.set_end_of_chunk(dbg!(decoder.is_end_of_chunk()));
+                            return Ok(Async::Ready(Some(chunk)));
                         };
                         (reading, Ok(Async::Ready(chunk)))
                     },

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -93,6 +93,13 @@ impl Decoder {
         }
     }
 
+    pub fn is_end_of_chunk(&self) -> bool {
+        match self.kind {
+            Chunked(_, size) if size == 0 => true,
+            _ => false
+        }
+    }
+
     pub fn decode<R: MemRead>(&mut self, body: &mut R) -> Poll<Bytes, io::Error> {
         trace!("decode; state={:?}", self.kind);
         match self.kind {
@@ -115,6 +122,7 @@ impl Decoder {
             }
             Chunked(ref mut state, ref mut size) => {
                 loop {
+                    dbg!(&size);
                     let mut buf = None;
                     // advances the chunked state
                     *state = try_ready!(state.step(body, size, &mut buf));

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -122,7 +122,6 @@ impl Decoder {
             }
             Chunked(ref mut state, ref mut size) => {
                 loop {
-                    dbg!(&size);
                     let mut buf = None;
                     // advances the chunked state
                     *state = try_ready!(state.step(body, size, &mut buf));


### PR DESCRIPTION
feat(client): Chunk method to detect if it is the final part of real http-chunk or not

During chunked transfer - hyper can return only part of http-chunk and it does not provide ability to detect if it is just part of the chunk or not. The solution could be to fill chunks in the buffer until you know that you read full size of the http-chunk-len. This PR adds Chunk::is_end_of_chunk(&self) -> bool method which return true - if you read http-chunk-len.

```rust
let mut buf = Vec::new();
body.for_each(move |chunk| {
    let is_final = chunk.is_end_of_chunk();
    buf.extend_from_slice(&chunk.into_bytes());

   if !is_final {
      return Ok(())
   }

   println!("buf contains valid json");
   buf.clear();
}
```
