### PR TITLE
feat: Implement Clone/Copy on ServiceFn and MakeServiceFn

### DIFF
--- a/src/service/make.rs
+++ b/src/service/make.rs
@@ -15,7 +15,6 @@ pub trait MakeConnection<Target>: self::sealed::Sealed<(Target,)> {
     type Future: Future<Output = Result<Self::Connection, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>>;
-
     fn make_connection(&mut self, target: Target) -> Self::Future;
 }
 
@@ -144,7 +143,8 @@ where
     MakeServiceFn { f }
 }
 
-// Not exported from crate as this will likely be replaced with `impl Service`.
+/// `MakeService` returned from [`make_service_fn`]
+#[derive(Clone, Copy)]
 pub struct MakeServiceFn<F> {
     f: F,
 }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -45,5 +45,5 @@ pub(crate) use self::http::HttpService;
 pub(crate) use self::make::{MakeConnection, MakeServiceRef};
 pub(crate) use self::oneshot::{oneshot, Oneshot};
 
-pub use self::make::{make_service_fn, MakeServiceFn};
-pub use self::util::{service_fn, ServiceFn};
+pub use self::make::make_service_fn;
+pub use self::util::service_fn;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -45,5 +45,5 @@ pub(crate) use self::http::HttpService;
 pub(crate) use self::make::{MakeConnection, MakeServiceRef};
 pub(crate) use self::oneshot::{oneshot, Oneshot};
 
-pub use self::make::make_service_fn;
-pub use self::util::service_fn;
+pub use self::make::{make_service_fn, MakeServiceFn};
+pub use self::util::{service_fn, ServiceFn};

--- a/src/service/util.rs
+++ b/src/service/util.rs
@@ -35,7 +35,7 @@ where
     }
 }
 
-// Not exported from crate as this will likely be replaced with `impl Service`.
+/// Service returned by [`service_fn`]
 pub struct ServiceFn<F, R> {
     f: F,
     _req: PhantomData<fn(R)>,
@@ -68,3 +68,17 @@ impl<F, R> fmt::Debug for ServiceFn<F, R> {
         f.debug_struct("impl Service").finish()
     }
 }
+
+impl<F, R> Clone for ServiceFn<F, R>
+where
+    F: Clone,
+{
+    fn clone(&self) -> Self {
+        ServiceFn {
+            f: self.f.clone(),
+            _req: PhantomData,
+        }
+    }
+}
+
+impl<F, R> Copy for ServiceFn<F, R> where F: Copy {}


### PR DESCRIPTION
And expose them in docs. Since Clone and Copy can't be propagated out
via `impl Service` I believe it is better to expose them now.
`tower::service_fn` already implement `Clone` and `Copy.

