### PR TITLE
feat(client): Make `client` an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,11 +74,12 @@ pnet = "0.25.0"
 default = [
     "runtime",
     "stream",
-
+    "client",
     "http1",
     "http2",
 ]
 full = [
+    "client",
     "http1",
     "http2",
     "stream",
@@ -98,6 +99,8 @@ tcp = [
 # HTTP versions
 http1 = []
 http2 = ["h2"]
+
+client = []
 
 # `impl Stream` for things
 stream = []

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,37 +1,50 @@
-macro_rules! cfg_any_http {
-    ($($item:item)*) => {
+macro_rules! cfg_feature {
+    (
+        #![$meta:meta]
+        $($item:item)*
+    ) => {
         $(
-            #[cfg(any(
-                feature = "http1",
-                feature = "http2",
-            ))]
-            #[cfg_attr(docsrs, doc(cfg(any(
-                feature = "http1",
-                feature = "http2",
-            ))))]
+            #[cfg($meta)]
+            #[cfg_attr(docsrs, doc(cfg($meta)))]
             $item
         )*
+    }
+}
+
+macro_rules! cfg_any_http {
+    ($($item:item)*) => {
+        cfg_feature! {
+            #![any(feature = "http1", feature = "http2")]
+            $($item)*
+        }
     }
 }
 
 cfg_any_http! {
     macro_rules! cfg_http1 {
         ($($item:item)*) => {
-            $(
-                #[cfg(feature = "http1")]
-                #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
-                $item
-            )*
+            cfg_feature! {
+                #![feature = "http1"]
+                $($item)*
+            }
         }
     }
 
     macro_rules! cfg_http2 {
         ($($item:item)*) => {
-            $(
-                #[cfg(feature = "http2")]
-                #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-                $item
-            )*
+            cfg_feature! {
+                #![feature = "http2"]
+                $($item)*
+            }
+        }
+    }
+
+    macro_rules! cfg_client {
+        ($($item:item)*) => {
+            cfg_feature! {
+                #![feature = "client"]
+                $($item)*
+            }
         }
     }
 }

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -25,7 +25,7 @@ use tower_service::Service;
 
 use super::dispatch;
 use crate::body::HttpBody;
-use crate::common::{task, BoxSendFuture, Exec, Future, Pin, Poll};
+use crate::common::{task, exec::{BoxSendFuture, Exec}, Future, Pin, Poll};
 use crate::proto;
 use crate::rt::Executor;
 #[cfg(feature = "http1")]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -62,7 +62,7 @@ use http::{Method, Request, Response, Uri, Version};
 use self::connect::{sealed::Connect, Alpn, Connected, Connection};
 use self::pool::{Key as PoolKey, Pool, Poolable, Pooled, Reservation};
 use crate::body::{Body, HttpBody};
-use crate::common::{lazy as hyper_lazy, task, BoxSendFuture, Future, Lazy, Pin, Poll};
+use crate::common::{lazy as hyper_lazy, task, exec::BoxSendFuture, Future, Lazy, Pin, Poll};
 use crate::rt::Executor;
 
 #[cfg(feature = "tcp")]

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -11,7 +11,7 @@ use futures_channel::oneshot;
 use tokio::time::{Duration, Instant, Interval};
 
 use super::Ver;
-use crate::common::{task, Exec, Future, Pin, Poll, Unpin};
+use crate::common::{task, exec::Exec, Future, Pin, Poll, Unpin};
 
 // FIXME: allow() required due to `impl Trait` leaking types to this lint
 #[allow(missing_debug_implementations)]

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -777,7 +777,7 @@ mod tests {
     use std::time::Duration;
 
     use super::{Connecting, Key, Pool, Poolable, Reservation, WeakOpt};
-    use crate::common::{task, Exec, Future, Pin};
+    use crate::common::{task, exec::Exec, Future, Pin};
 
     /// Test unique reservations.
     #[derive(Debug, PartialEq, Eq)]

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod drain;
 pub(crate) mod exec;
 pub(crate) mod io;
 #[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(feature = "client")]
 mod lazy;
 mod never;
 #[cfg(feature = "stream")]
@@ -23,9 +24,10 @@ pub(crate) mod sync_wrapper;
 pub(crate) mod task;
 pub(crate) mod watch;
 
+//#[cfg(any(feature = "http1", feature = "http2"))]
+//pub(crate) use self::exec::{BoxSendFuture, Exec};
 #[cfg(any(feature = "http1", feature = "http2"))]
-pub(crate) use self::exec::{BoxSendFuture, Exec};
-#[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(feature = "client")]
 pub(crate) use self::lazy::{lazy, Started as Lazy};
 pub use self::never::Never;
 pub(crate) use self::task::Poll;

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,15 +88,18 @@ pub(crate) enum User {
     UnexpectedHeader,
     /// User tried to create a Request with bad version.
     #[cfg(any(feature = "http1", feature = "http2"))]
+    #[cfg(feature = "client")]
     UnsupportedVersion,
     /// User tried to create a CONNECT Request with the Client.
     #[cfg(any(feature = "http1", feature = "http2"))]
+    #[cfg(feature = "client")]
     UnsupportedRequestMethod,
     /// User tried to respond with a 1xx (not 101) response code.
     #[cfg(feature = "http1")]
     UnsupportedStatusCode,
     /// User tried to send a Request with Client with non-absolute URI.
     #[cfg(any(feature = "http1", feature = "http2"))]
+    #[cfg(feature = "client")]
     AbsoluteUriRequired,
 
     /// User tried polling for an upgrade that doesn't exist.
@@ -241,6 +244,7 @@ impl Error {
     }
 
     #[cfg(any(feature = "http1", feature = "http2"))]
+    #[cfg(feature = "client")]
     pub(crate) fn new_connect<E: Into<Cause>>(cause: E) -> Error {
         Error::new(Kind::Connect).with(cause)
     }
@@ -273,11 +277,13 @@ impl Error {
     }
 
     #[cfg(any(feature = "http1", feature = "http2"))]
+    #[cfg(feature = "client")]
     pub(crate) fn new_user_unsupported_version() -> Error {
         Error::new_user(User::UnsupportedVersion)
     }
 
     #[cfg(any(feature = "http1", feature = "http2"))]
+    #[cfg(feature = "client")]
     pub(crate) fn new_user_unsupported_request_method() -> Error {
         Error::new_user(User::UnsupportedRequestMethod)
     }
@@ -288,6 +294,7 @@ impl Error {
     }
 
     #[cfg(any(feature = "http1", feature = "http2"))]
+    #[cfg(feature = "client")]
     pub(crate) fn new_user_absolute_uri_required() -> Error {
         Error::new_user(User::AbsoluteUriRequired)
     }
@@ -371,14 +378,17 @@ impl Error {
             #[cfg(feature = "http1")]
             Kind::User(User::UnexpectedHeader) => "user sent unexpected header",
             #[cfg(any(feature = "http1", feature = "http2"))]
+            #[cfg(feature = "client")]
             Kind::User(User::UnsupportedVersion) => "request has unsupported HTTP version",
             #[cfg(any(feature = "http1", feature = "http2"))]
+            #[cfg(feature = "client")]
             Kind::User(User::UnsupportedRequestMethod) => "request has unsupported HTTP method",
             #[cfg(feature = "http1")]
             Kind::User(User::UnsupportedStatusCode) => {
                 "response has 1xx status code, not supported by server"
             }
             #[cfg(any(feature = "http1", feature = "http2"))]
+            #[cfg(feature = "client")]
             Kind::User(User::AbsoluteUriRequired) => "client requires absolute-form URIs",
             Kind::User(User::NoUpgrade) => "no upgrade available",
             #[cfg(feature = "http1")]

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -3,7 +3,8 @@ use bytes::BytesMut;
 use http::header::CONTENT_LENGTH;
 use http::header::{HeaderValue, ValueIter};
 #[cfg(feature = "http2")]
-use http::method::Method;
+#[cfg(feature = "client")]
+use http::Method;
 use http::HeaderMap;
 
 #[cfg(feature = "http1")]
@@ -65,6 +66,7 @@ pub fn content_length_parse_all_values(values: ValueIter<'_, HeaderValue>) -> Op
 }
 
 #[cfg(feature = "http2")]
+#[cfg(feature = "client")]
 pub fn method_has_defined_payload_semantics(method: &Method) -> bool {
     match *method {
         Method::GET | Method::HEAD | Method::DELETE | Method::CONNECT => false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,14 @@ pub mod upgrade;
 cfg_any_http! {
     mod headers;
     mod proto;
-    pub mod client;
     pub mod server;
 
-    pub use crate::client::Client;
     pub use crate::server::Server;
+}
+
+cfg_feature! {
+    #![all(feature = "client", any(feature = "http1", feature = "http2"))]
+
+    pub mod client;
+    pub use crate::client::Client;
 }

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::io::{self};
+use std::io;
 use std::marker::PhantomData;
 
 use bytes::{Buf, Bytes};
@@ -65,6 +65,7 @@ where
         self.io.set_max_buf_size(max);
     }
 
+    #[cfg(feature = "client")]
     pub fn set_read_buf_exact_size(&mut self, sz: usize) {
         self.io.set_read_buf_exact_size(sz);
     }
@@ -77,6 +78,7 @@ where
         self.io.set_write_strategy_queue();
     }
 
+    #[cfg(feature = "client")]
     pub fn set_title_case_headers(&mut self) {
         self.state.title_case_headers = true;
     }

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -584,7 +584,7 @@ cfg_client! {
             match msg {
                 Ok((msg, body)) => {
                     if let Some(cb) = self.callback.take() {
-                        let mut res = Response::new(body);
+                        let mut res = http::Response::new(body);
                         *res.status_mut() = msg.subject;
                         *res.headers_mut() = msg.headers;
                         *res.version_mut() = msg.version;

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -1,15 +1,14 @@
 use std::error::Error as StdError;
 
 use bytes::{Buf, Bytes};
-use http::{Request, Response, StatusCode};
+use http::{Request, StatusCode};
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::{Http1Transaction, Wants};
 use crate::body::{Body, DecodedLength, HttpBody};
-use crate::common::{task, Future, Never, Pin, Poll, Unpin};
+use crate::common::{task, Future, Pin, Poll, Unpin};
 use crate::proto::{
-    BodyLength, Conn, Dispatched, MessageHead, RequestHead, RequestLine,
-    ResponseHead,
+    BodyLength, Conn, Dispatched, MessageHead, RequestHead,
 };
 use crate::service::HttpService;
 
@@ -40,15 +39,17 @@ pub struct Server<S: HttpService<B>, B> {
     pub(crate) service: S,
 }
 
-#[pin_project::pin_project]
-pub struct Client<B> {
-    callback: Option<crate::client::dispatch::Callback<Request<B>, Response<Body>>>,
-    #[pin]
-    rx: ClientRx<B>,
-    rx_closed: bool,
-}
+cfg_client! {
+    #[pin_project::pin_project]
+    pub struct Client<B> {
+        callback: Option<crate::client::dispatch::Callback<Request<B>, http::Response<Body>>>,
+        #[pin]
+        rx: ClientRx<B>,
+        rx_closed: bool,
+    }
 
-type ClientRx<B> = crate::client::dispatch::Receiver<Request<B>, Response<Body>>;
+    type ClientRx<B> = crate::client::dispatch::Receiver<Request<B>, http::Response<Body>>;
+}
 
 impl<D, Bs, I, T> Dispatcher<D, Bs, I, T>
 where
@@ -523,115 +524,117 @@ where
 
 // ===== impl Client =====
 
-impl<B> Client<B> {
-    pub fn new(rx: ClientRx<B>) -> Client<B> {
-        Client {
-            callback: None,
-            rx,
-            rx_closed: false,
-        }
-    }
-}
-
-impl<B> Dispatch for Client<B>
-where
-    B: HttpBody,
-{
-    type PollItem = RequestHead;
-    type PollBody = B;
-    type PollError = Never;
-    type RecvItem = ResponseHead;
-
-    fn poll_msg(
-        self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
-    ) -> Poll<Option<Result<(Self::PollItem, Self::PollBody), Never>>> {
-        let this = self.project();
-        debug_assert!(!*this.rx_closed);
-        match this.rx.poll_next(cx) {
-            Poll::Ready(Some((req, mut cb))) => {
-                // check that future hasn't been canceled already
-                match cb.poll_canceled(cx) {
-                    Poll::Ready(()) => {
-                        trace!("request canceled");
-                        Poll::Ready(None)
-                    }
-                    Poll::Pending => {
-                        let (parts, body) = req.into_parts();
-                        let head = RequestHead {
-                            version: parts.version,
-                            subject: RequestLine(parts.method, parts.uri),
-                            headers: parts.headers,
-                        };
-                        *this.callback = Some(cb);
-                        Poll::Ready(Some(Ok((head, body))))
-                    }
-                }
+cfg_client! {
+    impl<B> Client<B> {
+        pub fn new(rx: ClientRx<B>) -> Client<B> {
+            Client {
+                callback: None,
+                rx,
+                rx_closed: false,
             }
-            Poll::Ready(None) => {
-                // user has dropped sender handle
-                trace!("client tx closed");
-                *this.rx_closed = true;
-                Poll::Ready(None)
-            }
-            Poll::Pending => Poll::Pending,
         }
     }
 
-    fn recv_msg(&mut self, msg: crate::Result<(Self::RecvItem, Body)>) -> crate::Result<()> {
-        match msg {
-            Ok((msg, body)) => {
-                if let Some(cb) = self.callback.take() {
-                    let mut res = Response::new(body);
-                    *res.status_mut() = msg.subject;
-                    *res.headers_mut() = msg.headers;
-                    *res.version_mut() = msg.version;
-                    cb.send(Ok(res));
-                    Ok(())
-                } else {
-                    // Getting here is likely a bug! An error should have happened
-                    // in Conn::require_empty_read() before ever parsing a
-                    // full message!
-                    Err(crate::Error::new_unexpected_message())
+    impl<B> Dispatch for Client<B>
+    where
+        B: HttpBody,
+    {
+        type PollItem = RequestHead;
+        type PollBody = B;
+        type PollError = crate::common::Never;
+        type RecvItem = crate::proto::ResponseHead;
+
+        fn poll_msg(
+            self: Pin<&mut Self>,
+            cx: &mut task::Context<'_>,
+        ) -> Poll<Option<Result<(Self::PollItem, Self::PollBody), crate::common::Never>>> {
+            let this = self.project();
+            debug_assert!(!*this.rx_closed);
+            match this.rx.poll_next(cx) {
+                Poll::Ready(Some((req, mut cb))) => {
+                    // check that future hasn't been canceled already
+                    match cb.poll_canceled(cx) {
+                        Poll::Ready(()) => {
+                            trace!("request canceled");
+                            Poll::Ready(None)
+                        }
+                        Poll::Pending => {
+                            let (parts, body) = req.into_parts();
+                            let head = RequestHead {
+                                version: parts.version,
+                                subject: crate::proto::RequestLine(parts.method, parts.uri),
+                                headers: parts.headers,
+                            };
+                            *this.callback = Some(cb);
+                            Poll::Ready(Some(Ok((head, body))))
+                        }
+                    }
                 }
+                Poll::Ready(None) => {
+                    // user has dropped sender handle
+                    trace!("client tx closed");
+                    *this.rx_closed = true;
+                    Poll::Ready(None)
+                }
+                Poll::Pending => Poll::Pending,
             }
-            Err(err) => {
-                if let Some(cb) = self.callback.take() {
-                    cb.send(Err((err, None)));
-                    Ok(())
-                } else if !self.rx_closed {
-                    self.rx.close();
-                    if let Some((req, cb)) = self.rx.try_recv() {
-                        trace!("canceling queued request with connection error: {}", err);
-                        // in this case, the message was never even started, so it's safe to tell
-                        // the user that the request was completely canceled
-                        cb.send(Err((crate::Error::new_canceled().with(err), Some(req))));
+        }
+
+        fn recv_msg(&mut self, msg: crate::Result<(Self::RecvItem, Body)>) -> crate::Result<()> {
+            match msg {
+                Ok((msg, body)) => {
+                    if let Some(cb) = self.callback.take() {
+                        let mut res = Response::new(body);
+                        *res.status_mut() = msg.subject;
+                        *res.headers_mut() = msg.headers;
+                        *res.version_mut() = msg.version;
+                        cb.send(Ok(res));
                         Ok(())
+                    } else {
+                        // Getting here is likely a bug! An error should have happened
+                        // in Conn::require_empty_read() before ever parsing a
+                        // full message!
+                        Err(crate::Error::new_unexpected_message())
+                    }
+                }
+                Err(err) => {
+                    if let Some(cb) = self.callback.take() {
+                        cb.send(Err((err, None)));
+                        Ok(())
+                    } else if !self.rx_closed {
+                        self.rx.close();
+                        if let Some((req, cb)) = self.rx.try_recv() {
+                            trace!("canceling queued request with connection error: {}", err);
+                            // in this case, the message was never even started, so it's safe to tell
+                            // the user that the request was completely canceled
+                            cb.send(Err((crate::Error::new_canceled().with(err), Some(req))));
+                            Ok(())
+                        } else {
+                            Err(err)
+                        }
                     } else {
                         Err(err)
                     }
-                } else {
-                    Err(err)
                 }
             }
         }
-    }
 
-    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), ()>> {
-        match self.callback {
-            Some(ref mut cb) => match cb.poll_canceled(cx) {
-                Poll::Ready(()) => {
-                    trace!("callback receiver has dropped");
-                    Poll::Ready(Err(()))
-                }
-                Poll::Pending => Poll::Ready(Ok(())),
-            },
-            None => Poll::Ready(Err(())),
+        fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), ()>> {
+            match self.callback {
+                Some(ref mut cb) => match cb.poll_canceled(cx) {
+                    Poll::Ready(()) => {
+                        trace!("callback receiver has dropped");
+                        Poll::Ready(Err(()))
+                    }
+                    Poll::Pending => Poll::Ready(Ok(())),
+                },
+                None => Poll::Ready(Err(())),
+            }
         }
-    }
 
-    fn should_poll(&self) -> bool {
-        self.callback.is_none()
+        fn should_poll(&self) -> bool {
+            self.callback.is_none()
+        }
     }
 }
 

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -19,7 +19,10 @@ mod io;
 mod role;
 
 pub(crate) type ServerTransaction = role::Server;
-pub(crate) type ClientTransaction = role::Client;
+
+cfg_client! {
+    pub(crate) type ClientTransaction = role::Client;
+}
 
 pub(crate) trait Http1Transaction {
     type Incoming;

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::{decode_content_length, ping, PipeToSendStream, SendBuf};
 use crate::body::HttpBody;
-use crate::common::{task, Exec, Future, Never, Pin, Poll};
+use crate::common::{task, exec::Exec, Future, Never, Pin, Poll};
 use crate::headers;
 use crate::proto::Dispatched;
 use crate::{Body, Request, Response};

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -13,11 +13,14 @@ use crate::body::{DecodedLength, HttpBody};
 use crate::common::{task, Future, Pin, Poll};
 use crate::headers::content_length_parse_all;
 
-pub(crate) mod client;
 pub(crate) mod ping;
 pub(crate) mod server;
 
-pub(crate) use self::client::ClientTask;
+cfg_client! {
+    pub(crate) mod client;
+    pub(crate) use self::client::ClientTask;
+}
+
 pub(crate) use self::server::Server;
 
 /// Default initial stream window size defined in HTTP2 spec.

--- a/src/proto/h2/ping.rs
+++ b/src/proto/h2/ping.rs
@@ -236,6 +236,7 @@ impl Recorder {
 
     /// If the incoming stream is already closed, convert self into
     /// a disabled reporter.
+    #[cfg(feature = "client")]
     pub(super) fn for_stream(self, stream: &h2::RecvStream) -> Self {
         if stream.is_end_stream() {
             disabled()

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -3,7 +3,10 @@
 cfg_http1! {
     pub(crate) mod h1;
 
-    pub(crate) use self::h1::{dispatch, Conn, ServerTransaction};
+    pub(crate) use self::h1::{Conn, ServerTransaction};
+
+    #[cfg(feature = "client")]
+    pub(crate) use self::h1::dispatch;
 }
 
 cfg_http2! {
@@ -31,6 +34,7 @@ pub struct RequestLine(pub http::Method, pub http::Uri);
 
 /// An incoming response message.
 #[cfg(feature = "http1")]
+#[cfg(feature = "client")]
 pub type ResponseHead = MessageHead<http::StatusCode>;
 
 #[derive(Debug)]

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -40,13 +40,18 @@ pub use tower_service::Service;
 mod http;
 mod make;
 #[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(feature = "client")]
 mod oneshot;
 mod util;
 
 pub(crate) use self::http::HttpService;
 #[cfg(any(feature = "http1", feature = "http2"))]
-pub(crate) use self::make::{MakeConnection, MakeServiceRef};
+#[cfg(feature = "client")]
+pub(crate) use self::make::MakeConnection;
 #[cfg(any(feature = "http1", feature = "http2"))]
+pub(crate) use self::make::MakeServiceRef;
+#[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(feature = "client")]
 pub(crate) use self::oneshot::{oneshot, Oneshot};
 
 pub use self::make::make_service_fn;


### PR DESCRIPTION
cc #2223

BREAKING CHANGE: The HTTP client of hyper is now an optional feature. To
  enable the client, add `features = ["client"]` to the dependency in
  your `Cargo.toml`.

