### PR TITLE
feat(client): propagate tracing spans

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ httparse = "1.0"
 h2 = "0.2.2"
 itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
+tracing-futures = { version = "0.2", default-features = false, features = ["std-future"]}
 pin-project = "0.4.20"
 tower-service = "0.3"
 tokio = { version = "0.2.11", features = ["sync"] }


### PR DESCRIPTION
Hyper's clients drive the connection to the server in a background task,
and dispatch requests to it from the `Client` handle types using
channels. This means that the actual work of sending a request and
receiving a response is _not_ performed on the same task as where the
user calls `Client::request`

When `tracing` is used in user code, it can be valuable to see the
`tracing` span context where the call to `Client::request` was made in
Hyper's debug output as well. This would allow associating proto errors
that Hyper logs with the individual request...and the semantic context
in the user's application where that request was made. However, because
the actual work of making the request takes place in a separate task,
the `tracing` span context is not propagated by default.

This branch fixes this by capturing the span context when a request is
made, and propagating it over the channel to be entered by the
background task.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>