### PR TITLE
Use httpdate for server date header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.3.1"
+httpdate = "0.3"
 httparse = "1.0"
 h2 = "0.2.2"
 itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "0.4.20"
-time = "0.1"
 tower-service = "0.3"
 tokio = { version = "0.2.11", features = ["sync"] }
 want = "0.3"


### PR DESCRIPTION
This removes the deprecated `time` crate, and switches to a small implementation using `SystemTime` and an optimized render format specifically needed by the `Date` header.

Running the new benchmarks in `hyper::proto::h1::date`, `check` stayed the same, and `render` went from 400ns to 80ns.