### PR TITLE
docs(server): Docs for conn modules in server and client

### DIFF
--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -7,6 +7,34 @@
 //!
 //! If you don't have need to manage connections yourself, consider using the
 //! higher-level [Server](super) API.
+//!
+//! ## Example
+//! A simple example that uses the `Http` struct to talk HTTP over a Tokio TCP stream
+//! ```no_run
+//! use http::{Request, Response, StatusCode};
+//! use hyper::{server::conn::Http, service::service_fn, Body};
+//! use std::{net::SocketAddr, convert::Infallible};
+//! use tokio::net::TcpListener;
+//! 
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//!     let addr: SocketAddr = ([127, 0, 0, 1], 8080).into();
+//! 
+//!     let mut tcp_listener = TcpListener::bind(addr).await?;
+//!     loop {
+//!         let (tcp_stream, _) = tcp_listener.accept().await?;
+//!         Http::new()
+//!             .http1_only(true)
+//!             .keep_alive(true)
+//!             .serve_connection(tcp_stream, service_fn(hello))
+//!             .await?;
+//!     }
+//! }
+//!
+//! async fn hello(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
+//!    Ok(Response::new(Body::from("Hello World!")))
+//! }
+//! ```
 
 use std::error::Error as StdError;
 use std::fmt;

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -15,11 +15,11 @@
 //! use hyper::{server::conn::Http, service::service_fn, Body};
 //! use std::{net::SocketAddr, convert::Infallible};
 //! use tokio::net::TcpListener;
-//! 
+//!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //!     let addr: SocketAddr = ([127, 0, 0, 1], 8080).into();
-//! 
+//!
 //!     let mut tcp_listener = TcpListener::bind(addr).await?;
 //!     loop {
 //!         let (tcp_stream, _) = tcp_listener.accept().await?;


### PR DESCRIPTION
[WIP] Adding doc examples for the lower-level `conn` modules in `server` and `client`.

Beginning to address #2272. 