### PR TITLE
feat(http1): Make HTTP/1 support an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
-
 [package]
 name = "hyper"
 version = "0.14.0-dev" # don't forget to update html_root_url
@@ -76,11 +75,11 @@ default = [
     "runtime",
     "stream",
 
-    #"http1",
+    "http1",
     "http2",
 ]
 full = [
-    #"http1",
+    "http1",
     "http2",
     "stream",
     "runtime",
@@ -97,7 +96,7 @@ tcp = [
 ]
 
 # HTTP versions
-#http1 = []
+http1 = []
 http2 = ["h2"]
 
 # `impl Stream` for things

--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -1,0 +1,100 @@
+use std::fmt;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DecodedLength(u64);
+
+#[cfg(any(feature = "http1", feature = "http2", test))]
+const MAX_LEN: u64 = std::u64::MAX - 2;
+
+impl DecodedLength {
+    pub(crate) const CLOSE_DELIMITED: DecodedLength = DecodedLength(::std::u64::MAX);
+    pub(crate) const CHUNKED: DecodedLength = DecodedLength(::std::u64::MAX - 1);
+    pub(crate) const ZERO: DecodedLength = DecodedLength(0);
+
+    #[cfg(test)]
+    pub(crate) fn new(len: u64) -> Self {
+        debug_assert!(len <= MAX_LEN);
+        DecodedLength(len)
+    }
+
+    /// Takes the length as a content-length without other checks.
+    ///
+    /// Should only be called if previously confirmed this isn't
+    /// CLOSE_DELIMITED or CHUNKED.
+    #[inline]
+    #[cfg(feature = "http1")]
+    pub(crate) fn danger_len(self) -> u64 {
+        debug_assert!(self.0 < Self::CHUNKED.0);
+        self.0
+    }
+
+    /// Converts to an Option<u64> representing a Known or Unknown length.
+    pub(crate) fn into_opt(self) -> Option<u64> {
+        match self {
+            DecodedLength::CHUNKED | DecodedLength::CLOSE_DELIMITED => None,
+            DecodedLength(known) => Some(known),
+        }
+    }
+
+    /// Checks the `u64` is within the maximum allowed for content-length.
+    #[cfg(any(feature = "http1", feature = "http2"))]
+    pub(crate) fn checked_new(len: u64) -> Result<Self, crate::error::Parse> {
+        if len <= MAX_LEN {
+            Ok(DecodedLength(len))
+        } else {
+            warn!("content-length bigger than maximum: {} > {}", len, MAX_LEN);
+            Err(crate::error::Parse::TooLarge)
+        }
+    }
+
+    pub(crate) fn sub_if(&mut self, amt: u64) {
+        match *self {
+            DecodedLength::CHUNKED | DecodedLength::CLOSE_DELIMITED => (),
+            DecodedLength(ref mut known) => {
+                *known -= amt;
+            }
+        }
+    }
+}
+
+impl fmt::Debug for DecodedLength {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            DecodedLength::CLOSE_DELIMITED => f.write_str("CLOSE_DELIMITED"),
+            DecodedLength::CHUNKED => f.write_str("CHUNKED"),
+            DecodedLength(n) => f.debug_tuple("DecodedLength").field(&n).finish(),
+        }
+    }
+}
+
+impl fmt::Display for DecodedLength {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            DecodedLength::CLOSE_DELIMITED => f.write_str("close-delimited"),
+            DecodedLength::CHUNKED => f.write_str("chunked encoding"),
+            DecodedLength::ZERO => f.write_str("empty"),
+            DecodedLength(n) => write!(f, "content-length ({} bytes)", n),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sub_if_known() {
+        let mut len = DecodedLength::new(30);
+        len.sub_if(20);
+
+        assert_eq!(len.0, 10);
+    }
+
+    #[test]
+    fn sub_if_chunked() {
+        let mut len = DecodedLength::CHUNKED;
+        len.sub_if(20);
+
+        assert_eq!(len, DecodedLength::CHUNKED);
+    }
+}

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -20,15 +20,18 @@ pub use http_body::Body as HttpBody;
 
 pub use self::aggregate::aggregate;
 pub use self::body::{Body, Sender};
+pub(crate) use self::length::DecodedLength;
 pub use self::to_bytes::to_bytes;
 
 mod aggregate;
 mod body;
+mod length;
 mod to_bytes;
 
 /// An optimization to try to take a full body if immediately available.
 ///
 /// This is currently limited to *only* `hyper::Body`s.
+#[cfg(feature = "http1")]
 pub(crate) fn take_full_data<T: HttpBody + 'static>(body: &mut T) -> Option<T::Data> {
     use std::any::{Any, TypeId};
 

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,9 +1,37 @@
-macro_rules! cfg_http2 {
+macro_rules! cfg_any_http {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "http2")]
-            //#[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+            #[cfg(any(
+                feature = "http1",
+                feature = "http2",
+            ))]
+            #[cfg_attr(docsrs, doc(cfg(any(
+                feature = "http1",
+                feature = "http2",
+            ))))]
             $item
         )*
+    }
+}
+
+cfg_any_http! {
+    macro_rules! cfg_http1 {
+        ($($item:item)*) => {
+            $(
+                #[cfg(feature = "http1")]
+                #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
+                $item
+            )*
+        }
+    }
+
+    macro_rules! cfg_http2 {
+        ($($item:item)*) => {
+            $(
+                #[cfg(feature = "http2")]
+                #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+                $item
+            )*
+        }
     }
 }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -162,11 +162,13 @@ impl<T, U> Receiver<T, U> {
         }
     }
 
+    #[cfg(feature = "http1")]
     pub(crate) fn close(&mut self) {
         self.taker.cancel();
         self.inner.close();
     }
 
+    #[cfg(feature = "http1")]
     pub(crate) fn try_recv(&mut self) -> Option<(T, Callback<T, U>)> {
         match self.inner.try_recv() {
             Ok(mut env) => env.0.take(),

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -62,7 +62,8 @@ use http::{Method, Request, Response, Uri, Version};
 use self::connect::{sealed::Connect, Alpn, Connected, Connection};
 use self::pool::{Key as PoolKey, Pool, Poolable, Pooled, Reservation};
 use crate::body::{Body, HttpBody};
-use crate::common::{lazy as hyper_lazy, task, BoxSendFuture, Executor, Future, Lazy, Pin, Poll};
+use crate::common::{lazy as hyper_lazy, task, BoxSendFuture, Future, Lazy, Pin, Poll};
+use crate::rt::Executor;
 
 #[cfg(feature = "tcp")]
 pub use self::connect::HttpConnector;
@@ -1022,6 +1023,8 @@ impl Builder {
     /// # Panics
     ///
     /// The minimum value allowed is 8192. This method panics if the passed `max` is less than the minimum.
+    #[cfg(feature = "http1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
     pub fn http1_max_buf_size(&mut self, max: usize) -> &mut Self {
         self.conn_builder.h1_max_buf_size(max);
         self

--- a/src/common/buf.rs
+++ b/src/common/buf.rs
@@ -21,6 +21,7 @@ impl<T: Buf> BufList<T> {
     }
 
     #[inline]
+    #[cfg(feature = "http1")]
     pub(crate) fn bufs_cnt(&self) -> usize {
         self.bufs.len()
     }

--- a/src/common/date.rs
+++ b/src/common/date.rs
@@ -10,12 +10,14 @@ use httpdate::HttpDate;
 // "Sun, 06 Nov 1994 08:49:37 GMT".len()
 pub const DATE_VALUE_LENGTH: usize = 29;
 
+#[cfg(feature = "http1")]
 pub fn extend(dst: &mut Vec<u8>) {
     CACHED.with(|cache| {
         dst.extend_from_slice(cache.borrow().buffer());
     })
 }
 
+#[cfg(feature = "http1")]
 pub fn update() {
     CACHED.with(|cache| {
         cache.borrow_mut().check();

--- a/src/common/exec.rs
+++ b/src/common/exec.rs
@@ -6,14 +6,9 @@ use std::sync::Arc;
 use crate::body::{Body, HttpBody};
 #[cfg(feature = "http2")]
 use crate::proto::h2::server::H2Stream;
+use crate::rt::Executor;
 use crate::server::conn::spawn_all::{NewSvcTask, Watcher};
 use crate::service::HttpService;
-
-/// An executor of futures.
-pub trait Executor<Fut> {
-    /// Place the future into the executor to be run.
-    fn execute(&self, fut: Fut);
-}
 
 pub trait ConnStreamExec<F, B: HttpBody>: Clone {
     fn execute_h2stream(&mut self, fut: H2Stream<F, B>);

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -29,7 +29,7 @@ impl<T> Rewind<T> {
         }
     }
 
-    #[cfg(any(feature = "http2", test))]
+    #[cfg(any(all(feature = "http1", feature = "http2"), test))]
     pub(crate) fn rewind(&mut self, bs: Bytes) {
         debug_assert!(self.pre.is_none());
         self.pre = Some(bs);

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -8,9 +8,14 @@ macro_rules! ready {
 }
 
 pub(crate) mod buf;
+#[cfg(any(feature = "http1", feature = "http2"))]
+pub(crate) mod date;
+#[cfg(any(feature = "http1", feature = "http2"))]
 pub(crate) mod drain;
+#[cfg(any(feature = "http1", feature = "http2"))]
 pub(crate) mod exec;
 pub(crate) mod io;
+#[cfg(any(feature = "http1", feature = "http2"))]
 mod lazy;
 mod never;
 #[cfg(feature = "stream")]
@@ -18,11 +23,14 @@ pub(crate) mod sync_wrapper;
 pub(crate) mod task;
 pub(crate) mod watch;
 
-pub use self::exec::Executor;
+#[cfg(any(feature = "http1", feature = "http2"))]
 pub(crate) use self::exec::{BoxSendFuture, Exec};
+#[cfg(any(feature = "http1", feature = "http2"))]
 pub(crate) use self::lazy::{lazy, Started as Lazy};
 pub use self::never::Never;
 pub(crate) use self::task::Poll;
 
 // group up types normally needed for `Future`
-pub(crate) use std::{future::Future, marker::Unpin, pin::Pin};
+#[cfg(any(feature = "http1", feature = "http2"))]
+pub(crate) use std::marker::Unpin;
+pub(crate) use std::{future::Future, pin::Pin};

--- a/src/common/task.rs
+++ b/src/common/task.rs
@@ -1,9 +1,11 @@
+#[cfg(feature = "http1")]
 use super::Never;
 pub(crate) use std::task::{Context, Poll};
 
 /// A function to help "yield" a future, such that it is re-scheduled immediately.
 ///
 /// Useful for spin counts, so a future doesn't hog too much time.
+#[cfg(feature = "http1")]
 pub(crate) fn yield_now(cx: &mut Context<'_>) -> Poll<Never> {
     cx.waker().wake_by_ref();
     Poll::Pending

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,18 +1,22 @@
+#[cfg(feature = "http1")]
 use bytes::BytesMut;
-use http::header::{HeaderValue, OccupiedEntry, ValueIter};
-use http::header::{CONTENT_LENGTH, TRANSFER_ENCODING};
+use http::header::CONTENT_LENGTH;
+use http::header::{HeaderValue, ValueIter};
 #[cfg(feature = "http2")]
 use http::method::Method;
 use http::HeaderMap;
 
+#[cfg(feature = "http1")]
 pub fn connection_keep_alive(value: &HeaderValue) -> bool {
     connection_has(value, "keep-alive")
 }
 
+#[cfg(feature = "http1")]
 pub fn connection_close(value: &HeaderValue) -> bool {
     connection_has(value, "close")
 }
 
+#[cfg(feature = "http1")]
 fn connection_has(value: &HeaderValue, needle: &str) -> bool {
     if let Ok(s) = value.to_str() {
         for val in s.split(',') {
@@ -24,6 +28,7 @@ fn connection_has(value: &HeaderValue, needle: &str) -> bool {
     false
 }
 
+#[cfg(feature = "http1")]
 pub fn content_length_parse(value: &HeaderValue) -> Option<u64> {
     value.to_str().ok().and_then(|s| s.parse().ok())
 }
@@ -74,10 +79,12 @@ pub fn set_content_length_if_missing(headers: &mut HeaderMap, len: u64) {
         .or_insert_with(|| HeaderValue::from(len));
 }
 
+#[cfg(feature = "http1")]
 pub fn transfer_encoding_is_chunked(headers: &HeaderMap) -> bool {
-    is_chunked(headers.get_all(TRANSFER_ENCODING).into_iter())
+    is_chunked(headers.get_all(http::header::TRANSFER_ENCODING).into_iter())
 }
 
+#[cfg(feature = "http1")]
 pub fn is_chunked(mut encodings: ValueIter<'_, HeaderValue>) -> bool {
     // chunked must always be the last encoding, according to spec
     if let Some(line) = encodings.next_back() {
@@ -87,6 +94,7 @@ pub fn is_chunked(mut encodings: ValueIter<'_, HeaderValue>) -> bool {
     false
 }
 
+#[cfg(feature = "http1")]
 pub fn is_chunked_(value: &HeaderValue) -> bool {
     // chunked must always be the last encoding, according to spec
     if let Ok(s) = value.to_str() {
@@ -98,7 +106,8 @@ pub fn is_chunked_(value: &HeaderValue) -> bool {
     false
 }
 
-pub fn add_chunked(mut entry: OccupiedEntry<'_, HeaderValue>) {
+#[cfg(feature = "http1")]
+pub fn add_chunked(mut entry: http::header::OccupiedEntry<'_, HeaderValue>) {
     const CHUNKED: &str = "chunked";
 
     if let Some(line) = entry.iter_mut().next_back() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 
 #[doc(hidden)]
 pub use http;
+#[cfg(any(feature = "http1", feature = "http2"))]
 #[macro_use]
 extern crate tracing;
 
@@ -51,23 +52,28 @@ extern crate test;
 pub use http::{header, HeaderMap, Method, Request, Response, StatusCode, Uri, Version};
 
 pub use crate::body::Body;
-pub use crate::client::Client;
 pub use crate::error::{Error, Result};
-pub use crate::server::Server;
 
 #[macro_use]
 mod cfg;
 #[macro_use]
 mod common;
 pub mod body;
-pub mod client;
 #[doc(hidden)] // Mistakenly public...
 pub mod error;
-mod headers;
 #[cfg(test)]
 mod mock;
-mod proto;
+#[cfg(any(feature = "http1", feature = "http2",))]
 pub mod rt;
-pub mod server;
 pub mod service;
 pub mod upgrade;
+
+cfg_any_http! {
+    mod headers;
+    mod proto;
+    pub mod client;
+    pub mod server;
+
+    pub use crate::client::Client;
+    pub use crate::server::Server;
+}

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -9,10 +9,10 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::io::Buffered;
 use super::{Decoder, Encode, EncodedBuf, Encoder, Http1Transaction, ParseContext, Wants};
+use crate::body::DecodedLength;
 use crate::common::{task, Pin, Poll, Unpin};
 use crate::headers::connection_keep_alive;
-use crate::proto::{BodyLength, DecodedLength, MessageHead};
-use crate::Result;
+use crate::proto::{BodyLength, MessageHead};
 
 const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
@@ -589,7 +589,7 @@ where
         self.state.writing = state;
     }
 
-    pub fn end_body(&mut self) -> Result<()> {
+    pub fn end_body(&mut self) -> crate::Result<()> {
         debug_assert!(self.can_write_body());
 
         let mut res = Ok(());

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -5,10 +5,10 @@ use http::{Request, Response, StatusCode};
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::{Http1Transaction, Wants};
-use crate::body::{Body, HttpBody};
+use crate::body::{Body, DecodedLength, HttpBody};
 use crate::common::{task, Future, Never, Pin, Poll, Unpin};
 use crate::proto::{
-    BodyLength, Conn, DecodedLength, Dispatched, MessageHead, RequestHead, RequestLine,
+    BodyLength, Conn, Dispatched, MessageHead, RequestHead, RequestLine,
     ResponseHead,
 };
 use crate::service::HttpService;

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -2,13 +2,14 @@ use std::cell::Cell;
 use std::cmp;
 use std::fmt;
 use std::io::{self, IoSlice};
+use std::marker::Unpin;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use super::{Http1Transaction, ParseContext, ParsedMessage};
 use crate::common::buf::BufList;
-use crate::common::{task, Pin, Poll, Unpin};
+use crate::common::{task, Pin, Poll};
 
 /// The initial buffer size allocated before trying to read from IO.
 pub(crate) const INIT_BUFFER_SIZE: usize = 8192;

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -1,7 +1,8 @@
 use bytes::BytesMut;
 use http::{HeaderMap, Method};
 
-use crate::proto::{BodyLength, DecodedLength, MessageHead};
+use crate::body::DecodedLength;
+use crate::proto::{BodyLength, MessageHead};
 
 pub(crate) use self::conn::Conn;
 pub use self::decode::Decoder;
@@ -11,7 +12,6 @@ pub use self::io::Cursor; //TODO: move out of h1::io
 pub use self::io::MINIMUM_MAX_BUFFER_SIZE;
 
 mod conn;
-pub(super) mod date;
 mod decode;
 pub(crate) mod dispatch;
 mod encode;

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -9,12 +9,14 @@ use bytes::BytesMut;
 use http::header::{self, Entry, HeaderName, HeaderValue};
 use http::{HeaderMap, Method, StatusCode, Version};
 
+use crate::body::DecodedLength;
+use crate::common::date;
 use crate::error::Parse;
 use crate::headers;
 use crate::proto::h1::{
-    date, Encode, Encoder, Http1Transaction, ParseContext, ParseResult, ParsedMessage,
+    Encode, Encoder, Http1Transaction, ParseContext, ParseResult, ParsedMessage,
 };
-use crate::proto::{BodyLength, DecodedLength, MessageHead, RequestHead, RequestLine};
+use crate::proto::{BodyLength, MessageHead, RequestHead, RequestLine};
 
 const MAX_HEADERS: usize = 100;
 const AVERAGE_HEADER_SIZE: usize = 30; // totally scientific

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -9,8 +9,7 @@ use pin_project::pin_project;
 use std::error::Error as StdError;
 use std::io::IoSlice;
 
-use super::DecodedLength;
-use crate::body::HttpBody;
+use crate::body::{DecodedLength, HttpBody};
 use crate::common::{task, Future, Pin, Poll};
 use crate::headers::content_length_parse_all;
 

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use super::{decode_content_length, ping, PipeToSendStream, SendBuf};
 use crate::body::HttpBody;
 use crate::common::exec::ConnStreamExec;
-use crate::common::{task, Future, Pin, Poll};
+use crate::common::{date, task, Future, Pin, Poll};
 use crate::headers;
 use crate::proto::Dispatched;
 use crate::service::HttpService;
@@ -400,7 +400,7 @@ where
                     // set Date header if it isn't already set...
                     res.headers_mut()
                         .entry(::http::header::DATE)
-                        .or_insert_with(crate::proto::h1::date::update_and_header_value);
+                        .or_insert_with(date::update_and_header_value);
 
                     // automatically set Content-Length from body...
                     if let Some(len) = body.size_hint().exact() {

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,10 +1,11 @@
 //! Pieces pertaining to the HTTP message protocol.
-use http::{HeaderMap, Method, StatusCode, Uri, Version};
 
-pub(crate) use self::body_length::DecodedLength;
-pub(crate) use self::h1::{dispatch, Conn, ServerTransaction};
+cfg_http1! {
+    pub(crate) mod h1;
 
-pub(crate) mod h1;
+    pub(crate) use self::h1::{dispatch, Conn, ServerTransaction};
+}
+
 cfg_http2! {
     pub(crate) mod h2;
 }
@@ -13,23 +14,27 @@ cfg_http2! {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct MessageHead<S> {
     /// HTTP version of the message.
-    pub version: Version,
+    pub version: http::Version,
     /// Subject (request line or status line) of Incoming message.
     pub subject: S,
     /// Headers of the Incoming message.
-    pub headers: HeaderMap,
+    pub headers: http::HeaderMap,
 }
 
 /// An incoming request message.
+#[cfg(feature = "http1")]
 pub type RequestHead = MessageHead<RequestLine>;
 
 #[derive(Debug, Default, PartialEq)]
-pub struct RequestLine(pub Method, pub Uri);
+#[cfg(feature = "http1")]
+pub struct RequestLine(pub http::Method, pub http::Uri);
 
 /// An incoming response message.
-pub type ResponseHead = MessageHead<StatusCode>;
+#[cfg(feature = "http1")]
+pub type ResponseHead = MessageHead<http::StatusCode>;
 
 #[derive(Debug)]
+#[cfg(feature = "http1")]
 pub enum BodyLength {
     /// Content-Length
     Known(u64),
@@ -42,106 +47,6 @@ pub(crate) enum Dispatched {
     /// Dispatcher completely shutdown connection.
     Shutdown,
     /// Dispatcher has pending upgrade, and so did not shutdown.
+    #[cfg(feature = "http1")]
     Upgrade(crate::upgrade::Pending),
-}
-
-/// A separate module to encapsulate the invariants of the DecodedLength type.
-mod body_length {
-    use std::fmt;
-
-    #[derive(Clone, Copy, PartialEq, Eq)]
-    pub(crate) struct DecodedLength(u64);
-
-    const MAX_LEN: u64 = std::u64::MAX - 2;
-
-    impl DecodedLength {
-        pub(crate) const CLOSE_DELIMITED: DecodedLength = DecodedLength(::std::u64::MAX);
-        pub(crate) const CHUNKED: DecodedLength = DecodedLength(::std::u64::MAX - 1);
-        pub(crate) const ZERO: DecodedLength = DecodedLength(0);
-
-        #[cfg(test)]
-        pub(crate) fn new(len: u64) -> Self {
-            debug_assert!(len <= MAX_LEN);
-            DecodedLength(len)
-        }
-
-        /// Takes the length as a content-length without other checks.
-        ///
-        /// Should only be called if previously confirmed this isn't
-        /// CLOSE_DELIMITED or CHUNKED.
-        #[inline]
-        pub(crate) fn danger_len(self) -> u64 {
-            debug_assert!(self.0 < Self::CHUNKED.0);
-            self.0
-        }
-
-        /// Converts to an Option<u64> representing a Known or Unknown length.
-        pub(crate) fn into_opt(self) -> Option<u64> {
-            match self {
-                DecodedLength::CHUNKED | DecodedLength::CLOSE_DELIMITED => None,
-                DecodedLength(known) => Some(known),
-            }
-        }
-
-        /// Checks the `u64` is within the maximum allowed for content-length.
-        pub(crate) fn checked_new(len: u64) -> Result<Self, crate::error::Parse> {
-            if len <= MAX_LEN {
-                Ok(DecodedLength(len))
-            } else {
-                warn!("content-length bigger than maximum: {} > {}", len, MAX_LEN);
-                Err(crate::error::Parse::TooLarge)
-            }
-        }
-
-        pub(crate) fn sub_if(&mut self, amt: u64) {
-            match *self {
-                DecodedLength::CHUNKED | DecodedLength::CLOSE_DELIMITED => (),
-                DecodedLength(ref mut known) => {
-                    *known -= amt;
-                }
-            }
-        }
-    }
-
-    impl fmt::Debug for DecodedLength {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            match *self {
-                DecodedLength::CLOSE_DELIMITED => f.write_str("CLOSE_DELIMITED"),
-                DecodedLength::CHUNKED => f.write_str("CHUNKED"),
-                DecodedLength(n) => f.debug_tuple("DecodedLength").field(&n).finish(),
-            }
-        }
-    }
-
-    impl fmt::Display for DecodedLength {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            match *self {
-                DecodedLength::CLOSE_DELIMITED => f.write_str("close-delimited"),
-                DecodedLength::CHUNKED => f.write_str("chunked encoding"),
-                DecodedLength::ZERO => f.write_str("empty"),
-                DecodedLength(n) => write!(f, "content-length ({} bytes)", n),
-            }
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn sub_if_known() {
-            let mut len = DecodedLength::new(30);
-            len.sub_if(20);
-
-            assert_eq!(len.0, 10);
-        }
-
-        #[test]
-        fn sub_if_chunked() {
-            let mut len = DecodedLength::CHUNKED;
-            len.sub_if(20);
-
-            assert_eq!(len, DecodedLength::CHUNKED);
-        }
-    }
 }

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -5,4 +5,8 @@
 //! If the `runtime` feature is disabled, the types in this module can be used
 //! to plug in other runtimes.
 
-pub use crate::common::Executor;
+/// An executor of futures.
+pub trait Executor<Fut> {
+    /// Place the future into the executor to be run.
+    fn execute(&self, fut: Fut);
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -241,6 +241,8 @@ impl<I, E> Builder<I, E> {
     /// Sets whether to use keep-alive for HTTP/1 connections.
     ///
     /// Default is `true`.
+    #[cfg(feature = "http1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
     pub fn http1_keepalive(mut self, val: bool) -> Self {
         self.protocol.http1_keep_alive(val);
         self
@@ -254,6 +256,8 @@ impl<I, E> Builder<I, E> {
     /// detects an EOF in the middle of a request.
     ///
     /// Default is `false`.
+    #[cfg(feature = "http1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
     pub fn http1_half_close(mut self, val: bool) -> Self {
         self.protocol.http1_half_close(val);
         self
@@ -262,6 +266,8 @@ impl<I, E> Builder<I, E> {
     /// Set the maximum buffer size.
     ///
     /// Default is ~ 400kb.
+    #[cfg(feature = "http1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
     pub fn http1_max_buf_size(mut self, val: usize) -> Self {
         self.protocol.max_buf_size(val);
         self
@@ -272,6 +278,7 @@ impl<I, E> Builder<I, E> {
     // This isn't really desirable in most cases, only really being useful in
     // silly pipeline benchmarks.
     #[doc(hidden)]
+    #[cfg(feature = "http1")]
     pub fn http1_pipeline_flush(mut self, val: bool) -> Self {
         self.protocol.pipeline_flush(val);
         self
@@ -290,7 +297,9 @@ impl<I, E> Builder<I, E> {
     /// which may eliminate unnecessary cloning on some TLS backends
     ///
     /// Default is `auto`. In this mode hyper will try to guess which
-    /// mode to use
+    /// mode to use.
+    #[cfg(feature = "http1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
     pub fn http1_writev(mut self, val: bool) -> Self {
         self.protocol.http1_writev(val);
         self
@@ -299,6 +308,8 @@ impl<I, E> Builder<I, E> {
     /// Sets whether HTTP/1 is required.
     ///
     /// Default is `false`.
+    #[cfg(feature = "http1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
     pub fn http1_only(mut self, val: bool) -> Self {
         self.protocol.http1_only(val);
         self

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -39,11 +39,14 @@ pub use tower_service::Service;
 
 mod http;
 mod make;
+#[cfg(any(feature = "http1", feature = "http2"))]
 mod oneshot;
 mod util;
 
 pub(crate) use self::http::HttpService;
+#[cfg(any(feature = "http1", feature = "http2"))]
 pub(crate) use self::make::{MakeConnection, MakeServiceRef};
+#[cfg(any(feature = "http1", feature = "http2"))]
 pub(crate) use self::oneshot::{oneshot, Oneshot};
 
 pub use self::make::make_service_fn;

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -57,6 +57,7 @@ pub struct Parts<T> {
     _inner: (),
 }
 
+#[cfg(feature = "http1")]
 pub(crate) struct Pending {
     tx: oneshot::Sender<crate::Result<Upgraded>>,
 }
@@ -68,6 +69,7 @@ pub(crate) struct Pending {
 #[derive(Debug)]
 struct UpgradeExpected(());
 
+#[cfg(feature = "http1")]
 pub(crate) fn pending() -> (Pending, OnUpgrade) {
     let (tx, rx) = oneshot::channel();
     (Pending { tx }, OnUpgrade { rx: Some(rx) })
@@ -76,6 +78,7 @@ pub(crate) fn pending() -> (Pending, OnUpgrade) {
 // ===== impl Upgraded =====
 
 impl Upgraded {
+    #[cfg(any(feature = "http1", test))]
     pub(crate) fn new<T>(io: T, read_buf: Bytes) -> Self
     where
         T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
@@ -145,6 +148,7 @@ impl OnUpgrade {
         OnUpgrade { rx: None }
     }
 
+    #[cfg(feature = "http1")]
     pub(crate) fn is_none(&self) -> bool {
         self.rx.is_none()
     }
@@ -175,6 +179,7 @@ impl fmt::Debug for OnUpgrade {
 
 // ===== impl Pending =====
 
+#[cfg(feature = "http1")]
 impl Pending {
     pub(crate) fn fulfill(self, upgraded: Upgraded) {
         trace!("pending upgrade fulfill");


### PR DESCRIPTION
cc #2251

BREAKING CHANGE: This puts all HTTP/1 methods and support behind an
  `http1` cargo feature, which will not be enabled by default. To use
  HTTP/1, add `features = ["http1"]` to the hyper dependency in your
  `Cargo.toml`.

