### PR TITLE
[WIP] feat(client): add origin config to client builder

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -56,7 +56,7 @@ use std::time::Duration;
 use futures_channel::oneshot;
 use futures_util::future::{self, Either, FutureExt as _, TryFutureExt as _};
 use http::header::{HeaderValue, HOST, ORIGIN};
-use http::uri::{Scheme};
+use http::uri::Scheme;
 use http::{Method, Request, Response, Uri, Version};
 
 use self::connect::{sealed::Connect, Alpn, Connected, Connection};
@@ -89,7 +89,7 @@ struct Config {
     retry_canceled_requests: bool,
     set_host: bool,
     ver: Ver,
-    origin: String
+    origin: String,
 }
 
 /// A `Future` that will resolve to an HTTP Response.
@@ -320,9 +320,11 @@ where
                 )));
             }
 
-
             if !origin.is_empty() && !origin.eq("/") {
-                req.headers_mut().append(ORIGIN, HeaderValue::from_str(&origin).expect("origin uri must be valid"));
+                req.headers_mut().append(
+                    ORIGIN,
+                    HeaderValue::from_str(&origin).expect("origin uri must be valid"),
+                );
             }
 
             let fut = pooled
@@ -898,7 +900,7 @@ impl Default for Builder {
                 retry_canceled_requests: true,
                 set_host: true,
                 ver: Ver::Auto,
-                origin: String::from("")
+                origin: String::from(""),
             },
             conn_builder: conn::Builder::new(),
             pool_config: pool::Config {
@@ -1173,11 +1175,10 @@ impl Builder {
 
         self.client_config.origin = match origin.port() {
             Some(port) => base_origin.add(format!(":{}", port).as_str()),
-            _ => base_origin
+            _ => base_origin,
         };
         self
     }
-
 
     /// Provide an executor to execute background `Connection` tasks.
     pub fn executor<E>(&mut self, exec: E) -> &mut Self
@@ -1281,5 +1282,4 @@ mod unit_tests {
         assert_eq!(scheme, *"http");
         assert_eq!(host, "hyper.rs");
     }
-
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -55,8 +55,8 @@ use std::time::Duration;
 
 use futures_channel::oneshot;
 use futures_util::future::{self, Either, FutureExt as _, TryFutureExt as _};
-use http::header::{HeaderValue, HOST};
-use http::uri::Scheme;
+use http::header::{HeaderValue, HOST, ORIGIN};
+use http::uri::{Scheme};
 use http::{Method, Request, Response, Uri, Version};
 
 use self::connect::{sealed::Connect, Alpn, Connected, Connection};
@@ -66,6 +66,7 @@ use crate::common::{lazy as hyper_lazy, task, BoxSendFuture, Executor, Future, L
 
 #[cfg(feature = "tcp")]
 pub use self::connect::HttpConnector;
+use std::ops::Add;
 
 pub mod conn;
 pub mod connect;
@@ -83,11 +84,12 @@ pub struct Client<C, B = Body> {
     pool: Pool<PoolClient<B>>,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct Config {
     retry_canceled_requests: bool,
     set_host: bool,
     ver: Ver,
+    origin: String
 }
 
 /// A `Future` that will resolve to an HTTP Response.
@@ -284,6 +286,7 @@ where
     ) -> impl Future<Output = Result<Response<Body>, ClientError<B>>> + Unpin {
         let conn = self.connection_for(pool_key);
 
+        let origin = self.config.origin.clone();
         let set_host = self.config.set_host;
         let executor = self.conn_builder.exec.clone();
         conn.and_then(move |mut pooled| {
@@ -315,6 +318,11 @@ where
                 return Either::Left(future::err(ClientError::Normal(
                     crate::Error::new_user_unsupported_request_method(),
                 )));
+            }
+
+
+            if !origin.is_empty() && !origin.eq("/") {
+                req.headers_mut().append(ORIGIN, HeaderValue::from_str(&origin).expect("origin uri must be valid"));
             }
 
             let fut = pooled
@@ -892,6 +900,7 @@ impl Default for Builder {
                 retry_canceled_requests: true,
                 set_host: true,
                 ver: Ver::Auto,
+                origin: String::from("")
             },
             conn_builder: conn::Builder::new(),
             pool_config: pool::Config {
@@ -1152,6 +1161,26 @@ impl Builder {
         self
     }
 
+    /// Sets the value to provide for the `Origin` header for requests .
+    ///
+    /// If a valid value is provided, it will set the `Origin` header
+    /// for all requests automatically.
+    ///
+    /// Default is `""`.
+    #[inline]
+    pub fn add_origin(&mut self, origin: Uri) -> &mut Self {
+        let scheme = origin.scheme_str().unwrap();
+        let host = origin.host().unwrap();
+        let base_origin = format!("{}://{}", scheme, host);
+
+        self.client_config.origin = match origin.port() {
+            Some(port) => base_origin.add(format!(":{}", port).as_str()),
+            _ => base_origin
+        };
+        self
+    }
+
+
     /// Provide an executor to execute background `Connection` tasks.
     pub fn executor<E>(&mut self, exec: E) -> &mut Self
     where
@@ -1183,7 +1212,7 @@ impl Builder {
         B::Data: Send,
     {
         Client {
-            config: self.client_config,
+            config: self.client_config.clone(),
             conn_builder: self.conn_builder.clone(),
             connector,
             pool: Pool::new(self.pool_config, &self.conn_builder.exec),
@@ -1254,4 +1283,5 @@ mod unit_tests {
         assert_eq!(scheme, *"http");
         assert_eq!(host, "hyper.rs");
     }
+
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2003,13 +2003,15 @@ mod dispatch_impl {
 
             println!("{:?}", String::from_utf8_lossy(&buf[..n]));
 
-            let expected = format!("GET /a HTTP/1.1\r\nhost: {addr}\r\norigin: http://secret-mission\r\n\r\n", addr=addr);
+            let expected = format!(
+                "GET /a HTTP/1.1\r\nhost: {addr}\r\norigin: http://secret-mission\r\n\r\n",
+                addr = addr
+            );
             assert_eq!(s(&buf[..n]), expected);
 
             sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
                 .unwrap();
             let _ = tx1.send(());
-
 
             // prevent this thread from closing until end of test, so the connection
             // stays open and idle until Client is dropped
@@ -2018,9 +2020,11 @@ mod dispatch_impl {
 
         let client = Client::builder()
             .add_origin("http://secret-mission".parse().unwrap())
-            .pool_max_idle_per_host(0).build(
-            DebugConnector::with_http_and_closes(HttpConnector::new(), closes_tx),
-        );
+            .pool_max_idle_per_host(0)
+            .build(DebugConnector::with_http_and_closes(
+                HttpConnector::new(),
+                closes_tx,
+            ));
 
         let req = Request::builder()
             .uri(&*format!("http://{}/a", addr))
@@ -2039,7 +2043,6 @@ mod dispatch_impl {
         let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
         future::select(t, close).await;
     }
-
 }
 
 mod conn {


### PR DESCRIPTION
Took an attempt to provide a solution for #2178 .

I went with the assumption that we'd only want to set when Hyper is used as a Http client.
The `Client::Builder` now has an additional config to accept a value for setting the `Origin` header. Once configured it gets added for every request made.

```
let client = Client::builder()
            .add_origin("http://secret-mission".parse().unwrap())
            .build()
```
Let me know if you think this makes sense. Can iterate on it as required.