### PR TITLE
hyper_capi/examples: add makefile to build the example

### DIFF
--- a/hyper-capi/examples/Makefile
+++ b/hyper-capi/examples/Makefile
@@ -1,0 +1,18 @@
+#
+# Build the example client
+#
+
+TARGET = client
+
+OBJS = client.o
+
+RPATH=$(PWD)/../target/debug
+CFLAGS = -I../include
+LDFLAGS = -L$(RPATH) -Wl,-rpath,$(RPATH)
+LIBS = -lhyper_c
+
+$(TARGET): $(OBJS)
+	$(CC) -o $(TARGET) $(OBJS) $(LDFLAGS) $(LIBS)
+
+clean:
+	rm -f $(OBJS) $(TARGET)


### PR DESCRIPTION
It also sets rpath to link with the hyper_capi lib in the build dir.

