### PR TITLE
feat(server): add poll_peek to AddrStream

### DIFF
--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -223,6 +223,15 @@ mod addr_stream {
         pub fn into_inner(self) -> TcpStream {
             self.inner
         }
+
+        /// Attempts to receive data on the socket, without removing that data from the queue, registering the current task for wakeup if data is not yet available.
+        pub fn poll_peek(
+            &mut self,
+            cx: &mut task::Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
+            self.inner.poll_peek(cx, buf)
+        }
     }
 
     impl AsyncRead for AddrStream {

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -224,7 +224,9 @@ mod addr_stream {
             self.inner
         }
 
-        /// Attempts to receive data on the socket, without removing that data from the queue, registering the current task for wakeup if data is not yet available.
+        /// Attempt to receive data on the socket, without removing that data
+        /// from the queue, registering the current task for wakeup if data is
+        /// not yet available.
         pub fn poll_peek(
             &mut self,
             cx: &mut task::Context<'_>,


### PR DESCRIPTION
This was specifically added to peek for the first byte to determine if the connection is HTTP or HTTPS.
I copied the documentation from tokio.