### PR TITLE
feat: update to Tokio 0.3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.39.0
+          - 1.45.2
 
         os:
           - ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,9 @@ tokio-util = { version = "0.3", features = ["codec"] }
 tower-util = "0.3"
 url = "1.0"
 
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dev-dependencies]
+pnet = "0.25.0"
+
 [features]
 default = [
     "runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,16 @@ spmc = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-tokio = { version = "0.3", features = ["fs", "macros", "io-std", "rt", "sync", "time", "test-util"] }
+tokio = { version = "0.3", features = [
+    "fs",
+    "macros",
+    "io-std",
+    "rt",
+    "rt-multi-thread", # so examples can use #[tokio::main]
+    "sync",
+    "time",
+    "test-util",
+] }
 tokio-test = "0.3"
 tokio-util = { version = "0.4", features = ["codec"] }
 tower-util = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ http = "0.2"
 http-body = "0.3.1"
 httpdate = "0.3"
 httparse = "1.0"
-h2 = "0.2.2"
+h2 = { git = "https://github.com/hyperium/h2" }
 itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,26 @@
 [package]
-name = "hyper"
+name = "hyper" 
 version = "0.13.8" # don't forget to update html_root_url
-description = "A fast and correct HTTP library."
-readme = "README.md"
-homepage = "https://hyper.rs"
-documentation = "https://docs.rs/hyper"
-repository = "https://github.com/hyperium/hyper"
-license = "MIT"
-authors = ["Sean McArthur <sean@seanmonstar.com>"]
-keywords = ["http", "hyper", "hyperium"]
-categories = ["network-programming", "web-programming::http-client", "web-programming::http-server"]
-edition = "2018"
+description = "A fast and correct HTTP library." 
+readme = "README.md" 
+homepage = "https://hyper.rs" 
+documentation = "https://docs.rs/hyper" 
+repository = "https://github.com/hyperium/hyper" 
+license = "MIT" 
+authors = ["Sean McArthur <sean@seanmonstar.com>"] 
+keywords = ["http", "hyper", "hyperium"] 
+categories = [
+    "network-programming",
+    "web-programming::http-client",
+    "web-programming::http-server",
+] 
+edition = "2018" 
 
 include = [
-  "Cargo.toml",
-  "LICENSE",
-  "src/**/*",
-  #"build.rs",
+    "Cargo.toml",
+    "LICENSE",
+    "src/**/*",
+    #"build.rs",
 ]
 
 [dependencies]
@@ -33,7 +37,7 @@ itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "1.0"
 tower-service = "0.3"
-tokio = { version = "0.3", features = ["sync"] }
+tokio = { version = "0.3", features = ["sync", "stream"] }
 want = "0.3"
 
 # Optional
@@ -59,20 +63,9 @@ url = "1.0"
 pnet = "0.25.0"
 
 [features]
-default = [
-    "runtime",
-    "stream"
-]
-runtime = [
-    "tcp",
-    "tokio/rt",
-]
-tcp = [
-    "socket2",
-    "tokio/net",
-    "tokio/rt",
-    "tokio/time",
-]
+default = ["runtime", "stream"]
+runtime = ["tcp", "tokio/rt"]
+tcp = ["socket2", "tokio/net", "tokio/rt", "tokio/time"]
 
 # `impl Stream` for things
 stream = []
@@ -82,10 +75,7 @@ nightly = []
 __internal_happy_eyeballs_tests = []
 
 [package.metadata.docs.rs]
-features = [
-    "runtime",
-    "stream",
-]
+features = ["runtime", "stream"]
 
 [profile.release]
 codegen-units = 1
@@ -217,4 +207,3 @@ required-features = ["runtime", "stream"]
 name = "server"
 path = "tests/server.rs"
 required-features = ["runtime"]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ tracing = { version = "0.1", default-features = false, features = ["log", "std"]
 pin-project = "1.0"
 tower-service = "0.3"
 tokio = { version = "0.3", features = ["sync", "stream"] }
+# TODO(eliza): this is sad
+tokio02 = { package = "tokio", version = "0.2", features = ["sync"] }
 want = "0.3"
 
 # Optional

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,6 @@ tracing = { version = "0.1", default-features = false, features = ["log", "std"]
 pin-project = "1.0"
 tower-service = "0.3"
 tokio = { version = "0.3", features = ["sync", "stream"] }
-# TODO(eliza): this is sad
-tokio02 = { package = "tokio", version = "0.2", features = ["sync"] }
 want = "0.3"
 
 # Optional

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "1.0"
 tower-service = "0.3"
-tokio = { version = "0.2.11", features = ["sync"] }
+tokio = { version = "0.3", features = ["sync"] }
 want = "0.3"
 
 # Optional
@@ -49,9 +49,9 @@ spmc = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-tokio = { version = "0.2.2", features = ["fs", "macros", "io-std", "rt-util", "sync", "time", "test-util"] }
-tokio-test = "0.2"
-tokio-util = { version = "0.3", features = ["codec"] }
+tokio = { version = "0.3", features = ["fs", "macros", "io-std", "rt", "sync", "time", "test-util"] }
+tokio-test = "0.3"
+tokio-util = { version = "0.4", features = ["codec"] }
 tower-util = "0.3"
 url = "1.0"
 
@@ -65,12 +65,12 @@ default = [
 ]
 runtime = [
     "tcp",
-    "tokio/rt-core",
+    "tokio/rt",
 ]
 tcp = [
     "socket2",
-    "tokio/blocking",
-    "tokio/tcp",
+    "tokio/net",
+    "tokio/rt",
     "tokio/time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,26 +1,23 @@
+
 [package]
-name = "hyper" 
+name = "hyper"
 version = "0.13.8" # don't forget to update html_root_url
-description = "A fast and correct HTTP library." 
-readme = "README.md" 
-homepage = "https://hyper.rs" 
-documentation = "https://docs.rs/hyper" 
-repository = "https://github.com/hyperium/hyper" 
-license = "MIT" 
-authors = ["Sean McArthur <sean@seanmonstar.com>"] 
-keywords = ["http", "hyper", "hyperium"] 
-categories = [
-    "network-programming",
-    "web-programming::http-client",
-    "web-programming::http-server",
-] 
-edition = "2018" 
+description = "A fast and correct HTTP library."
+readme = "README.md"
+homepage = "https://hyper.rs"
+documentation = "https://docs.rs/hyper"
+repository = "https://github.com/hyperium/hyper"
+license = "MIT"
+authors = ["Sean McArthur <sean@seanmonstar.com>"]
+keywords = ["http", "hyper", "hyperium"]
+categories = ["network-programming", "web-programming::http-client", "web-programming::http-server"]
+edition = "2018"
 
 include = [
-    "Cargo.toml",
-    "LICENSE",
-    "src/**/*",
-    #"build.rs",
+  "Cargo.toml",
+  "LICENSE",
+  "src/**/*",
+  #"build.rs",
 ]
 
 [dependencies]
@@ -74,9 +71,20 @@ url = "1.0"
 pnet = "0.25.0"
 
 [features]
-default = ["runtime", "stream"]
-runtime = ["tcp", "tokio/rt"]
-tcp = ["socket2", "tokio/net", "tokio/rt", "tokio/time"]
+default = [
+    "runtime",
+    "stream"
+]
+runtime = [
+    "tcp",
+    "tokio/rt",
+]
+tcp = [
+    "socket2",
+    "tokio/net",
+    "tokio/rt",
+    "tokio/time",
+]
 
 # `impl Stream` for things
 stream = []
@@ -86,7 +94,10 @@ nightly = []
 __internal_happy_eyeballs_tests = []
 
 [package.metadata.docs.rs]
-features = ["runtime", "stream"]
+features = [
+    "runtime",
+    "stream",
+]
 
 [profile.release]
 codegen-units = 1

--- a/benches/body.rs
+++ b/benches/body.rs
@@ -10,8 +10,7 @@ use hyper::body::Body;
 
 macro_rules! bench_stream {
     ($bencher:ident, bytes: $bytes:expr, count: $count:expr, $total_ident:ident, $body_pat:pat, $block:expr) => {{
-        let mut rt = tokio::runtime::Builder::new()
-            .basic_scheduler()
+        let mut rt = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("rt build");
 

--- a/benches/body.rs
+++ b/benches/body.rs
@@ -10,7 +10,7 @@ use hyper::body::Body;
 
 macro_rules! bench_stream {
     ($bencher:ident, bytes: $bytes:expr, count: $count:expr, $total_ident:ident, $body_pat:pat, $block:expr) => {{
-        let mut rt = tokio::runtime::Builder::new_current_thread()
+        let rt = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("rt build");
 

--- a/benches/connect.rs
+++ b/benches/connect.rs
@@ -12,12 +12,11 @@ use tokio::net::TcpListener;
 #[bench]
 fn http_connector(b: &mut test::Bencher) {
     let _ = pretty_env_logger::try_init();
-    let mut rt = tokio::runtime::Builder::new()
+    let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
-        .basic_scheduler()
         .build()
         .expect("rt build");
-    let mut listener = rt
+    let listener = rt
         .block_on(TcpListener::bind(&SocketAddr::from(([127, 0, 0, 1], 0))))
         .expect("bind");
     let addr = listener.local_addr().expect("local_addr");

--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -290,7 +290,7 @@ impl Opts {
         let bytes_per_iter = (req_len + self.response_body.len() as u64) * self.parallel_cnt as u64;
         b.bytes = bytes_per_iter;
 
-        let addr = spawn_server(&mut rt, &self);
+        let addr = spawn_server(&rt, &self);
 
         let connector = HttpConnector::new();
         let client = hyper::Client::builder()
@@ -353,7 +353,7 @@ impl Opts {
     }
 }
 
-fn spawn_server(rt: &mut tokio::runtime::Runtime, opts: &Opts) -> SocketAddr {
+fn spawn_server(rt: &tokio::runtime::Runtime, opts: &Opts) -> SocketAddr {
     use hyper::service::{make_service_fn, service_fn};
     let addr = "127.0.0.1:0".parse().unwrap();
 

--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -270,14 +270,16 @@ impl Opts {
     }
 
     fn bench(self, b: &mut test::Bencher) {
+        use std::sync::Arc;
         let _ = pretty_env_logger::try_init();
         // Create a runtime of current thread.
-        let mut rt = tokio::runtime::Builder::new()
-            .enable_all()
-            .basic_scheduler()
-            .build()
-            .expect("rt build");
-        let exec = rt.handle().clone();
+        let rt = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("rt build"),
+        );
+        let exec = rt.clone();
 
         let req_len = self.request_body.map(|b| b.len()).unwrap_or(0) as u64;
         let req_len = if self.request_chunks > 0 {

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -31,9 +31,8 @@ fn hello_world(b: &mut test::Bencher) {
                 }))
             });
 
-            let mut rt = tokio::runtime::Builder::new()
+            let mut rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
-                .basic_scheduler()
                 .build()
                 .expect("rt build");
             let srv = rt.block_on(async move {

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -31,7 +31,7 @@ fn hello_world(b: &mut test::Bencher) {
                 }))
             });
 
-            let mut rt = tokio::runtime::Builder::new_current_thread()
+            let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .expect("rt build");

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -34,7 +34,7 @@ macro_rules! bench_server {
                     }))
                 });
 
-                let mut rt = tokio::runtime::Builder::new_current_thread()
+                let rt = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()
                     .expect("rt build");
@@ -184,6 +184,7 @@ fn raw_tcp_throughput_large_payload(b: &mut test::Bencher) {
         let mut buf = [0u8; 8192];
         while rx.try_recv().is_err() {
             let r = sock.read(&mut buf).unwrap();
+            extern crate test;
             if r == 0 {
                 break;
             }

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -34,9 +34,8 @@ macro_rules! bench_server {
                     }))
                 });
 
-                let mut rt = tokio::runtime::Builder::new()
+                let mut rt = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
-                    .basic_scheduler()
                     .build()
                     .expect("rt build");
 

--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -10,15 +10,14 @@ fn main() {
     pretty_env_logger::init();
 
     // Configure a runtime that runs everything on the current thread
-    let mut rt = tokio::runtime::Builder::new()
+    let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
-        .basic_scheduler()
         .build()
         .expect("build runtime");
 
     // Combine it with a `LocalSet,  which means it can spawn !Send futures...
     let local = tokio::task::LocalSet::new();
-    local.block_on(&mut rt, run());
+    local.block_on(&rt, run());
 }
 
 async fn run() {

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -640,17 +640,7 @@ fn connect(
 
     let std_tcp = socket.into_tcp_stream();
 
-    Ok(async move {
-        let connect = TcpStream::connect_std(std_tcp, &addr);
-        match connect_timeout {
-            Some(dur) => match tokio::time::timeout(dur, connect).await {
-                Ok(Ok(s)) => Ok(s),
-                Ok(Err(e)) => Err(e),
-                Err(e) => Err(io::Error::new(io::ErrorKind::TimedOut, e)),
-            },
-            None => connect.await,
-        }
-    })
+    Ok(async move { TcpStream::from_std(std_tcp) })
 }
 
 impl ConnectingTcp {

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -749,7 +749,7 @@ mod tests {
     #[tokio::test]
     async fn local_address() {
         use std::net::{IpAddr, TcpListener};
-        let _ = pretty_env_logger::init();
+        let _ = pretty_env_logger::try_init();
 
         let (bind_ip_v4, bind_ip_v6) = get_local_ips();
         let server4 = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -607,8 +607,6 @@ fn connect(
             .map_err(ConnectError::m("tcp set_recv_buffer_size error"))?;
     }
 
-    let addr = *addr;
-
     let std_tcp = socket.into_tcp_stream();
 
     Ok(async move { TcpStream::from_std(std_tcp).map_err(ConnectError::m("tcp connect error")) })
@@ -764,7 +762,7 @@ mod tests {
         let server4 = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = server4.local_addr().unwrap();
         let _server6 = TcpListener::bind(&format!("[::1]:{}", addr.port())).unwrap();
-        let mut rt = tokio::runtime::Builder::new_current_thread()
+        let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
@@ -883,7 +881,7 @@ mod tests {
                     };
                     let connecting_tcp = ConnectingTcp::new(dns::IpAddrs::new(addrs), &cfg);
                     let start = Instant::now();
-                    Ok::<_, ConnectError>((start, connecting_tcp.connect().await?))
+                    Ok::<_, ConnectError>((start, ConnectingTcp::connect(connecting_tcp).await?))
                 })
                 .unwrap();
             let res = if stream.peer_addr().unwrap().is_ipv4() {

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -586,6 +586,12 @@ fn connect(
             .map_err(ConnectError::m("tcp set_reuse_address error"))?;
     }
 
+    // When constructing a Tokio `TcpSocket` from a raw fd/socket, the user is
+    // responsible for ensuring O_NONBLOCK is set.
+    socket
+        .set_nonblocking(true)
+        .map_err(ConnectError::m("tcp set_nonblocking error"))?;
+
     bind_local_address(
         &socket,
         addr,

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -13,7 +13,7 @@ use futures_util::future::Either;
 use http::uri::{Scheme, Uri};
 use pin_project::pin_project;
 use tokio::net::TcpStream;
-use tokio::time::Delay;
+use tokio::time::Sleep;
 
 use super::dns::{self, resolve, GaiResolver, Resolve};
 use super::{Connected, Connection};
@@ -510,7 +510,7 @@ impl ConnectingTcp {
                 local_addr_ipv6,
                 preferred: ConnectingTcpRemote::new(preferred_addrs, connect_timeout),
                 fallback: Some(ConnectingTcpFallback {
-                    delay: tokio::time::delay_for(fallback_timeout),
+                    delay: tokio::time::sleep(fallback_timeout),
                     remote: ConnectingTcpRemote::new(fallback_addrs, connect_timeout),
                 }),
                 reuse_address,
@@ -528,7 +528,7 @@ impl ConnectingTcp {
 }
 
 struct ConnectingTcpFallback {
-    delay: Delay,
+    delay: Sleep,
     remote: ConnectingTcpRemote,
 }
 

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -568,6 +568,10 @@ fn connect(
     config: &Config,
     connect_timeout: Option<Duration>,
 ) -> Result<impl Future<Output = Result<TcpStream, ConnectError>>, ConnectError> {
+    // TODO(eliza): if Tokio's `TcpSocket` gains support for setting the
+    // keepalive timeout and send/recv buffer size, it would be nice to use that
+    // instead of socket2, and avoid the unsafe `into_raw_fd`/`from_raw_fd`
+    // dance...
     use socket2::{Domain, Protocol, Socket, Type};
     let domain = match *addr {
         SocketAddr::V4(_) => Domain::ipv4(),

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -171,7 +171,7 @@ impl<T, U> Receiver<T, U> {
 
 #[pin_project::pinned_drop]
 impl<T, U> PinnedDrop for Receiver<T, U> {
-    fn drop(self: Pin<&mut Self>) {
+    fn drop(mut self: Pin<&mut Self>) {
         // Notify the giver about the closure first, before dropping
         // the mpsc::Receiver.
         self.as_mut().taker.cancel();
@@ -267,7 +267,7 @@ mod tests {
     impl<T, U> Future for Receiver<T, U> {
         type Output = Option<(T, Callback<T, U>)>;
 
-        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             self.poll_next(cx)
         }
     }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -349,9 +349,8 @@ mod tests {
     fn giver_queue_throughput(b: &mut test::Bencher) {
         use crate::{Body, Request, Response};
 
-        let mut rt = tokio::runtime::Builder::new()
+        let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
-            .basic_scheduler()
             .build()
             .unwrap();
         let (mut tx, mut rx) = channel::<Request<Body>, Response<Body>>();
@@ -373,9 +372,8 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn giver_queue_not_ready(b: &mut test::Bencher) {
-        let mut rt = tokio::runtime::Builder::new()
+        let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
-            .basic_scheduler()
             .build()
             .unwrap();
         let (_tx, mut rx) = channel::<i32, ()>();

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -706,12 +706,15 @@ impl Expiration {
 }
 
 #[cfg(feature = "runtime")]
+#[pin_project::pin_project]
 struct IdleTask<T> {
+    #[pin]
     interval: Interval,
     pool: WeakOpt<Mutex<PoolInner<T>>>,
     // This allows the IdleTask to be notified as soon as the entire
     // Pool is fully dropped, and shutdown. This channel is never sent on,
     // but Err(Canceled) will be received when the Pool is dropped.
+    #[pin]
     pool_drop_notifier: oneshot::Receiver<crate::common::Never>,
 }
 
@@ -719,9 +722,11 @@ struct IdleTask<T> {
 impl<T: Poolable + 'static> Future for IdleTask<T> {
     type Output = ();
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        use tokio::stream::Stream;
+        let mut this = self.project();
         loop {
-            match Pin::new(&mut self.pool_drop_notifier).poll(cx) {
+            match this.pool_drop_notifier.as_mut().poll(cx) {
                 Poll::Ready(Ok(n)) => match n {},
                 Poll::Pending => (),
                 Poll::Ready(Err(_canceled)) => {
@@ -730,9 +735,9 @@ impl<T: Poolable + 'static> Future for IdleTask<T> {
                 }
             }
 
-            ready!(self.interval.poll_tick(cx));
+            ready!(this.interval.as_mut().poll_next(cx));
 
-            if let Some(inner) = self.pool.upgrade() {
+            if let Some(inner) = this.pool.upgrade() {
                 if let Ok(mut inner) = inner.lock() {
                     trace!("idle interval checking for expired");
                     inner.clear_expired();

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -850,7 +850,7 @@ mod tests {
         let pooled = pool.pooled(c(key.clone()), Uniq(41));
 
         drop(pooled);
-        tokio::time::delay_for(pool.locked().timeout.unwrap()).await;
+        tokio::time::sleep(pool.locked().timeout.unwrap()).await;
         let mut checkout = pool.checkout(key);
         let poll_once = PollOnce(&mut checkout);
         let is_not_ready = poll_once.await.is_none();
@@ -871,7 +871,7 @@ mod tests {
             pool.locked().idle.get(&key).map(|entries| entries.len()),
             Some(3)
         );
-        tokio::time::delay_for(pool.locked().timeout.unwrap()).await;
+        tokio::time::sleep(pool.locked().timeout.unwrap()).await;
 
         let mut checkout = pool.checkout(key.clone());
         let poll_once = PollOnce(&mut checkout);

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -47,7 +47,7 @@ where
     T: AsyncRead + Unpin,
 {
     fn poll_read(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -2,7 +2,7 @@ use std::marker::Unpin;
 use std::{cmp, io};
 
 use bytes::{Buf, Bytes};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::common::{task, Pin, Poll};
 
@@ -46,27 +46,22 @@ impl<T> AsyncRead for Rewind<T>
 where
     T: AsyncRead + Unpin,
 {
-    #[inline]
-    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [std::mem::MaybeUninit<u8>]) -> bool {
-        self.inner.prepare_uninitialized_buffer(buf)
-    }
-
     fn poll_read(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
         if let Some(mut prefix) = self.pre.take() {
             // If there are no remaining bytes, let the bytes get dropped.
             if !prefix.is_empty() {
-                let copy_len = cmp::min(prefix.len(), buf.len());
-                prefix.copy_to_slice(&mut buf[..copy_len]);
+                let copy_len = cmp::min(prefix.len(), buf.remaining());
+                // TODO: There should be a way to do following two lines cleaner...
+                buf.put_slice(prefix.to_vec().as_slice());
+                prefix.advance(copy_len);
                 // Put back whats left
                 if !prefix.is_empty() {
                     self.pre = Some(prefix);
                 }
-
-                return Poll::Ready(Ok(copy_len));
             }
         }
         Pin::new(&mut self.inner).poll_read(cx, buf)
@@ -91,15 +86,6 @@ where
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.inner).poll_shutdown(cx)
-    }
-
-    #[inline]
-    fn poll_write_buf<B: Buf>(
-        mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_write_buf(cx, buf)
     }
 }
 

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -56,7 +56,7 @@ where
             if !prefix.is_empty() {
                 let copy_len = cmp::min(prefix.len(), buf.remaining());
                 // TODO: There should be a way to do following two lines cleaner...
-                buf.put_slice(prefix.to_vec().as_slice());
+                buf.put_slice(&prefix[..copy_len]);
                 prefix.advance(copy_len);
                 // Put back whats left
                 if !prefix.is_empty() {

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -62,6 +62,8 @@ where
                 if !prefix.is_empty() {
                     self.pre = Some(prefix);
                 }
+
+                return Poll::Ready(Ok(()));
             }
         }
         Pin::new(&mut self.inner).poll_read(cx, buf)

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -37,9 +37,9 @@ impl<T> Rewind<T> {
         (self.inner, self.pre.unwrap_or_else(Bytes::new))
     }
 
-    pub(crate) fn get_mut(&mut self) -> &mut T {
-        &mut self.inner
-    }
+    // pub(crate) fn get_mut(&mut self) -> &mut T {
+    //     &mut self.inner
+    // }
 }
 
 impl<T> AsyncRead for Rewind<T>

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -967,9 +967,8 @@ mod tests {
         *conn.io.read_buf_mut() = ::bytes::BytesMut::from(&s[..]);
         conn.state.cached_headers = Some(HeaderMap::with_capacity(2));
 
-        let mut rt = tokio::runtime::Builder::new()
+        let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
-            .basic_scheduler()
             .build()
             .unwrap();
 

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -624,7 +624,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_decode_chunked_1kb(b: &mut test::Bencher) {
-        let mut rt = new_runtime();
+        let rt = new_runtime();
 
         const LEN: usize = 1024;
         let mut vec = Vec::new();
@@ -648,7 +648,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_decode_length_1kb(b: &mut test::Bencher) {
-        let mut rt = new_runtime();
+        let rt = new_runtime();
 
         const LEN: usize = 1024;
         let content = Bytes::from(&[0; LEN][..]);
@@ -666,9 +666,8 @@ mod tests {
 
     #[cfg(feature = "nightly")]
     fn new_runtime() -> tokio::runtime::Runtime {
-        tokio::runtime::Builder::new()
+        tokio::runtime::Builder::new_current_thread()
             .enable_all()
-            .basic_scheduler()
             .build()
             .expect("rt build")
     }

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -198,7 +198,6 @@ where
                     // @tokio pls give me back `poll_read_buf` thanks
                     self.read_buf.advance_mut(n);
                 }
-                debug!("read {} bytes", n);
                 self.read_buf_strategy.record(n);
                 Poll::Ready(Ok(n))
             }

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -33,6 +33,8 @@ pub struct Buffered<T, B> {
     io: T,
     read_blocked: bool,
     read_buf: BytesMut,
+    // TODO(eliza): get rid of this when tokio regrows `poll_read_buf`...
+    read_pos: usize,
     read_buf_strategy: ReadStrategy,
     write_buf: WriteBuf<B>,
 }
@@ -60,6 +62,7 @@ where
             io,
             read_blocked: false,
             read_buf: BytesMut::with_capacity(0),
+            read_pos: 0,
             read_buf_strategy: ReadStrategy::default(),
             write_buf: WriteBuf::new(),
         }
@@ -188,12 +191,20 @@ where
         if self.read_buf_remaining_mut() < next {
             self.read_buf.reserve(next);
         }
-        let mut buf = ReadBuf::new(&mut self.read_buf[..]);
+        let mut buf = ReadBuf::uninit(&mut self.read_buf.bytes_mut()[self.read_pos..]);
         match Pin::new(&mut self.io).poll_read(cx, &mut buf) {
             Poll::Ready(Ok(_)) => {
+                let _ = dbg!(std::str::from_utf8(buf.filled()));
                 let n = buf.filled().len();
                 debug!("read {} bytes", n);
                 self.read_buf_strategy.record(n);
+                self.read_pos += n;
+                unsafe {
+                    // Safety: we just read that many bytes into the
+                    // uninitialized part of the buffer, so this is okay.
+                    // @tokio pls give me back `poll_read_buf` thanks
+                    self.read_buf.advance_mut(n);
+                }
                 Poll::Ready(Ok(n))
             }
             Poll::Pending => {
@@ -663,6 +674,7 @@ mod tests {
     async fn parse_reads_until_blocked() {
         use crate::proto::h1::ClientTransaction;
 
+        let _ = pretty_env_logger::try_init();
         let mock = Mock::new()
             // Split over multiple reads will read all of it
             .read(b"HTTP/1.1 200 OK\r\n")

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -660,7 +660,8 @@ impl Http1Transaction for Client {
                 );
                 let mut res = httparse::Response::new(&mut headers);
                 let bytes = buf.as_ref();
-                match res.parse(bytes)? {
+                let _ = dbg!(std::str::from_utf8(bytes));
+                match dbg!(res.parse(bytes))? {
                     httparse::Status::Complete(len) => {
                         trace!("Response.parse Complete({})", len);
                         let status = StatusCode::from_u16(res.code.unwrap())?;

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -660,8 +660,7 @@ impl Http1Transaction for Client {
                 );
                 let mut res = httparse::Response::new(&mut headers);
                 let bytes = buf.as_ref();
-                let _ = dbg!(std::str::from_utf8(bytes));
-                match dbg!(res.parse(bytes))? {
+                match res.parse(bytes)? {
                     httparse::Status::Complete(len) => {
                         trace!("Response.parse Complete({})", len);
                         let status = StatusCode::from_u16(res.code.unwrap())?;

--- a/src/proto/h2/ping.rs
+++ b/src/proto/h2/ping.rs
@@ -33,7 +33,7 @@ use std::time::Instant;
 
 use h2::{Ping, PingPong};
 #[cfg(feature = "runtime")]
-use tokio::time::{Delay, Instant};
+use tokio::time::{Instant, Sleep};
 
 type WindowSize = u32;
 
@@ -60,7 +60,7 @@ pub(super) fn channel(ping_pong: PingPong, config: Config) -> (Recorder, Ponger)
         interval,
         timeout: config.keep_alive_timeout,
         while_idle: config.keep_alive_while_idle,
-        timer: tokio::time::delay_for(interval),
+        timer: tokio::time::sleep(interval),
         state: KeepAliveState::Init,
     });
 
@@ -156,7 +156,7 @@ struct KeepAlive {
     while_idle: bool,
 
     state: KeepAliveState,
-    timer: Delay,
+    timer: Sleep,
 }
 
 #[cfg(feature = "runtime")]

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -809,9 +809,9 @@ where
     type Output = Result<Connection<I, S, E>, FE>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        let me = self.project();
+        let mut me = self.project();
         let service = ready!(me.future.poll(cx))?;
-        let io = me.io.take().expect("polled after complete");
+        let io = Option::take(&mut me.io).expect("polled after complete");
         Poll::Ready(Ok(me.protocol.serve_connection(io, service)))
     }
 }

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -30,6 +30,10 @@ impl AddrIncoming {
     }
 
     pub(super) fn from_std(std_listener: StdTcpListener) -> crate::Result<Self> {
+        // TcpListener::from_std doesn't set O_NONBLOCK
+        std_listener
+            .set_nonblocking(true)
+            .map_err(crate::Error::new_listen)?;
         let listener = TcpListener::from_std(std_listener).map_err(crate::Error::new_listen)?;
         let addr = listener.local_addr().map_err(crate::Error::new_listen)?;
         Ok(AddrIncoming {

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -141,7 +141,7 @@ impl AddrIncoming {
                         #[cfg(unix)]
                         drop(std::os::unix::io::IntoRawFd::into_raw_fd(socket));
                         #[cfg(windows)]
-                        drop(std::os::windows::io::IntoRawFd::into_raw_fd(socket));
+                        drop(std::os::windows::io::IntoRawSocket::into_raw_socket(socket));
                     }
                     if let Err(e) = socket.set_nodelay(self.tcp_nodelay) {
                         trace!("error trying to set TCP nodelay: {}", e);

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -249,7 +249,7 @@ mod addr_stream {
     impl AsyncWrite for AddrStream {
         #[inline]
         fn poll_write(
-            mut self: Pin<&mut Self>,
+            self: Pin<&mut Self>,
             cx: &mut task::Context<'_>,
             buf: &[u8],
         ) -> Poll<io::Result<usize>> {
@@ -263,10 +263,7 @@ mod addr_stream {
         }
 
         #[inline]
-        fn poll_shutdown(
-            mut self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
-        ) -> Poll<io::Result<()>> {
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
             self.project().inner.poll_shutdown(cx)
         }
     }

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -97,14 +97,47 @@ impl AddrIncoming {
         loop {
             match ready!(self.listener.poll_accept(cx)) {
                 Ok((socket, addr)) => {
-                    #[cfg(unix)] // TODO(eliza): keepalive should work on non unix OSes
                     if let Some(dur) = self.tcp_keepalive_timeout {
-                        use std::os::unix::io::{AsRawFd, FromRawFd};
-                        // TODO(eliza): ughhh
-                        let socket = unsafe { socket2::Socket::from_raw_fd(socket.as_raw_fd()) };
+                        // Convert the Tokio `TcpStream` into a `socket2` socket
+                        // so we can call `set_keepalive`.
+                        // TODO(eliza): if Tokio's `TcpSocket` API grows a few
+                        // more methods in the future, hopefully we shouldn't
+                        // have to do the `from_raw_fd` dance any longer...
+                        #[cfg(unix)]
+                        let socket = unsafe {
+                            // Safety: `socket2`'s socket will try to close the
+                            // underlying fd when it's dropped. However, we
+                            // can't take ownership of the fd from the tokio
+                            // TcpStream, so instead we will call `into_raw_fd`
+                            // on the socket2 socket before dropping it. This
+                            // prevents it from trying to close the fd.
+                            use std::os::unix::io::{AsRawFd, FromRawFd};
+                            socket2::Socket::from_raw_fd(socket.as_raw_fd())
+                        };
+                        #[cfg(windows)]
+                        let socket = unsafe {
+                            // Safety: `socket2`'s socket will try to close the
+                            // underlying SOCKET when it's dropped. However, we
+                            // can't take ownership of the SOCKET from the tokio
+                            // TcpStream, so instead we will call `into_raw_socket`
+                            // on the socket2 socket before dropping it. This
+                            // prevents it from trying to close the SOCKET.
+                            use std::os::windows::io::{AsRawSocket, FromRawSocket};
+                            socket2::Socket::from_raw_socket(socket.as_raw_socket())
+                        };
+
+                        // Actually set the TCP keepalive timeout.
                         if let Err(e) = socket.set_keepalive(Some(dur)) {
                             trace!("error trying to set TCP keepalive: {}", e);
                         }
+
+                        // Take ownershop of the fd/socket back from the socket2
+                        // `Socket`, so that socket2 doesn't try to close it
+                        // when it's dropped.
+                        #[cfg(unix)]
+                        drop(std::os::unix::io::IntoRawFd::into_raw_fd(socket));
+                        #[cfg(windows)]
+                        drop(std::os::windows::io::IntoRawFd::into_raw_fd(socket));
                     }
                     if let Err(e) = socket.set_nodelay(self.tcp_nodelay) {
                         trace!("error trying to set TCP nodelay: {}", e);

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -4,7 +4,7 @@ use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::time::Duration;
 
 use tokio::net::TcpListener;
-use tokio::time::Delay;
+use tokio::time::Sleep;
 
 use crate::common::{task, Future, Pin, Poll};
 
@@ -19,7 +19,7 @@ pub struct AddrIncoming {
     sleep_on_errors: bool,
     tcp_keepalive_timeout: Option<Duration>,
     tcp_nodelay: bool,
-    timeout: Option<Delay>,
+    timeout: Option<Sleep>,
 }
 
 impl AddrIncoming {
@@ -119,7 +119,7 @@ impl AddrIncoming {
                         error!("accept error: {}", e);
 
                         // Sleep 1s.
-                        let mut timeout = tokio::time::delay_for(Duration::from_secs(1));
+                        let mut timeout = tokio::time::sleep(Duration::from_secs(1));
 
                         match Pin::new(&mut timeout).poll(cx) {
                             Poll::Ready(()) => {

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -311,7 +311,7 @@ mod tests {
     impl AsyncWrite for Mock {
         fn poll_write(
             self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
+            _: &mut task::Context<'_>,
             buf: &[u8],
         ) -> Poll<io::Result<usize>> {
             // panic!("poll_write shouldn't be called");

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -302,8 +302,8 @@ mod tests {
         fn poll_read(
             self: Pin<&mut Self>,
             _cx: &mut task::Context<'_>,
-            _buf: &mut [u8],
-        ) -> Poll<io::Result<usize>> {
+            _buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
             unreachable!("Mock::poll_read")
         }
     }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -963,7 +963,7 @@ mod dispatch_impl {
     use futures_util::future::{FutureExt, TryFutureExt};
     use futures_util::stream::StreamExt;
     use http::Uri;
-    use tokio::io::{AsyncRead, AsyncWrite};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
     use tokio::net::TcpStream;
     use tokio::runtime::Runtime;
 
@@ -1016,7 +1016,7 @@ mod dispatch_impl {
         rt.block_on(async move {
             let (res, ()) = future::join(res, rx).await;
             res.unwrap();
-            tokio::time::delay_for(Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         });
 
         rt.block_on(closes.into_future()).0.expect("closes");
@@ -1075,7 +1075,7 @@ mod dispatch_impl {
         rt.block_on(async move {
             let (res, ()) = future::join(res, rx).await;
             res.unwrap();
-            tokio::time::delay_for(Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
         });
 
         rt.block_on(closes.into_future()).0.expect("closes");
@@ -1147,7 +1147,7 @@ mod dispatch_impl {
         drop(client);
 
         // and wait a few ticks for the connections to close
-        let t = tokio::time::delay_for(Duration::from_millis(100)).map(|_| panic!("time out"));
+        let t = tokio::time::sleep(Duration::from_millis(100)).map(|_| panic!("time out"));
         let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
         future::select(t, close).await;
     }
@@ -1195,7 +1195,7 @@ mod dispatch_impl {
         future::select(res, rx1).await;
 
         // res now dropped
-        let t = tokio::time::delay_for(Duration::from_millis(100)).map(|_| panic!("time out"));
+        let t = tokio::time::sleep(Duration::from_millis(100)).map(|_| panic!("time out"));
         let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
         future::select(t, close).await;
     }
@@ -1250,7 +1250,7 @@ mod dispatch_impl {
         res.unwrap();
 
         // and wait a few ticks to see the connection drop
-        let t = tokio::time::delay_for(Duration::from_millis(100)).map(|_| panic!("time out"));
+        let t = tokio::time::sleep(Duration::from_millis(100)).map(|_| panic!("time out"));
         let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
         future::select(t, close).await;
     }
@@ -1300,7 +1300,7 @@ mod dispatch_impl {
         let (res, ()) = future::join(res, rx).await;
         res.unwrap();
 
-        let t = tokio::time::delay_for(Duration::from_millis(100)).map(|_| panic!("time out"));
+        let t = tokio::time::sleep(Duration::from_millis(100)).map(|_| panic!("time out"));
         let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
         future::select(t, close).await;
     }
@@ -1346,7 +1346,7 @@ mod dispatch_impl {
         let (res, ()) = future::join(res, rx).await;
         res.unwrap();
 
-        let t = tokio::time::delay_for(Duration::from_millis(100)).map(|_| panic!("time out"));
+        let t = tokio::time::sleep(Duration::from_millis(100)).map(|_| panic!("time out"));
         let close = closes.into_future().map(|(opt, _)| opt.expect("closes"));
         future::select(t, close).await;
     }
@@ -1544,7 +1544,7 @@ mod dispatch_impl {
         assert_eq!(connects.load(Ordering::Relaxed), 0);
 
         let delayed_body = rx1
-            .then(|_| tokio::time::delay_for(Duration::from_millis(200)))
+            .then(|_| tokio::time::sleep(Duration::from_millis(200)))
             .map(|_| Ok::<_, ()>("hello a"))
             .map_err(|_| -> hyper::Error { panic!("rx1") })
             .into_stream();
@@ -1559,7 +1559,7 @@ mod dispatch_impl {
 
         // req 1
         let fut = future::join(client.request(req), rx)
-            .then(|_| tokio::time::delay_for(Duration::from_millis(200)))
+            .then(|_| tokio::time::sleep(Duration::from_millis(200)))
             // req 2
             .then(move |()| {
                 let rx = rx3.expect("thread panicked");
@@ -1646,7 +1646,7 @@ mod dispatch_impl {
 
         // sleep real quick to let the threadpool put connection in ready
         // state and back into client pool
-        tokio::time::delay_for(Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
         let rx = rx2.expect("thread panicked");
         let req = Request::builder()
@@ -1961,10 +1961,10 @@ mod dispatch_impl {
 
     impl AsyncRead for DebugStream {
         fn poll_read(
-            mut self: Pin<&mut Self>,
+            self: Pin<&mut Self>,
             cx: &mut Context<'_>,
-            buf: &mut [u8],
-        ) -> Poll<Result<usize, io::Error>> {
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
             Pin::new(&mut self.tcp).poll_read(cx, buf)
         }
     }
@@ -2090,7 +2090,7 @@ mod conn {
         });
 
         let rx = rx1.expect("thread panicked");
-        let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+        let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
         let chunk = rt.block_on(future::join(res, rx).map(|r| r.0)).unwrap();
         assert_eq!(chunk.len(), 5);
     }
@@ -2185,7 +2185,7 @@ mod conn {
             concat(res)
         });
         let rx = rx1.expect("thread panicked");
-        let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+        let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
         rt.block_on(future::join(res, rx).map(|r| r.0)).unwrap();
     }
 
@@ -2231,7 +2231,7 @@ mod conn {
             concat(res)
         });
         let rx = rx1.expect("thread panicked");
-        let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+        let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
         rt.block_on(future::join(res, rx).map(|r| r.0)).unwrap();
     }
 
@@ -2283,7 +2283,7 @@ mod conn {
         });
 
         let rx = rx1.expect("thread panicked");
-        let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+        let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
         rt.block_on(future::join3(res1, res2, rx).map(|r| r.0))
             .unwrap();
     }
@@ -2346,7 +2346,7 @@ mod conn {
             });
 
             let rx = rx1.expect("thread panicked");
-            let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+            let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
             rt.block_on(future::join3(until_upgrade, res, rx).map(|r| r.0))
                 .unwrap();
 
@@ -2439,7 +2439,7 @@ mod conn {
                 });
 
             let rx = rx1.expect("thread panicked");
-            let rx = rx.then(|_| tokio::time::delay_for(Duration::from_millis(200)));
+            let rx = rx.then(|_| tokio::time::sleep(Duration::from_millis(200)));
             rt.block_on(future::join3(until_tunneled, res, rx).map(|r| r.0))
                 .unwrap();
 
@@ -2529,7 +2529,7 @@ mod conn {
         let _ = shdn_tx.send(());
 
         // Allow time for graceful shutdown roundtrips...
-        tokio::time::delay_for(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
         // After graceful shutdown roundtrips, the client should be closed...
         future::poll_fn(|ctx| client.poll_ready(ctx))
@@ -2606,7 +2606,7 @@ mod conn {
         });
 
         // sleep longer than keepalive would trigger
-        tokio::time::delay_for(Duration::from_secs(4)).await;
+        tokio::time::sleep(Duration::from_secs(4)).await;
 
         future::poll_fn(|ctx| client.poll_ready(ctx))
             .await
@@ -2711,7 +2711,7 @@ mod conn {
         let _resp = client.send_request(req1).await.expect("send_request");
 
         // sleep longer than keepalive would trigger
-        tokio::time::delay_for(Duration::from_secs(4)).await;
+        tokio::time::sleep(Duration::from_secs(4)).await;
 
         future::poll_fn(|ctx| client.poll_ready(ctx))
             .await
@@ -2761,10 +2761,10 @@ mod conn {
 
     impl AsyncRead for DebugStream {
         fn poll_read(
-            mut self: Pin<&mut Self>,
+            self: Pin<&mut Self>,
             cx: &mut Context<'_>,
-            buf: &mut [u8],
-        ) -> Poll<Result<usize, io::Error>> {
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
             Pin::new(&mut self.tcp).poll_read(cx, buf)
         }
     }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1939,7 +1939,7 @@ async fn write_pong_frame(conn: &mut TkTcpStream) {
 async fn http2_keep_alive_count_server_pings() {
     let _ = pretty_env_logger::try_init();
 
-    let mut listener = tcp_bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let listener = tcp_bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = listener.local_addr().unwrap();
 
     tokio::spawn(async move {

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2206,9 +2206,8 @@ impl ServeOptions {
         let thread = thread::Builder::new()
             .name(thread_name)
             .spawn(move || {
-                let mut rt = tokio::runtime::Builder::new()
-                    .enable_io()
-                    .enable_time()
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
                     .basic_scheduler()
                     .build()
                     .expect("rt new");

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{
@@ -15,6 +16,7 @@ pub use futures_util::{
 pub use hyper::{HeaderMap, StatusCode};
 pub use std::net::SocketAddr;
 
+#[allow(unused_macros)]
 macro_rules! t {
     (
         $name:ident,
@@ -303,15 +305,16 @@ pub struct __TestConfig {
     pub proxy: bool,
 }
 
-pub fn __run_test(cfg: __TestConfig) {
-    let _ = pretty_env_logger::try_init();
-    tokio::runtime::Builder::new()
-        .enable_io()
-        .enable_time()
-        .basic_scheduler()
+pub fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
         .build()
         .expect("new rt")
-        .block_on(async_test(cfg));
+}
+
+pub fn __run_test(cfg: __TestConfig) {
+    let _ = pretty_env_logger::try_init();
+    runtime().block_on(async_test(cfg));
 }
 
 async fn async_test(cfg: __TestConfig) {


### PR DESCRIPTION
  This branch updates Hyper's Tokio dependency to v0.3.x. This continues
the work started by @Urhengulas in PR #2309, updating additional parts
of the codebase and fixing some bugs introduced in that branch.

There are a few important notes:

* `h2` is currently a Git dependency, so this will block releasing a new
  Hyper version until a new `h2` is published.

* Tokio 0.3 doesn't currently have vectored IO APIs, so Hyper has
  (hopefully temporarily) lost its vectored IO support

* `AsyncRead::poll_read_buf` and `AsyncWrite::poll_write_buf` are being
  moved to `tokio-util`. Currently, they're not available, so we fall
  back to slicing and advancing `Bytes` and `BytesMut` buffers
  ourselves. When support lands upstream, we should change back.

* Ideally, Tokio's new `TcpSocket` type should gain support for more of
  the socket options hyper needs to set. If this happens, we should be
  able to remove some messy code involving `AsRawFd`/`FromRawFd` and
  `socket2`.

* This also bumps Hyper's minimum supported Rust version to 1.45.2,
  which is Tokio's minimum supported version. Tokio 0.3 doesn't build
  on 1.39.0

Closes #2309

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
Co-authored-by: Urhengulas <johann.hemmann@code.berlin>