### PR TITLE
perf(body): reduce memory size of Body by a u64

### DIFF
--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -239,7 +239,7 @@ where
                 let mut body = match body_len {
                     DecodedLength::ZERO => Body::empty(),
                     other => {
-                        let (tx, rx) = Body::new_channel(other.into_opt());
+                        let (tx, rx) = Body::new_channel(other);
                         self.body_tx = Some(tx);
                         rx
                     }

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -4,11 +4,10 @@ use futures_util::stream::StreamExt as _;
 use h2::client::{Builder, SendRequest};
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use super::{PipeToSendStream, SendBuf};
+use super::{decode_content_length, PipeToSendStream, SendBuf};
 use crate::body::Payload;
 use crate::common::{task, Exec, Future, Never, Pin, Poll};
 use crate::headers;
-use crate::headers::content_length_parse_all;
 use crate::proto::Dispatched;
 use crate::{Body, Request, Response};
 
@@ -159,7 +158,7 @@ where
 
                     let fut = fut.map(move |result| match result {
                         Ok(res) => {
-                            let content_length = content_length_parse_all(res.headers());
+                            let content_length = decode_content_length(res.headers());
                             let res = res.map(|stream| crate::Body::h2(stream, content_length));
                             Ok(res)
                         }


### PR DESCRIPTION
Replaces the `Option<u64>` content-length with a `DecodedLength`, which
stores its unknown-ness as `u64::MAX`.

