### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ httparse = "1.0"
 h2 = "0.2.2"
 itoa = "0.4.1"
 log = "0.4"
-pin-project = "0.4"
+pin-project = "0.4.17"
 time = "0.1"
 tower-service = "0.3"
 tokio = { version = "0.2.5", features = ["sync"] }

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures_util::future::{self, Either, FutureExt as _};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
 
@@ -30,7 +30,7 @@ use crate::{Body, Request, Response};
 
 type Http1Dispatcher<T, B, R> = proto::dispatch::Dispatcher<proto::dispatch::Client<B>, B, T, R>;
 
-#[pin_project]
+#[pin_project(project = ProtoClientProj)]
 enum ProtoClient<T, B>
 where
     B: HttpBody,
@@ -677,12 +677,10 @@ where
 {
     type Output = crate::Result<proto::Dispatched>;
 
-    #[project]
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        #[project]
         match self.project() {
-            ProtoClient::H1(c) => c.poll(cx),
-            ProtoClient::H2(c) => c.poll(cx),
+            ProtoClientProj::H1(c) => c.poll(cx),
+            ProtoClientProj::H2(c) => c.poll(cx),
         }
     }
 }


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*

