### PR TITLE
style: use just std instead of ::std in paths

### DIFF
--- a/src/body/body.rs
+++ b/src/body/body.rs
@@ -128,7 +128,7 @@ impl Body {
     ///
     /// ```
     /// # use hyper::Body;
-    /// let chunks: Vec<Result<_, ::std::io::Error>> = vec![
+    /// let chunks: Vec<Result<_, std::io::Error>> = vec![
     ///     Ok("hello"),
     ///     Ok(" "),
     ///     Ok("world"),

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -692,7 +692,7 @@ mod tests {
         let local_timeout = Duration::default();
         let unreachable_v4_timeout = measure_connect(unreachable_ipv4_addr()).1;
         let unreachable_v6_timeout = measure_connect(unreachable_ipv6_addr()).1;
-        let fallback_timeout = ::std::cmp::max(unreachable_v4_timeout, unreachable_v6_timeout)
+        let fallback_timeout = std::cmp::max(unreachable_v4_timeout, unreachable_v6_timeout)
             + Duration::from_millis(250);
 
         let scenarios = &[
@@ -849,7 +849,7 @@ mod tests {
         fn measure_connect(addr: IpAddr) -> (bool, Duration) {
             let start = Instant::now();
             let result =
-                ::std::net::TcpStream::connect_timeout(&(addr, 80).into(), Duration::from_secs(1));
+                std::net::TcpStream::connect_timeout(&(addr, 80).into(), Duration::from_secs(1));
 
             let reachable = result.is_ok() || result.unwrap_err().kind() == io::ErrorKind::TimedOut;
             let duration = start.elapsed();

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -171,7 +171,7 @@ impl<T: Poolable> Pool<T> {
     }
 
     #[cfg(test)]
-    fn locked(&self) -> ::std::sync::MutexGuard<'_, PoolInner<T>> {
+    fn locked(&self) -> std::sync::MutexGuard<'_, PoolInner<T>> {
         self.inner.as_ref().expect("enabled").lock().expect("lock")
     }
 
@@ -899,7 +899,7 @@ mod tests {
             super::Config {
                 enabled: true,
                 keep_alive_timeout: Some(Duration::from_millis(10)),
-                max_idle_per_host: ::std::usize::MAX,
+                max_idle_per_host: std::usize::MAX,
             },
             &Exec::Default,
         );

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -36,7 +36,7 @@ fn retryable_request() {
             try_ready!(sock1.read(&mut [0u8; 512]));
             try_ready!(sock1.write(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"));
             Ok(Async::Ready(()))
-        }).map_err(|e: ::std::io::Error| panic!("srv1 poll_fn error: {}", e));
+        }).map_err(|e: std::io::Error| panic!("srv1 poll_fn error: {}", e));
         rt.block_on(res1.join(srv1)).expect("res1");
     }
     drop(sock1);
@@ -53,7 +53,7 @@ fn retryable_request() {
         try_ready!(sock2.read(&mut [0u8; 512]));
         try_ready!(sock2.write(b"HTTP/1.1 222 OK\r\nContent-Length: 0\r\n\r\n"));
         Ok(Async::Ready(()))
-    }).map_err(|e: ::std::io::Error| panic!("srv2 poll_fn error: {}", e));
+    }).map_err(|e: std::io::Error| panic!("srv2 poll_fn error: {}", e));
 
     rt.block_on(res2.join(srv2)).expect("res2");
 }
@@ -82,7 +82,7 @@ fn conn_reset_after_write() {
             try_ready!(sock1.read(&mut [0u8; 512]));
             try_ready!(sock1.write(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"));
             Ok(Async::Ready(()))
-        }).map_err(|e: ::std::io::Error| panic!("srv1 poll_fn error: {}", e));
+        }).map_err(|e: std::io::Error| panic!("srv1 poll_fn error: {}", e));
         rt.block_on(res1.join(srv1)).expect("res1");
     }
 
@@ -102,7 +102,7 @@ fn conn_reset_after_write() {
         try_ready!(sock1.as_mut().unwrap().read(&mut [0u8; 512]));
         sock1.take();
         Ok(Async::Ready(()))
-    }).map_err(|e: ::std::io::Error| panic!("srv2 poll_fn error: {}", e));
+    }).map_err(|e: std::io::Error| panic!("srv2 poll_fn error: {}", e));
     let err = rt.block_on(res2.join(srv2)).expect_err("res2");
     assert!(err.is_incomplete_message(), "{:?}", err);
 }
@@ -144,7 +144,7 @@ fn checkout_win_allows_connect_future_to_be_pooled() {
                 0\r\n\r\n\
             "));
             Ok(Async::Ready(()))
-        }).map_err(|e: ::std::io::Error| panic!("srv1 poll_fn error: {}", e));
+        }).map_err(|e: std::io::Error| panic!("srv1 poll_fn error: {}", e));
 
         rt.block_on(res1.join(srv1)).expect("res1").0
     };
@@ -162,7 +162,7 @@ fn checkout_win_allows_connect_future_to_be_pooled() {
             try_ready!(sock1.read(&mut [0u8; 512]));
             try_ready!(sock1.write(b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nx"));
             Ok(Async::Ready(()))
-        }).map_err(|e: ::std::io::Error| panic!("srv2 poll_fn error: {}", e));
+        }).map_err(|e: std::io::Error| panic!("srv2 poll_fn error: {}", e));
 
         rt.block_on(res2.join(drain).join(srv2)).expect("res2");
     }
@@ -199,7 +199,7 @@ fn checkout_win_allows_connect_future_to_be_pooled() {
             try_ready!(sock2.read(&mut [0u8; 512]));
             try_ready!(sock2.write(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"));
             Ok(Async::Ready(()))
-        }).map_err(|e: ::std::io::Error| panic!("srv3 poll_fn error: {}", e));
+        }).map_err(|e: std::io::Error| panic!("srv3 poll_fn error: {}", e));
 
         rt.block_on(res3.join(srv3)).expect("res3");
     }
@@ -232,7 +232,7 @@ fn bench_http1_get_0b(b: &mut test::Bencher) {
             try_ready!(sock1.read(&mut [0u8; 512]));
             try_ready!(sock1.write(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"));
             Ok(Async::Ready(()))
-        }).map_err(|e: ::std::io::Error| panic!("srv1 poll_fn error: {}", e));
+        }).map_err(|e: std::io::Error| panic!("srv1 poll_fn error: {}", e));
         rt.block_on(res1.join(srv1)).expect("res1");
     });
 }
@@ -264,7 +264,7 @@ fn bench_http1_get_10b(b: &mut test::Bencher) {
             try_ready!(sock1.read(&mut [0u8; 512]));
             try_ready!(sock1.write(b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\n0123456789"));
             Ok(Async::Ready(()))
-        }).map_err(|e: ::std::io::Error| panic!("srv1 poll_fn error: {}", e));
+        }).map_err(|e: std::io::Error| panic!("srv1 poll_fn error: {}", e));
         rt.block_on(res1.join(srv1)).expect("res1");
     });
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,8 +1,8 @@
 macro_rules! ready {
     ($e:expr) => {
         match $e {
-            ::std::task::Poll::Ready(v) => v,
-            ::std::task::Poll::Pending => return ::std::task::Poll::Pending,
+            std::task::Poll::Ready(v) => v,
+            std::task::Poll::Pending => return std::task::Poll::Pending,
         }
     };
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::io;
 
 /// Result type often returned from methods that can have hyper `Error`s.
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 type Cause = Box<dyn StdError + Send + Sync>;
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -37,7 +37,7 @@ impl Duplex {
         let mut inner = DuplexInner {
             handle_read_task: None,
             read: AsyncIo::new_buf(Vec::new(), 0),
-            write: AsyncIo::new_buf(Vec::new(), ::std::usize::MAX),
+            write: AsyncIo::new_buf(Vec::new(), std::usize::MAX),
         };
 
         inner.read.park_tasks(true);

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -757,7 +757,7 @@ impl fmt::Debug for Writing {
     }
 }
 
-impl ::std::ops::BitAndAssign<bool> for KA {
+impl std::ops::BitAndAssign<bool> for KA {
     fn bitand_assign(&mut self, enabled: bool) {
         if !enabled {
             trace!("remote disabling keep-alive");
@@ -1022,7 +1022,7 @@ mod tests {
         conn.state.idle();
 
         match conn.poll() {
-            Err(ref err) if err.kind() == ::std::io::ErrorKind::UnexpectedEof => {},
+            Err(ref err) if err.kind() == std::io::ErrorKind::UnexpectedEof => {},
             other => panic!("unexpected frame: {:?}", other)
         }
     }
@@ -1046,7 +1046,7 @@ mod tests {
             conn.state.busy();
 
             match conn.poll() {
-                Err(ref err) if err.kind() == ::std::io::ErrorKind::UnexpectedEof => {},
+                Err(ref err) if err.kind() == std::io::ErrorKind::UnexpectedEof => {},
                 other => panic!("unexpected frame: {:?}", other)
             }
             Ok(())

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -386,7 +386,7 @@ mod tests {
 
     impl<'a> MemRead for &'a [u8] {
         fn read_mem(&mut self, _: &mut task::Context<'_>, len: usize) -> Poll<io::Result<Bytes>> {
-            let n = ::std::cmp::min(len, self.len());
+            let n = std::cmp::min(len, self.len());
             if n > 0 {
                 let (a, b) = self.split_at(n);
                 let buf = Bytes::copy_from_slice(a);

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -278,7 +278,7 @@ where
 {
     fn read_mem(&mut self, cx: &mut task::Context<'_>, len: usize) -> Poll<io::Result<Bytes>> {
         if !self.read_buf.is_empty() {
-            let n = ::std::cmp::min(len, self.read_buf.len());
+            let n = std::cmp::min(len, self.read_buf.len());
             Poll::Ready(Ok(self.read_buf.split_to(n).freeze()))
         } else {
             let n = ready!(self.poll_read_from_io(cx))?;
@@ -773,7 +773,7 @@ mod tests {
         }
 
         let mut max = 8192;
-        while max < ::std::usize::MAX {
+        while max < std::usize::MAX {
             fuzz(max);
             max = (max / 2).saturating_mul(3);
         }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -50,7 +50,7 @@ mod body_length {
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub(crate) struct DecodedLength(u64);
 
-    const MAX_LEN: u64 = ::std::u64::MAX - 2;
+    const MAX_LEN: u64 = std::u64::MAX - 2;
 
     impl DecodedLength {
         pub(crate) const CLOSE_DELIMITED: DecodedLength = DecodedLength(::std::u64::MAX);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -21,7 +21,7 @@ use tokio::net::TcpStream;
 use tokio::runtime::Runtime;
 
 fn s(buf: &[u8]) -> &str {
-    ::std::str::from_utf8(buf).expect("from_utf8")
+    std::str::from_utf8(buf).expect("from_utf8")
 }
 
 fn tcp_connect(addr: &SocketAddr) -> impl Future<Output = std::io::Result<TcpStream>> {
@@ -2503,7 +2503,7 @@ trait FutureHyperExt: TryFuture {
 impl<F> FutureHyperExt for F
 where
     F: TryFuture + 'static,
-    F::Error: ::std::fmt::Debug,
+    F::Error: std::fmt::Debug,
 {
     fn expect(self, msg: &'static str) -> Pin<Box<dyn Future<Output = Self::Ok>>> {
         Box::pin(

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2066,7 +2066,7 @@ impl ServeOptions {
 }
 
 fn s(buf: &[u8]) -> &str {
-    ::std::str::from_utf8(buf).unwrap()
+    std::str::from_utf8(buf).unwrap()
 }
 
 fn has_header(msg: &str, name: &str) -> bool {

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -208,12 +208,12 @@ macro_rules! __internal_headers_map {
 
 macro_rules! __internal_headers_eq {
     (@pat $name: expr, $pat:pat) => {
-        ::std::sync::Arc::new(move |__hdrs: &hyper::HeaderMap| {
+        std::sync::Arc::new(move |__hdrs: &hyper::HeaderMap| {
             match __hdrs.get($name) {
                 $pat => (),
                 other => panic!("headers[{}] was not {}: {:?}", stringify!($name), stringify!($pat), other),
             }
-        }) as ::std::sync::Arc<dyn Fn(&hyper::HeaderMap) + Send + Sync>
+        }) as std::sync::Arc<dyn Fn(&hyper::HeaderMap) + Send + Sync>
     };
     (@val $name: expr, NONE) => {
         __internal_headers_eq!(@pat $name, None);
@@ -223,13 +223,13 @@ macro_rules! __internal_headers_eq {
     };
     (@val $name: expr, $val:expr) => ({
         let __val = Option::from($val);
-        ::std::sync::Arc::new(move |__hdrs: &hyper::HeaderMap| {
+        std::sync::Arc::new(move |__hdrs: &hyper::HeaderMap| {
             if let Some(ref val) = __val {
                 assert_eq!(__hdrs.get($name).expect(stringify!($name)), val.to_string().as_str(), stringify!($name));
             } else {
                 assert_eq!(__hdrs.get($name), None, stringify!($name));
             }
-        }) as ::std::sync::Arc<dyn Fn(&hyper::HeaderMap) + Send + Sync>
+        }) as std::sync::Arc<dyn Fn(&hyper::HeaderMap) + Send + Sync>
     });
     ($headers:ident, { $($name:expr => $val:tt,)* }) => {
         $(


### PR DESCRIPTION
It was a long time ago one had to write `::std` to make rustc recognize the path. Now just `std` works fine.