### PR TITLE
Bump tokio from 0.2.11 to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ http = "0.2"
 http-body = "0.3.1"
 httpdate = "0.3"
 httparse = "1.0"
-h2 = "0.2.2"
+h2 = { git = "https://github.com/hyperium/h2" }
 itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "1.0"
 tower-service = "0.3"
-tokio = { version = "0.2.11", features = ["sync"] }
+tokio = { version = "0.3", features = ["sync"] }
 want = "0.3"
 
 # Optional
@@ -49,9 +49,9 @@ spmc = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-tokio = { version = "0.2.2", features = ["fs", "macros", "io-std", "rt-util", "sync", "time", "test-util"] }
-tokio-test = "0.2"
-tokio-util = { version = "0.3", features = ["codec"] }
+tokio = { version = "0.3", features = ["fs", "macros", "io-std", "rt", "sync", "time", "test-util"] }
+tokio-test = "0.3"
+tokio-util = { version = "0.4", features = ["codec"] }
 tower-util = "0.3"
 url = "1.0"
 
@@ -65,12 +65,12 @@ default = [
 ]
 runtime = [
     "tcp",
-    "tokio/rt-core",
+    "tokio/rt",
 ]
 tcp = [
     "socket2",
-    "tokio/blocking",
-    "tokio/tcp",
+    "tokio/net",
+    "tokio/rt",
     "tokio/time",
 ]
 

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -640,17 +640,7 @@ fn connect(
 
     let std_tcp = socket.into_tcp_stream();
 
-    Ok(async move {
-        let connect = TcpStream::connect_std(std_tcp, &addr);
-        match connect_timeout {
-            Some(dur) => match tokio::time::timeout(dur, connect).await {
-                Ok(Ok(s)) => Ok(s),
-                Ok(Err(e)) => Err(e),
-                Err(e) => Err(io::Error::new(io::ErrorKind::TimedOut, e)),
-            },
-            None => connect.await,
-        }
-    })
+    Ok(async move { TcpStream::from_std(std_tcp) })
 }
 
 impl ConnectingTcp {

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -13,7 +13,7 @@ use futures_util::future::Either;
 use http::uri::{Scheme, Uri};
 use pin_project::pin_project;
 use tokio::net::TcpStream;
-use tokio::time::Delay;
+use tokio::time::Sleep;
 
 use super::dns::{self, resolve, GaiResolver, Resolve};
 use super::{Connected, Connection};
@@ -510,7 +510,7 @@ impl ConnectingTcp {
                 local_addr_ipv6,
                 preferred: ConnectingTcpRemote::new(preferred_addrs, connect_timeout),
                 fallback: Some(ConnectingTcpFallback {
-                    delay: tokio::time::delay_for(fallback_timeout),
+                    delay: tokio::time::sleep(fallback_timeout),
                     remote: ConnectingTcpRemote::new(fallback_addrs, connect_timeout),
                 }),
                 reuse_address,
@@ -528,7 +528,7 @@ impl ConnectingTcp {
 }
 
 struct ConnectingTcpFallback {
-    delay: Delay,
+    delay: Sleep,
     remote: ConnectingTcpRemote,
 }
 

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -850,7 +850,7 @@ mod tests {
         let pooled = pool.pooled(c(key.clone()), Uniq(41));
 
         drop(pooled);
-        tokio::time::delay_for(pool.locked().timeout.unwrap()).await;
+        tokio::time::sleep(pool.locked().timeout.unwrap()).await;
         let mut checkout = pool.checkout(key);
         let poll_once = PollOnce(&mut checkout);
         let is_not_ready = poll_once.await.is_none();
@@ -871,7 +871,7 @@ mod tests {
             pool.locked().idle.get(&key).map(|entries| entries.len()),
             Some(3)
         );
-        tokio::time::delay_for(pool.locked().timeout.unwrap()).await;
+        tokio::time::sleep(pool.locked().timeout.unwrap()).await;
 
         let mut checkout = pool.checkout(key.clone());
         let poll_once = PollOnce(&mut checkout);

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -2,7 +2,7 @@ use std::marker::Unpin;
 use std::{cmp, io};
 
 use bytes::{Buf, Bytes};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::common::{task, Pin, Poll};
 
@@ -46,27 +46,22 @@ impl<T> AsyncRead for Rewind<T>
 where
     T: AsyncRead + Unpin,
 {
-    #[inline]
-    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [std::mem::MaybeUninit<u8>]) -> bool {
-        self.inner.prepare_uninitialized_buffer(buf)
-    }
-
     fn poll_read(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
         if let Some(mut prefix) = self.pre.take() {
             // If there are no remaining bytes, let the bytes get dropped.
             if !prefix.is_empty() {
-                let copy_len = cmp::min(prefix.len(), buf.len());
-                prefix.copy_to_slice(&mut buf[..copy_len]);
+                let copy_len = cmp::min(prefix.len(), buf.remaining());
+                // TODO: There should be a way to do following two lines cleaner...
+                buf.put_slice(prefix.to_vec().as_slice());
+                prefix.advance(copy_len);
                 // Put back whats left
                 if !prefix.is_empty() {
                     self.pre = Some(prefix);
                 }
-
-                return Poll::Ready(Ok(copy_len));
             }
         }
         Pin::new(&mut self.inner).poll_read(cx, buf)
@@ -91,15 +86,6 @@ where
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.inner).poll_shutdown(cx)
-    }
-
-    #[inline]
-    fn poll_write_buf<B: Buf>(
-        mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_write_buf(cx, buf)
     }
 }
 

--- a/src/proto/h2/ping.rs
+++ b/src/proto/h2/ping.rs
@@ -33,7 +33,7 @@ use std::time::Instant;
 
 use h2::{Ping, PingPong};
 #[cfg(feature = "runtime")]
-use tokio::time::{Delay, Instant};
+use tokio::time::{Instant, Sleep};
 
 type WindowSize = u32;
 
@@ -60,7 +60,7 @@ pub(super) fn channel(ping_pong: PingPong, config: Config) -> (Recorder, Ponger)
         interval,
         timeout: config.keep_alive_timeout,
         while_idle: config.keep_alive_while_idle,
-        timer: tokio::time::delay_for(interval),
+        timer: tokio::time::sleep(interval),
         state: KeepAliveState::Init,
     });
 
@@ -156,7 +156,7 @@ struct KeepAlive {
     while_idle: bool,
 
     state: KeepAliveState,
-    timer: Delay,
+    timer: Sleep,
 }
 
 #[cfg(feature = "runtime")]

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -4,7 +4,7 @@ use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::time::Duration;
 
 use tokio::net::TcpListener;
-use tokio::time::Delay;
+use tokio::time::Sleep;
 
 use crate::common::{task, Future, Pin, Poll};
 
@@ -19,7 +19,7 @@ pub struct AddrIncoming {
     sleep_on_errors: bool,
     tcp_keepalive_timeout: Option<Duration>,
     tcp_nodelay: bool,
-    timeout: Option<Delay>,
+    timeout: Option<Sleep>,
 }
 
 impl AddrIncoming {
@@ -119,7 +119,7 @@ impl AddrIncoming {
                         error!("accept error: {}", e);
 
                         // Sleep 1s.
-                        let mut timeout = tokio::time::delay_for(Duration::from_secs(1));
+                        let mut timeout = tokio::time::sleep(Duration::from_secs(1));
 
                         match Pin::new(&mut timeout).poll(cx) {
                             Poll::Ready(()) => {

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -302,8 +302,8 @@ mod tests {
         fn poll_read(
             self: Pin<&mut Self>,
             _cx: &mut task::Context<'_>,
-            _buf: &mut [u8],
-        ) -> Poll<io::Result<usize>> {
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
             unreachable!("Mock::poll_read")
         }
     }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -963,7 +963,7 @@ mod dispatch_impl {
     use futures_util::future::{FutureExt, TryFutureExt};
     use futures_util::stream::StreamExt;
     use http::Uri;
-    use tokio::io::{AsyncRead, AsyncWrite};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
     use tokio::net::TcpStream;
     use tokio::runtime::Runtime;
 
@@ -1016,7 +1016,7 @@ mod dispatch_impl {
         rt.block_on(async move {
             let (res, ()) = future::join(res, rx).await;
             res.unwrap();
-            tokio::time::delay_for(Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         });
 
         rt.block_on(closes.into_future()).0.expect("closes");
@@ -1075,7 +1075,7 @@ mod dispatch_impl {
         rt.block_on(async move {
             let (res, ()) = future::join(res, rx).await;
             res.unwrap();
-            tokio::time::delay_for(Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         });
 
         rt.block_on(closes.into_future()).0.expect("closes");
@@ -1147,7 +1147,7 @@ mod dispatch_impl {
         drop(client);
 
         // and wait a few ticks for the connections to close
-        let t = tokio::time::delay_for(Duration::from_millis(100)).map(|_| panic!("time out"));
+        let t = tokio::time::sleep(Duration::from_millis(100)).map(|_| panic!("time out"));
         let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
         future::select(t, close).await;
     }
@@ -1195,7 +1195,7 @@ mod dispatch_impl {
         future::select(res, rx1).await;
 
         // res now dropped
-        let t = tokio::time::delay_for(Duration::from_millis(100)).map(|_| panic!("time out"));
+        let t = tokio::time::sleep(Duration::from_millis(100)).map(|_| panic!("time out"));
         let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
         future::select(t, close).await;
     }
@@ -1250,7 +1250,7 @@ mod dispatch_impl {
         res.unwrap();
 
         // and wait a few ticks to see the connection drop
-        let t = tokio::time::delay_for(Duration::from_millis(100)).map(|_| panic!("time out"));
+        let t = tokio::time::sleep(Duration::from_millis(100)).map(|_| panic!("time out"));
         let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
         future::select(t, close).await;
     }
@@ -1300,7 +1300,7 @@ mod dispatch_impl {
         let (res, ()) = future::join(res, rx).await;
         res.unwrap();
 
-        let t = tokio::time::delay_for(Duration::from_millis(100)).map(|_| panic!("time out"));
+        let t = tokio::time::sleep(Duration::from_millis(100)).map(|_| panic!("time out"));
         let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
         future::select(t, close).await;
     }
@@ -1346,7 +1346,7 @@ mod dispatch_impl {
         let (res, ()) = future::join(res, rx).await;
         res.unwrap();
 
-        let t = tokio::time::delay_for(Duration::from_millis(100)).map(|_| panic!("time out"));
+        let t = tokio::time::sleep(Duration::from_millis(100)).map(|_| panic!("time out"));
         let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
         future::select(t, close).await;
     }
@@ -1544,7 +1544,7 @@ mod dispatch_impl {
         assert_eq!(connects.load(Ordering::Relaxed), 0);
 
         let delayed_body = rx1
-            .then(|_| tokio::time::delay_for(Duration::from_millis(200)))
+            .then(|_| tokio::time::sleep(Duration::from_millis(200)))
             .map(|_| Ok::<_, ()>("hello a"))
             .map_err(|_| -> hyper::Error { panic!("rx1") })
             .into_stream();
@@ -1559,7 +1559,7 @@ mod dispatch_impl {
 
         // req 1
         let fut = future::join(client.request(req), rx)
-            .then(|_| tokio::time::delay_for(Duration::from_millis(200)))
+            .then(|_| tokio::time::sleep(Duration::from_millis(200)))
             // req 2
             .then(move |()| {
                 let rx = rx3.expect("thread panicked");
@@ -1646,7 +1646,7 @@ mod dispatch_impl {
 
         // sleep real quick to let the threadpool put connection in ready
         // state and back into client pool
-        tokio::time::delay_for(Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
         let rx = rx2.expect("thread panicked");
         let req = Request::builder()
@@ -1961,10 +1961,10 @@ mod dispatch_impl {
 
     impl AsyncRead for DebugStream {
         fn poll_read(
-            mut self: Pin<&mut Self>,
+            self: Pin<&mut Self>,
             cx: &mut Context<'_>,
-            buf: &mut [u8],
-        ) -> Poll<Result<usize, io::Error>> {
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
             Pin::new(&mut self.tcp).poll_read(cx, buf)
         }
     }
@@ -2090,7 +2090,7 @@ mod conn {
         });
 
         let rx = rx1.expect("thread panicked");
-        let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+        let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
         let chunk = rt.block_on(future::join(res, rx).map(|r| r.0)).unwrap();
         assert_eq!(chunk.len(), 5);
     }
@@ -2185,7 +2185,7 @@ mod conn {
             concat(res)
         });
         let rx = rx1.expect("thread panicked");
-        let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+        let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
         rt.block_on(future::join(res, rx).map(|r| r.0)).unwrap();
     }
 
@@ -2231,7 +2231,7 @@ mod conn {
             concat(res)
         });
         let rx = rx1.expect("thread panicked");
-        let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+        let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
         rt.block_on(future::join(res, rx).map(|r| r.0)).unwrap();
     }
 
@@ -2283,7 +2283,7 @@ mod conn {
         });
 
         let rx = rx1.expect("thread panicked");
-        let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+        let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
         rt.block_on(future::join3(res1, res2, rx).map(|r| r.0))
             .unwrap();
     }
@@ -2346,7 +2346,7 @@ mod conn {
             });
 
             let rx = rx1.expect("thread panicked");
-            let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+            let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
             rt.block_on(future::join3(until_upgrade, res, rx).map(|r| r.0))
                 .unwrap();
 
@@ -2439,7 +2439,7 @@ mod conn {
                 });
 
             let rx = rx1.expect("thread panicked");
-            let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+            let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
             rt.block_on(future::join3(until_tunneled, res, rx).map(|r| r.0))
                 .unwrap();
 
@@ -2529,7 +2529,7 @@ mod conn {
         let _ = shdn_tx.send(());
 
         // Allow time for graceful shutdown roundtrips...
-        tokio::time::delay_for(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
         // After graceful shutdown roundtrips, the client should be closed...
         future::poll_fn(|ctx| client.poll_ready(ctx))
@@ -2606,7 +2606,7 @@ mod conn {
         });
 
         // sleep longer than keepalive would trigger
-        tokio::time::delay_for(Duration::from_secs(4)).await;
+        tokio::time::sleep(Duration::from_secs(4)).await;
 
         future::poll_fn(|ctx| client.poll_ready(ctx))
             .await
@@ -2711,7 +2711,7 @@ mod conn {
         let _resp = client.send_request(req1).await.expect("send_request");
 
         // sleep longer than keepalive would trigger
-        tokio::time::delay_for(Duration::from_secs(4)).await;
+        tokio::time::sleep(Duration::from_secs(4)).await;
 
         future::poll_fn(|ctx| client.poll_ready(ctx))
             .await
@@ -2761,10 +2761,10 @@ mod conn {
 
     impl AsyncRead for DebugStream {
         fn poll_read(
-            mut self: Pin<&mut Self>,
+            self: Pin<&mut Self>,
             cx: &mut Context<'_>,
-            buf: &mut [u8],
-        ) -> Poll<Result<usize, io::Error>> {
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
             Pin::new(&mut self.tcp).poll_read(cx, buf)
         }
     }


### PR DESCRIPTION
This PR shall update tokio to version `0.3`.

**Changes**
* adapt `AsyncRead`, `AsyncWrite` implementations
* rename `delay_for` -> `sleep`, `Delay` -> `Sleep`
* ...

Fixes #2302 

---

There are still quite some errors left to resolve, so I am happy to get some input there 😃 