### PR TITLE
feat(client): rename `client::Builder` pool options

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1282,13 +1282,9 @@ mod dispatch_impl {
             let _ = rx2.recv();
         });
 
-        let client =
-            Client::builder()
-                .keep_alive(false)
-                .build(DebugConnector::with_http_and_closes(
-                    HttpConnector::new(),
-                    closes_tx,
-                ));
+        let client = Client::builder().pool_max_idle_per_host(0).build(
+            DebugConnector::with_http_and_closes(HttpConnector::new(), closes_tx),
+        );
 
         let req = Request::builder()
             .uri(&*format!("http://{}/a", addr))

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -4,7 +4,6 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc, Mutex,
 };
-use std::time::Duration;
 
 use hyper::client::HttpConnector;
 use hyper::service::{make_service_fn, service_fn};
@@ -326,7 +325,6 @@ async fn async_test(cfg: __TestConfig) {
 
     let connector = HttpConnector::new();
     let client = Client::builder()
-        .keep_alive_timeout(Duration::from_secs(10))
         .http2_only(cfg.client_version == 2)
         .build::<_, Body>(connector);
 
@@ -450,7 +448,6 @@ struct ProxyConfig {
 
 fn naive_proxy(cfg: ProxyConfig) -> (SocketAddr, impl Future<Output = ()>) {
     let client = Client::builder()
-        .keep_alive_timeout(Duration::from_secs(10))
         .http2_only(cfg.version == 2)
         .build_http::<Body>();
 


### PR DESCRIPTION
- Renamed `keep_alive_timeout` to `pool_idle_timeout`.
- Renamed `max_idle_per_host` to `pool_max_idle_per_host`.
- Deprecated `keep_alive(bool)` due to confusing name. To disable the
  connection pool, call `pool_max_idle_per_host(0)`.

