### PR TITLE
fix(h1): ending close-delimited body should close

### DIFF
--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -81,6 +81,13 @@ impl Encoder {
         self.is_last
     }
 
+    pub fn is_close_delimited(&self) -> bool {
+        match self.kind {
+            Kind::CloseDelimited => true,
+            _ => false,
+        }
+    }
+
     pub fn end<B>(&self) -> Result<Option<EncodedBuf<B>>, NotEof> {
         match self.kind {
             Kind::Length(0) => Ok(None),


### PR DESCRIPTION
PR #2264 introduced a bug where calling `end_body` on close-delimited
encoders would not actually close the connection. This is because the
call to `encoder.end()` now returns `Ok(None)` for close-delimited
encoders, to prevent the error from being propagated as though the user
body ended too early. However, when `Ok` is returned, the write state is
only advanced to `Closed` if the encoder returns `true` from `is_last`.
This means that when the body is close-delimited, ending the body does
nothing, leaving the connection in keepalive.

This causes a hang in Linkerd, where we proxy HTTP requests connections
by returning a client body in a response. If the upstream server closes
the connection, we need to rely on the close always being propagated to
the connection with our client. This bug resulted in the body closing
abruptly leaving the connection in a stuck state, instead.

This branch fixes this by special-casing close-delimited bodies so that
they will also set the write state to `Closed` when calling `end_body`,
even if the `is_last` bit has not been set.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

