### PR TITLE
Force tokio to be at least 0.2.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ log = "0.4"
 pin-project = "0.4"
 time = "0.1"
 tower-service = "0.3"
-tokio = { version = "0.2", features = ["sync"] }
+tokio = { version = "0.2.5", features = ["sync"] }
 want = "0.3"
 
 # Optional


### PR DESCRIPTION
Without this, you can end up with tokio 0.2.4 and hyper 0.13.5 in your
project, leading to a compile error like this:

```
error[E0599]: no method named `try_recv` found for struct `tokio::sync::mpsc::unbounded::UnboundedReceiver<client::dispatch::Envelope<T, U>>` in the current scope
   --> src/client/dispatch.rs:161:26
    |
161 |         match self.inner.try_recv() {
    |                          ^^^^^^^^ method not found in `tokio::sync::mpsc::unbounded::UnboundedReceiver<client::dispatch::Envelope<T, U>>`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: could not compile `hyper`.
```

