### PR TITLE
fix(http2): add client content-length header accroding to rfc7230

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,6 +1,7 @@
 use bytes::BytesMut;
 use http::header::{HeaderValue, OccupiedEntry, ValueIter};
 use http::header::{CONTENT_LENGTH, TRANSFER_ENCODING};
+use http::method::Method;
 use http::HeaderMap;
 
 pub fn connection_keep_alive(value: &HeaderValue) -> bool {
@@ -54,6 +55,13 @@ pub fn content_length_parse_all_values(values: ValueIter<'_, HeaderValue>) -> Op
         Some(n)
     } else {
         None
+    }
+}
+
+pub fn method_has_defined_payload_semantics(method: &Method) -> bool {
+    match *method {
+        Method::GET | Method::HEAD | Method::DELETE | Method::CONNECT => false,
+        _ => true,
     }
 }
 

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -120,7 +120,9 @@ where
                     let mut req = ::http::Request::from_parts(head, ());
                     super::strip_connection_headers(req.headers_mut(), true);
                     if let Some(len) = body.size_hint().exact() {
-                        headers::set_content_length_if_missing(req.headers_mut(), len);
+                        if len != 0 || headers::method_has_defined_payload_semantics(req.method()) {
+                            headers::set_content_length_if_missing(req.headers_mut(), len);
+                        }
                     }
                     let eos = body.is_end_stream();
                     let (fut, body_tx) = match self.h2_tx.send_request(req, eos) {


### PR DESCRIPTION
This patch adds content-length header for client request according to rfc7230.

Current implementation adds content-length header for every client request if there is no one. However, according [rfc7230](https://tools.ietf.org/html/rfc7230#section-3.3.2): ` A user agent SHOULD NOT send a Content-Length header field when the request message does not contain a payload body and the method semantics do not anticipate such a body.`

 Moreover, in [rfc7230](https://tools.ietf.org/html/rfc7231#section-4), there are similar comments for HTTP Method GET, HEAD, DELETE, CONNECT. For example, `A payload within a GET request message has no defined semantics; sending a payload body on a GET request might cause some existing implementations to reject the request.`

In our situation, current implementation adds a header `Content-Length: 0` for the GET method, and the server returns 500.

It is necessary to add the header more accurately.