### PR TITLE
Update echo.rs

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,6 +1,6 @@
 #![deny(warnings)]
 
-use futures_util::TryStreamExt;
+use futures_util::TryStreamExt as _;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 


### PR DESCRIPTION
missing from https://hyper.rs/guides/server/echo/

otherwise compilation error:

use futures_util::TryStreamExt;
  |     ^^^^^^^^^^^^ use of undeclared type or module `futures_util`
