### PR TITLE
Fix server keep alive to send more than one ping

### DIFF
--- a/src/proto/h2/ping.rs
+++ b/src/proto/h2/ping.rs
@@ -442,7 +442,16 @@ impl KeepAlive {
                 let interval = shared.last_read_at() + self.interval;
                 self.timer.reset(interval);
             }
-            KeepAliveState::Scheduled | KeepAliveState::PingSent => (),
+            KeepAliveState::PingSent => {
+                if shared.is_ping_sent() {
+                    return;
+                }
+
+                self.state = KeepAliveState::Scheduled;
+                let interval = shared.last_read_at() + self.interval;
+                self.timer.reset(interval);
+            }
+            KeepAliveState::Scheduled => (),
         }
     }
 


### PR DESCRIPTION
When enabling HTTP2 server keep alive, only the first ping is sent after the configured interval.
Afterwards, no more pings are sent.

More details on this issue: #2310 

The suggested solution checks if `ping_sent_at` has already been cleared by `Ponger::poll` when `KeepAliveState::PingSent` state is active. A test is added to make sure the server produces more than one ping when configured to do so.