### PR TITLE
feat(lib): Move from `log` to `tracing` in a backwards-compatible way

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ http-body = "0.3.1"
 httparse = "1.0"
 h2 = "0.2.2"
 itoa = "0.4.1"
-tracing = { version = "0.1", default-features = false, features = ["std"] }
+tracing = { version = "0.1", default-features = false, features = ["std", "log"] }
 pin-project = "0.4"
 time = "0.1"
 tower-service = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ httparse = "1.0"
 h2 = "0.2.2"
 itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
-pin-project = "0.4"
+pin-project = "0.4.20"
 time = "0.1"
 tower-service = "0.3"
 tokio = { version = "0.2.5", features = ["sync"] }
@@ -82,7 +82,6 @@ __internal_happy_eyeballs_tests = []
 features = [
     "runtime",
     "stream",
-    "log"
 ]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,7 @@ url = "1.0"
 [features]
 default = [
     "runtime",
-    "stream",
-    "log"
+    "stream"
 ]
 runtime = [
     "tcp",
@@ -70,9 +69,6 @@ tcp = [
     "tokio/blocking",
     "tokio/tcp",
     "tokio/time",
-]
-log = [
-    "tracing/log",
 ]
 
 # `impl Stream` for things

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ http-body = "0.3.1"
 httparse = "1.0"
 h2 = "0.2.2"
 itoa = "0.4.1"
-tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
+tracing = { version = "0.1", default-features = false, features = ["std"] }
 pin-project = "0.4"
 time = "0.1"
 tower-service = "0.3"
@@ -59,6 +59,7 @@ url = "1.0"
 default = [
     "runtime",
     "stream",
+    "log"
 ]
 runtime = [
     "tcp",
@@ -69,6 +70,10 @@ tcp = [
     "tokio/blocking",
     "tokio/tcp",
     "tokio/time",
+]
+log = [
+    "tracing/log",
+    "tracing/std"
 ]
 
 # `impl Stream` for things
@@ -82,6 +87,7 @@ __internal_happy_eyeballs_tests = []
 features = [
     "runtime",
     "stream",
+    "log"
 ]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ http-body = "0.3.1"
 httparse = "1.0"
 h2 = "0.2.2"
 itoa = "0.4.1"
-tracing = { version = "0.1", default-features = false, features = ["std", "log"] }
+tracing = { version = "0.1", features = ["log"] }
 pin-project = "0.4"
 time = "0.1"
 tower-service = "0.3"
@@ -73,7 +73,6 @@ tcp = [
 ]
 log = [
     "tracing/log",
-    "tracing/std"
 ]
 
 # `impl Stream` for things

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ http-body = "0.3.1"
 httparse = "1.0"
 h2 = "0.2.2"
 itoa = "0.4.1"
-tracing = { version = "0.1", features = ["log"] }
+tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "0.4"
 time = "0.1"
 tower-service = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ http-body = "0.3.1"
 httparse = "1.0"
 h2 = "0.2.2"
 itoa = "0.4.1"
-log = "0.4"
-pin-project = "0.4.20"
+tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
+pin-project = "0.4"
 time = "0.1"
 tower-service = "0.3"
 tokio = { version = "0.2.5", features = ["sync"] }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -793,13 +793,11 @@ fn absolute_form(uri: &mut Uri) {
 }
 
 fn authority_form(uri: &mut Uri) {
-    if log_enabled!(::log::Level::Warn) {
-        if let Some(path) = uri.path_and_query() {
-            // `https://hyper.rs` would parse with `/` path, don't
-            // annoy people about that...
-            if path != "/" {
-                warn!("HTTP/1.1 CONNECT request stripping path: {:?}", path);
-            }
+    if let Some(path) = uri.path_and_query() {
+        // `https://hyper.rs` would parse with `/` path, don't
+        // annoy people about that...
+        if path != "/" {
+            warn!("HTTP/1.1 CONNECT request stripping path: {:?}", path);
         }
     }
     *uri = match uri.authority() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 #[doc(hidden)]
 pub use http;
 #[macro_use]
-extern crate log;
+extern crate tracing;
 
 #[cfg(all(test, feature = "nightly"))]
 extern crate test;


### PR DESCRIPTION
I've moved Hyper from `log` to `tracing`. Existing `log`-based users shouldn't notice a difference, but `tracing` users will see higher performance when filtering data. This isn't the _end_  of the `tracing` integration that can happen in `Hyper` (e.g., Hyper can start using spans, typed fields, etc.), but _something_ is better than nothing. I'd rather address those points, including examples, in followups.

I've attached a screenshot of the `hello` example working, but the logged information is pulled from `tracing`, not `log`.

<img width="514" alt="Screen Shot 2020-05-16 at 1 23 19 PM" src="https://user-images.githubusercontent.com/2067774/82126298-d8103800-9779-11ea-8f0b-57c632c684d6.png">
