### PR TITLE
docs(examples): add example for integration testing a client/server

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,8 @@ pretty_env_logger = "0.4"
 
 * [`http_proxy`](http_proxy.rs) - A simple HTTP(S) proxy that handle and upgrade `CONNECT` requests and then proxy data between client and remote server.
 
+* [`integration_test`](integration_test.rs) - Shows how hyper can be used to integration test a server or client.
+
 * [`multi_server`](multi_server.rs) - A server that listens to two different ports, a different `Service` per port.
 
 * [`params`](params.rs) - A webserver that accept a form, with a name and a number, checks the parameters are presents and validates the input.

--- a/examples/integration_test.rs
+++ b/examples/integration_test.rs
@@ -1,0 +1,45 @@
+#![deny(warnings)]
+#![warn(rust_2018_idioms)]
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{body, Body, Client, Request, Response, Server, StatusCode};
+
+type Error = Box<dyn std::error::Error + Send + Sync>;
+type Result<T> = std::result::Result<T, Error>;
+
+// Server code for testing. If you're writing an integration test for a server you would use your
+// real server instead of this.
+async fn test_service(request: Request<Body>) -> Result<Response<Body>> {
+    match request.uri().path() {
+        "/my-api" => Ok(Response::builder().body(Body::from("Hello world"))?),
+        _ => Ok(Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::empty())?),
+    }
+}
+
+// Note: In an integration test (in the `tests` directory), you would use `#[tokio::test]` instead
+// of `#[tokio::main]`. Here we need to use `#[tokio::main]` because it's in an example.
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Set up test server. We bind to port 0 which means use an available port, and after starting
+    // the server we get the bound address to run the test against.
+    let make_svc = make_service_fn(|_conn| async { Ok::<_, Error>(service_fn(test_service)) });
+    let server = Server::bind(&([127, 0, 0, 1], 0).into()).serve(make_svc);
+    let base_url = format!("http://{}", server.local_addr());
+
+    // Run server in background. The server will automatically terminate once the test is done.
+    tokio::spawn(server);
+
+    // Client code for testing.. If you're writing an integration test for a client you would use
+    // your real client here and set up a test server with expected responses.
+    let uri = format!("{}/my-api", base_url).parse()?;
+    let client = Client::new();
+    let response = client.get(uri).await?;
+
+    let bytes = body::to_bytes(response).await?;
+    let text = std::str::from_utf8(bytes.as_ref())?;
+
+    assert_eq!("Hello world", text);
+
+    Ok(())
+}


### PR DESCRIPTION
I wrote a small library for a client that does some requests, and I
wanted to write an integration test for it (in `tests/`) and run against
a test server that will automatically shut down at the end of the test.

Being new to async hyper, it took me a while to figure out how to write
it. An example like this would have helped.

The same style of test can also be used if the code being tested is a
server.

