### PR TITLE
fix(server): fix graceful_shutdown on freshly opened connections

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -42,7 +42,7 @@ where
                 allow_half_close: false,
                 cached_headers: None,
                 error: None,
-                keep_alive: KA::Busy,
+                keep_alive: KA::Idle,
                 method: None,
                 title_case_headers: false,
                 notify_read: false,
@@ -686,7 +686,7 @@ where
         self.state.close_write();
     }
 
-    pub fn disable_keep_alive(&mut self) {
+    pub fn close_idle_connection(&mut self) {
         if self.state.is_idle() {
             trace!("disable_keep_alive; closing idle connection");
             self.state.close();
@@ -694,6 +694,10 @@ where
             trace!("disable_keep_alive; in-progress connection");
             self.state.disable_keep_alive();
         }
+    }
+
+    pub fn disable_keep_alive(&mut self) {
+        self.state.disable_keep_alive();
     }
 
     pub fn take_error(&mut self) -> crate::Result<()> {

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -71,8 +71,8 @@ where
         }
     }
 
-    pub fn disable_keep_alive(&mut self) {
-        self.conn.disable_keep_alive();
+    pub fn close_idle_connection(&mut self) {
+        self.conn.close_idle_connection();
         if self.conn.is_write_closed() {
             self.close();
         }

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -568,7 +568,7 @@ where
     pub fn graceful_shutdown(self: Pin<&mut Self>) {
         match self.project().conn {
             Some(ProtoServer::H1(ref mut h1)) => {
-                h1.disable_keep_alive();
+                h1.close_idle_connection();
             }
             Some(ProtoServer::H2(ref mut h2)) => {
                 h2.graceful_shutdown();


### PR DESCRIPTION
When opening a http1 connection, the keep_alive state is set to Busy,
preventing a graceful_shutdown in that case. With this patch the
keep_alive disabling and closing of idle connections is decoupled and
should fix this issue.

Closes #1885

Although all tests go through (afaict), i am not entirely sure this is desired behaviour, though
we run into an issue where we use the graceful_shutdown for a daemon reload and an
open connection (with no data) can block our reload... (this issue fixes that)

Signed-off-by: Dominik Csapak <d.csapak@proxmox.com>

