### PR TITLE
feat(client): impl tower_service::Service for &Client

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -562,6 +562,26 @@ where
     }
 }
 
+impl<C, B> tower_service::Service<Request<B>> for &'_ Client<C, B>
+where
+    C: Connect + Clone + Send + Sync + 'static,
+    B: HttpBody + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+{
+    type Response = Response<Body>;
+    type Error = crate::Error;
+    type Future = ResponseFuture;
+
+    fn poll_ready(&mut self, _: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        self.request(req)
+    }
+}
+
 impl<C: Clone, B> Clone for Client<C, B> {
     fn clone(&self) -> Client<C, B> {
         Client {


### PR DESCRIPTION
There's a blanket implementation of `tower_service::Service` for `&mut S` but not for `&S`. Since `hyper::Client::request` takes `&self` only, `&Client` can implement `Service`, allowing users to take advantage of Tower's abstraction without additional ownership restrictions.