### PR TITLE
feat(http2): Make HTTP/2 support an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ http = "0.2"
 http-body = "0.3.1"
 httpdate = "0.3"
 httparse = "1.0"
-h2 = { git = "https://github.com/hyperium/h2" }
+h2 = { git = "https://github.com/hyperium/h2", optional = true }
 itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "1.0"
@@ -56,6 +56,7 @@ tokio = { version = "0.3", features = [
     "fs",
     "macros",
     "io-std",
+    "io-util",
     "rt",
     "rt-multi-thread", # so examples can use #[tokio::main]
     "sync",
@@ -73,7 +74,16 @@ pnet = "0.25.0"
 [features]
 default = [
     "runtime",
-    "stream"
+    "stream",
+
+    #"http1",
+    "http2",
+]
+full = [
+    #"http1",
+    "http2",
+    "stream",
+    "runtime",
 ]
 runtime = [
     "tcp",
@@ -86,6 +96,10 @@ tcp = [
     "tokio/time",
 ]
 
+# HTTP versions
+#http1 = []
+http2 = ["h2"]
+
 # `impl Stream` for things
 stream = []
 
@@ -94,10 +108,11 @@ nightly = []
 __internal_happy_eyeballs_tests = []
 
 [package.metadata.docs.rs]
-features = [
-    "runtime",
-    "stream",
-]
+features = ["full"]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.playground]
+features = ["full"]
 
 [profile.release]
 codegen-units = 1

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,0 +1,9 @@
+macro_rules! cfg_http2 {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "http2")]
+            //#[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+            $item
+        )*
+    }
+}

--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -184,6 +184,7 @@ impl Connected {
 
     // Don't public expose that `Connected` is `Clone`, unsure if we want to
     // keep that contract...
+    #[cfg(feature = "http2")]
     pub(super) fn clone(&self) -> Connected {
         Connected {
             alpn: self.alpn.clone(),

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -14,6 +14,7 @@ pub(crate) struct Rewind<T> {
 }
 
 impl<T> Rewind<T> {
+    #[cfg(any(feature = "http2", test))]
     pub(crate) fn new(io: T) -> Self {
         Rewind {
             pre: None,
@@ -28,6 +29,7 @@ impl<T> Rewind<T> {
         }
     }
 
+    #[cfg(any(feature = "http2", test))]
     pub(crate) fn rewind(&mut self, bs: Bytes) {
         debug_assert!(self.pre.is_none());
         self.pre = Some(bs);

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,7 @@ pub(crate) enum Kind {
     Shutdown,
 
     /// A general error from h2.
+    #[cfg(feature = "http2")]
     Http2,
 }
 
@@ -175,6 +176,7 @@ impl Error {
         None
     }
 
+    #[cfg(feature = "http2")]
     pub(crate) fn h2_reason(&self) -> h2::Reason {
         // Find an h2::Reason somewhere in the cause stack, if it exists,
         // otherwise assume an INTERNAL_ERROR.
@@ -284,6 +286,7 @@ impl Error {
         Error::new(Kind::Shutdown).with(cause)
     }
 
+    #[cfg(feature = "http2")]
     pub(crate) fn new_h2(cause: ::h2::Error) -> Error {
         if cause.is_io() {
             Error::new_io(cause.into_io().expect("h2::Error::is_io"))
@@ -313,6 +316,7 @@ impl Error {
             Kind::BodyWrite => "error writing a body to connection",
             Kind::BodyWriteAborted => "body write aborted",
             Kind::Shutdown => "error shutting down connection",
+            #[cfg(feature = "http2")]
             Kind::Http2 => "http2 error",
             Kind::Io => "connection error",
 
@@ -432,18 +436,21 @@ mod tests {
         assert_eq!(mem::size_of::<Error>(), mem::size_of::<usize>());
     }
 
+    #[cfg(feature = "http2")]
     #[test]
     fn h2_reason_unknown() {
         let closed = Error::new_closed();
         assert_eq!(closed.h2_reason(), h2::Reason::INTERNAL_ERROR);
     }
 
+    #[cfg(feature = "http2")]
     #[test]
     fn h2_reason_one_level() {
         let body_err = Error::new_user_body(h2::Error::from(h2::Reason::ENHANCE_YOUR_CALM));
         assert_eq!(body_err.h2_reason(), h2::Reason::ENHANCE_YOUR_CALM);
     }
 
+    #[cfg(feature = "http2")]
     #[test]
     fn h2_reason_nested() {
         let recvd = Error::new_h2(h2::Error::from(h2::Reason::HTTP_1_1_REQUIRED));

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,6 +1,7 @@
 use bytes::BytesMut;
 use http::header::{HeaderValue, OccupiedEntry, ValueIter};
 use http::header::{CONTENT_LENGTH, TRANSFER_ENCODING};
+#[cfg(feature = "http2")]
 use http::method::Method;
 use http::HeaderMap;
 
@@ -58,6 +59,7 @@ pub fn content_length_parse_all_values(values: ValueIter<'_, HeaderValue>) -> Op
     }
 }
 
+#[cfg(feature = "http2")]
 pub fn method_has_defined_payload_semantics(method: &Method) -> bool {
     match *method {
         Method::GET | Method::HEAD | Method::DELETE | Method::CONNECT => false,
@@ -65,6 +67,7 @@ pub fn method_has_defined_payload_semantics(method: &Method) -> bool {
     }
 }
 
+#[cfg(feature = "http2")]
 pub fn set_content_length_if_missing(headers: &mut HeaderMap, len: u64) {
     headers
         .entry(CONTENT_LENGTH)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@ pub use crate::error::{Error, Result};
 pub use crate::server::Server;
 
 #[macro_use]
+mod cfg;
+#[macro_use]
 mod common;
 pub mod body;
 pub mod client;

--- a/src/proto/h1/date.rs
+++ b/src/proto/h1/date.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Write};
 use std::str;
 use std::time::{Duration, SystemTime};
 
+#[cfg(feature = "http2")]
 use http::header::HeaderValue;
 use httpdate::HttpDate;
 
@@ -21,6 +22,7 @@ pub fn update() {
     })
 }
 
+#[cfg(feature = "http2")]
 pub(crate) fn update_and_header_value() -> HeaderValue {
     CACHED.with(|cache| {
         let mut cache = cache.borrow_mut();

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::{decode_content_length, ping, PipeToSendStream, SendBuf};
 use crate::body::HttpBody;
-use crate::common::exec::H2Exec;
+use crate::common::exec::ConnStreamExec;
 use crate::common::{task, Future, Pin, Poll};
 use crate::headers;
 use crate::proto::Dispatched;
@@ -95,7 +95,7 @@ where
     S: HttpService<Body, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: HttpBody + 'static,
-    E: H2Exec<S::Future, B>,
+    E: ConnStreamExec<S::Future, B>,
 {
     pub(crate) fn new(io: T, service: S, config: &Config, exec: E) -> Server<T, S, B, E> {
         let mut builder = h2::server::Builder::default();
@@ -162,7 +162,7 @@ where
     S: HttpService<Body, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: HttpBody + 'static,
-    E: H2Exec<S::Future, B>,
+    E: ConnStreamExec<S::Future, B>,
 {
     type Output = crate::Result<Dispatched>;
 
@@ -216,7 +216,7 @@ where
     where
         S: HttpService<Body, ResBody = B>,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
-        E: H2Exec<S::Future, B>,
+        E: ConnStreamExec<S::Future, B>,
     {
         if self.closing.is_none() {
             loop {

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -5,7 +5,9 @@ pub(crate) use self::body_length::DecodedLength;
 pub(crate) use self::h1::{dispatch, Conn, ServerTransaction};
 
 pub(crate) mod h1;
-pub(crate) mod h2;
+cfg_http2! {
+    pub(crate) mod h2;
+}
 
 /// An Incoming Message head. Includes request/status line, and headers.
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -45,10 +45,12 @@
 
 use std::error::Error as StdError;
 use std::fmt;
+use std::marker::PhantomData;
 use std::mem;
 #[cfg(feature = "tcp")]
 use std::net::SocketAddr;
 #[cfg(feature = "runtime")]
+#[cfg(feature = "http2")]
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -57,9 +59,11 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::Accept;
 use crate::body::{Body, HttpBody};
-use crate::common::exec::{Exec, H2Exec, NewSvcExec};
+use crate::common::exec::{ConnStreamExec, Exec, NewSvcExec};
+#[cfg(feature = "http2")]
 use crate::common::io::Rewind;
 use crate::common::{task, Future, Pin, Poll, Unpin};
+#[cfg(feature = "http2")]
 use crate::error::{Kind, Parse};
 use crate::proto;
 use crate::service::{HttpService, MakeServiceRef};
@@ -85,6 +89,7 @@ pub struct Http<E = Exec> {
     h1_half_close: bool,
     h1_keep_alive: bool,
     h1_writev: Option<bool>,
+    #[cfg(feature = "http2")]
     h2_builder: proto::h2::server::Config,
     mode: ConnectionMode,
     max_buf_size: Option<usize>,
@@ -97,8 +102,10 @@ enum ConnectionMode {
     /// Always use HTTP/1 and do not upgrade when a parse error occurs.
     H1Only,
     /// Always use HTTP/2.
+    #[cfg(feature = "http2")]
     H2Only,
     /// Use HTTP/1 and try to upgrade to h2 when a parse error occurs.
+    #[cfg(feature = "http2")]
     Fallback,
 }
 
@@ -150,6 +157,7 @@ where
     S: HttpService<Body>,
 {
     pub(super) conn: Option<ProtoServer<T, S::ResBody, S, E>>,
+    #[cfg(feature = "http2")]
     fallback: Fallback<E>,
 }
 
@@ -167,16 +175,20 @@ where
             T,
             proto::ServerTransaction,
         >,
+        PhantomData<E>,
     ),
+    #[cfg(feature = "http2")]
     H2(#[pin] proto::h2::Server<Rewind<T>, S, B, E>),
 }
 
+#[cfg(feature = "http2")]
 #[derive(Clone, Debug)]
 enum Fallback<E> {
     ToHttp2(proto::h2::server::Config, E),
     Http1Only,
 }
 
+#[cfg(feature = "http2")]
 impl<E> Fallback<E> {
     fn to_h2(&self) -> bool {
         match *self {
@@ -186,6 +198,7 @@ impl<E> Fallback<E> {
     }
 }
 
+#[cfg(feature = "http2")]
 impl<E> Unpin for Fallback<E> {}
 
 /// Deconstructed parts of a `Connection`.
@@ -221,8 +234,9 @@ impl Http {
             h1_half_close: false,
             h1_keep_alive: true,
             h1_writev: None,
+            #[cfg(feature = "http2")]
             h2_builder: Default::default(),
-            mode: ConnectionMode::Fallback,
+            mode: ConnectionMode::default(),
             max_buf_size: None,
             pipeline_flush: false,
         }
@@ -237,7 +251,10 @@ impl<E> Http<E> {
         if val {
             self.mode = ConnectionMode::H1Only;
         } else {
-            self.mode = ConnectionMode::Fallback;
+            #[cfg(feature = "http2")]
+            {
+                self.mode = ConnectionMode::Fallback;
+            }
         }
         self
     }
@@ -291,6 +308,8 @@ impl<E> Http<E> {
     /// Sets whether HTTP2 is required.
     ///
     /// Default is false
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_only(&mut self, val: bool) -> &mut Self {
         if val {
             self.mode = ConnectionMode::H2Only;
@@ -308,6 +327,8 @@ impl<E> Http<E> {
     /// If not set, hyper will use a default.
     ///
     /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_initial_stream_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         if let Some(sz) = sz.into() {
             self.h2_builder.adaptive_window = false;
@@ -321,6 +342,8 @@ impl<E> Http<E> {
     /// Passing `None` will do nothing.
     ///
     /// If not set, hyper will use a default.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_initial_connection_window_size(
         &mut self,
         sz: impl Into<Option<u32>>,
@@ -337,6 +360,8 @@ impl<E> Http<E> {
     /// Enabling this will override the limits set in
     /// `http2_initial_stream_window_size` and
     /// `http2_initial_connection_window_size`.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_adaptive_window(&mut self, enabled: bool) -> &mut Self {
         use proto::h2::SPEC_WINDOW_SIZE;
 
@@ -353,6 +378,8 @@ impl<E> Http<E> {
     /// Passing `None` will do nothing.
     ///
     /// If not set, hyper will use a default.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_max_frame_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         if let Some(sz) = sz.into() {
             self.h2_builder.max_frame_size = sz;
@@ -366,6 +393,8 @@ impl<E> Http<E> {
     /// Default is no limit (`std::u32::MAX`). Passing `None` will do nothing.
     ///
     /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_MAX_CONCURRENT_STREAMS
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_max_concurrent_streams(&mut self, max: impl Into<Option<u32>>) -> &mut Self {
         self.h2_builder.max_concurrent_streams = max.into();
         self
@@ -382,6 +411,8 @@ impl<E> Http<E> {
     ///
     /// Requires the `runtime` cargo feature to be enabled.
     #[cfg(feature = "runtime")]
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_interval(
         &mut self,
         interval: impl Into<Option<Duration>>,
@@ -401,6 +432,8 @@ impl<E> Http<E> {
     ///
     /// Requires the `runtime` cargo feature to be enabled.
     #[cfg(feature = "runtime")]
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.h2_builder.keep_alive_timeout = timeout;
         self
@@ -441,6 +474,7 @@ impl<E> Http<E> {
             h1_half_close: self.h1_half_close,
             h1_keep_alive: self.h1_keep_alive,
             h1_writev: self.h1_writev,
+            #[cfg(feature = "http2")]
             h2_builder: self.h2_builder,
             mode: self.mode,
             max_buf_size: self.max_buf_size,
@@ -483,10 +517,10 @@ impl<E> Http<E> {
         Bd: HttpBody + 'static,
         Bd::Error: Into<Box<dyn StdError + Send + Sync>>,
         I: AsyncRead + AsyncWrite + Unpin,
-        E: H2Exec<S::Future, Bd>,
+        E: ConnStreamExec<S::Future, Bd>,
     {
-        let proto = match self.mode {
-            ConnectionMode::H1Only | ConnectionMode::Fallback => {
+        macro_rules! h1 {
+            () => {{
                 let mut conn = proto::Conn::new(io);
                 if !self.h1_keep_alive {
                     conn.disable_keep_alive();
@@ -506,8 +540,16 @@ impl<E> Http<E> {
                     conn.set_max_buf_size(max);
                 }
                 let sd = proto::h1::dispatch::Server::new(service);
-                ProtoServer::H1(proto::h1::Dispatcher::new(sd, conn))
-            }
+                ProtoServer::H1(proto::h1::Dispatcher::new(sd, conn), PhantomData)
+            }};
+        }
+
+        let proto = match self.mode {
+            #[cfg(not(feature = "http2"))]
+            ConnectionMode::H1Only => h1!(),
+            #[cfg(feature = "http2")]
+            ConnectionMode::H1Only | ConnectionMode::Fallback => h1!(),
+            #[cfg(feature = "http2")]
             ConnectionMode::H2Only => {
                 let rewind_io = Rewind::new(io);
                 let h2 =
@@ -518,6 +560,7 @@ impl<E> Http<E> {
 
         Connection {
             conn: Some(proto),
+            #[cfg(feature = "http2")]
             fallback: if self.mode == ConnectionMode::Fallback {
                 Fallback::ToHttp2(self.h2_builder.clone(), self.exec.clone())
             } else {
@@ -534,7 +577,7 @@ impl<E> Http<E> {
         S: MakeServiceRef<IO, Body, ResBody = Bd>,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
         Bd: HttpBody,
-        E: H2Exec<<S::Service as HttpService<Body>>::Future, Bd>,
+        E: ConnStreamExec<<S::Service as HttpService<Body>>::Future, Bd>,
     {
         Serve {
             incoming,
@@ -553,7 +596,7 @@ where
     I: AsyncRead + AsyncWrite + Unpin,
     B: HttpBody + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
-    E: H2Exec<S::Future, B>,
+    E: ConnStreamExec<S::Future, B>,
 {
     /// Start a graceful shutdown process for this connection.
     ///
@@ -567,9 +610,10 @@ where
     /// nothing.
     pub fn graceful_shutdown(self: Pin<&mut Self>) {
         match self.project().conn {
-            Some(ProtoServer::H1(ref mut h1)) => {
+            Some(ProtoServer::H1(ref mut h1, _)) => {
                 h1.disable_keep_alive();
             }
+            #[cfg(feature = "http2")]
             Some(ProtoServer::H2(ref mut h2)) => {
                 h2.graceful_shutdown();
             }
@@ -596,7 +640,7 @@ where
     /// This method will return a `None` if this connection is using an h2 protocol.
     pub fn try_into_parts(self) -> Option<Parts<I, S>> {
         match self.conn.unwrap() {
-            ProtoServer::H1(h1) => {
+            ProtoServer::H1(h1, _) => {
                 let (io, read_buf, dispatch) = h1.into_inner();
                 Some(Parts {
                     io,
@@ -605,6 +649,7 @@ where
                     _inner: (),
                 })
             }
+            #[cfg(feature = "http2")]
             ProtoServer::H2(_h2) => None,
         }
     }
@@ -628,18 +673,24 @@ where
     {
         loop {
             let polled = match *self.conn.as_mut().unwrap() {
-                ProtoServer::H1(ref mut h1) => h1.poll_without_shutdown(cx),
+                ProtoServer::H1(ref mut h1, _) => h1.poll_without_shutdown(cx),
+                #[cfg(feature = "http2")]
                 ProtoServer::H2(ref mut h2) => return Pin::new(h2).poll(cx).map_ok(|_| ()),
             };
             match ready!(polled) {
                 Ok(()) => return Poll::Ready(Ok(())),
-                Err(e) => match *e.kind() {
-                    Kind::Parse(Parse::VersionH2) if self.fallback.to_h2() => {
-                        self.upgrade_h2();
-                        continue;
+                Err(e) => {
+                    #[cfg(feature = "http2")]
+                    match *e.kind() {
+                        Kind::Parse(Parse::VersionH2) if self.fallback.to_h2() => {
+                            self.upgrade_h2();
+                            continue;
+                        }
+                        _ => (),
                     }
-                    _ => return Poll::Ready(Err(e)),
-                },
+
+                    return Poll::Ready(Err(e));
+                }
             }
         }
     }
@@ -659,12 +710,13 @@ where
         })
     }
 
+    #[cfg(feature = "http2")]
     fn upgrade_h2(&mut self) {
         trace!("Trying to upgrade connection to h2");
         let conn = self.conn.take();
 
         let (io, read_buf, dispatch) = match conn.unwrap() {
-            ProtoServer::H1(h1) => h1.into_inner(),
+            ProtoServer::H1(h1, _) => h1.into_inner(),
             ProtoServer::H2(_h2) => {
                 panic!("h2 cannot into_inner");
             }
@@ -699,7 +751,7 @@ where
     I: AsyncRead + AsyncWrite + Unpin + 'static,
     B: HttpBody + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
-    E: H2Exec<S::Future, B>,
+    E: ConnStreamExec<S::Future, B>,
 {
     type Output = crate::Result<()>;
 
@@ -716,13 +768,18 @@ where
                     }
                     return Poll::Ready(Ok(()));
                 }
-                Err(e) => match *e.kind() {
-                    Kind::Parse(Parse::VersionH2) if self.fallback.to_h2() => {
-                        self.upgrade_h2();
-                        continue;
+                Err(e) => {
+                    #[cfg(feature = "http2")]
+                    match *e.kind() {
+                        Kind::Parse(Parse::VersionH2) if self.fallback.to_h2() => {
+                            self.upgrade_h2();
+                            continue;
+                        }
+                        _ => (),
                     }
-                    _ => return Poll::Ready(Err(e)),
-                },
+
+                    return Poll::Ready(Err(e));
+                }
             }
         }
     }
@@ -736,6 +793,23 @@ where
         f.debug_struct("Connection").finish()
     }
 }
+
+// ===== impl ConnectionMode =====
+
+impl ConnectionMode {}
+
+impl Default for ConnectionMode {
+    #[cfg(feature = "http2")]
+    fn default() -> ConnectionMode {
+        ConnectionMode::Fallback
+    }
+
+    #[cfg(not(feature = "http2"))]
+    fn default() -> ConnectionMode {
+        ConnectionMode::H1Only
+    }
+}
+
 // ===== impl Serve =====
 
 impl<I, S, E> Serve<I, S, E> {
@@ -766,7 +840,7 @@ where
     IE: Into<Box<dyn StdError + Send + Sync>>,
     S: MakeServiceRef<IO, Body, ResBody = B>,
     B: HttpBody,
-    E: H2Exec<<S::Service as HttpService<Body>>::Future, B>,
+    E: ConnStreamExec<<S::Service as HttpService<Body>>::Future, B>,
 {
     fn poll_next_(
         self: Pin<&mut Self>,
@@ -804,7 +878,7 @@ where
     S: HttpService<Body, ResBody = B>,
     B: HttpBody + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
-    E: H2Exec<S::Future, B>,
+    E: ConnStreamExec<S::Future, B>,
 {
     type Output = Result<Connection<I, S, E>, FE>;
 
@@ -838,7 +912,7 @@ where
     IO: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     S: MakeServiceRef<IO, Body, ResBody = B>,
     B: HttpBody,
-    E: H2Exec<<S::Service as HttpService<Body>>::Future, B>,
+    E: ConnStreamExec<<S::Service as HttpService<Body>>::Future, B>,
 {
     pub(super) fn poll_watch<W>(
         self: Pin<&mut Self>,
@@ -875,13 +949,14 @@ where
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: HttpBody + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
-    E: H2Exec<S::Future, B>,
+    E: ConnStreamExec<S::Future, B>,
 {
     type Output = crate::Result<proto::Dispatched>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         match self.project() {
-            ProtoServerProj::H1(s) => s.poll(cx),
+            ProtoServerProj::H1(s, _) => s.poll(cx),
+            #[cfg(feature = "http2")]
             ProtoServerProj::H2(s) => s.poll(cx),
         }
     }
@@ -893,7 +968,7 @@ pub(crate) mod spawn_all {
 
     use super::{Connecting, UpgradeableConnection};
     use crate::body::{Body, HttpBody};
-    use crate::common::exec::H2Exec;
+    use crate::common::exec::ConnStreamExec;
     use crate::common::{task, Future, Pin, Poll, Unpin};
     use crate::service::HttpService;
     use pin_project::pin_project;
@@ -920,7 +995,7 @@ pub(crate) mod spawn_all {
     where
         I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
         S: HttpService<Body>,
-        E: H2Exec<S::Future, S::ResBody>,
+        E: ConnStreamExec<S::Future, S::ResBody>,
         S::ResBody: 'static,
         <S::ResBody as HttpBody>::Error: Into<Box<dyn StdError + Send + Sync>>,
     {
@@ -970,7 +1045,7 @@ pub(crate) mod spawn_all {
         S: HttpService<Body, ResBody = B>,
         B: HttpBody + 'static,
         B::Error: Into<Box<dyn StdError + Send + Sync>>,
-        E: H2Exec<S::Future, B>,
+        E: ConnStreamExec<S::Future, B>,
         W: Watcher<I, S, E>,
     {
         type Output = ();
@@ -1036,7 +1111,7 @@ mod upgrades {
         I: AsyncRead + AsyncWrite + Unpin,
         B: HttpBody + 'static,
         B::Error: Into<Box<dyn StdError + Send + Sync>>,
-        E: H2Exec<S::Future, B>,
+        E: ConnStreamExec<S::Future, B>,
     {
         /// Start a graceful shutdown process for this connection.
         ///
@@ -1054,7 +1129,7 @@ mod upgrades {
         I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
         B: HttpBody + 'static,
         B::Error: Into<Box<dyn StdError + Send + Sync>>,
-        E: super::H2Exec<S::Future, B>,
+        E: ConnStreamExec<S::Future, B>,
     {
         type Output = crate::Result<()>;
 
@@ -1064,7 +1139,7 @@ mod upgrades {
                     Ok(proto::Dispatched::Shutdown) => return Poll::Ready(Ok(())),
                     Ok(proto::Dispatched::Upgrade(pending)) => {
                         let h1 = match mem::replace(&mut self.inner.conn, None) {
-                            Some(ProtoServer::H1(h1)) => h1,
+                            Some(ProtoServer::H1(h1, _)) => h1,
                             _ => unreachable!("Upgrade expects h1"),
                         };
 
@@ -1072,13 +1147,18 @@ mod upgrades {
                         pending.fulfill(Upgraded::new(io, buf));
                         return Poll::Ready(Ok(()));
                     }
-                    Err(e) => match *e.kind() {
-                        Kind::Parse(Parse::VersionH2) if self.inner.fallback.to_h2() => {
-                            self.inner.upgrade_h2();
-                            continue;
+                    Err(e) => {
+                        #[cfg(feature = "http2")]
+                        match *e.kind() {
+                            Kind::Parse(Parse::VersionH2) if self.inner.fallback.to_h2() => {
+                                self.inner.upgrade_h2();
+                                continue;
+                            }
+                            _ => (),
                         }
-                        _ => return Poll::Ready(Err(e)),
-                    },
+
+                        return Poll::Ready(Err(e));
+                    }
                 }
             }
         }

--- a/src/server/shutdown.rs
+++ b/src/server/shutdown.rs
@@ -7,7 +7,7 @@ use super::conn::{SpawnAll, UpgradeableConnection, Watcher};
 use super::Accept;
 use crate::body::{Body, HttpBody};
 use crate::common::drain::{self, Draining, Signal, Watch, Watching};
-use crate::common::exec::{H2Exec, NewSvcExec};
+use crate::common::exec::{ConnStreamExec, NewSvcExec};
 use crate::common::{task, Future, Pin, Poll, Unpin};
 use crate::service::{HttpService, MakeServiceRef};
 
@@ -53,7 +53,7 @@ where
     B: HttpBody + Send + Sync + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
     F: Future<Output = ()>,
-    E: H2Exec<<S::Service as HttpService<Body>>::Future, B>,
+    E: ConnStreamExec<<S::Service as HttpService<Body>>::Future, B>,
     E: NewSvcExec<IO, S::Future, S::Service, E, GracefulWatcher>,
 {
     type Output = crate::Result<()>;
@@ -96,7 +96,7 @@ impl<I, S, E> Watcher<I, S, E> for GracefulWatcher
 where
     I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     S: HttpService<Body>,
-    E: H2Exec<S::Future, S::ResBody>,
+    E: ConnStreamExec<S::Future, S::ResBody>,
     S::ResBody: Send + Sync + 'static,
     <S::ResBody as HttpBody>::Error: Into<Box<dyn StdError + Send + Sync>>,
 {
@@ -115,7 +115,7 @@ where
     I: AsyncRead + AsyncWrite + Unpin,
     S::ResBody: HttpBody + Send + 'static,
     <S::ResBody as HttpBody>::Error: Into<Box<dyn StdError + Send + Sync>>,
-    E: H2Exec<S::Future, S::ResBody>,
+    E: ConnStreamExec<S::Future, S::ResBody>,
 {
     conn.graceful_shutdown()
 }


### PR DESCRIPTION
cc #2251

BREAKING CHANGE: This puts all HTTP/2 methods and support behind an
  `http2` cargo feature, which will not be enabled by default. To use
  HTTP/2, add `features = ["http2"]` to the hyper dependency in your
  `Cargo.toml`.

