### PR TITLE
Add spans for parse_headers and encode_headers

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -474,7 +474,7 @@ where
         self.enforce_version(&mut head);
 
         let buf = self.io.headers_buf();
-        match T::encode(
+        match super::role::encode_headers::<T>(
             Encode {
                 head: &mut head,
                 body,

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -149,7 +149,7 @@ where
         S: Http1Transaction,
     {
         loop {
-            match S::parse(
+            match super::role::parse_headers::<S>(
                 &mut self.read_buf,
                 ParseContext {
                     cached_headers: parse_ctx.cached_headers,


### PR DESCRIPTION
Add `trace` level spans to record time spent parsing and encoding headers.