### PR TITLE
feat(server): Make the `server` code an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ default = [
     "runtime",
     "stream",
     "client",
+    "server",
     "http1",
     "http2",
 ]
@@ -82,6 +83,7 @@ full = [
     "client",
     "http1",
     "http2",
+    "server",
     "stream",
     "runtime",
 ]
@@ -100,7 +102,9 @@ tcp = [
 http1 = []
 http2 = ["h2"]
 
+# Client/Server
 client = []
+server = []
 
 # `impl Stream` for things
 stream = []

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -11,16 +11,19 @@ macro_rules! cfg_feature {
     }
 }
 
-macro_rules! cfg_any_http {
+macro_rules! cfg_proto {
     ($($item:item)*) => {
         cfg_feature! {
-            #![any(feature = "http1", feature = "http2")]
+            #![all(
+                any(feature = "http1", feature = "http2"),
+                any(feature = "client", feature = "server"),
+            )]
             $($item)*
         }
     }
 }
 
-cfg_any_http! {
+cfg_proto! {
     macro_rules! cfg_http1 {
         ($($item:item)*) => {
             cfg_feature! {
@@ -43,6 +46,15 @@ cfg_any_http! {
         ($($item:item)*) => {
             cfg_feature! {
                 #![feature = "client"]
+                $($item)*
+            }
+        }
+    }
+
+    macro_rules! cfg_server {
+        ($($item:item)*) => {
+            cfg_feature! {
+                #![feature = "server"]
                 $($item)*
             }
         }

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -15,6 +15,7 @@ pub(crate) struct Rewind<T> {
 
 impl<T> Rewind<T> {
     #[cfg(any(feature = "http2", test))]
+    #[cfg(feature = "server")]
     pub(crate) fn new(io: T) -> Self {
         Rewind {
             pre: None,
@@ -29,7 +30,7 @@ impl<T> Rewind<T> {
         }
     }
 
-    #[cfg(any(all(feature = "http1", feature = "http2"), test))]
+    #[cfg(any(all(feature = "http1", feature = "http2", feature = "server"), test))]
     pub(crate) fn rewind(&mut self, bs: Bytes) {
         debug_assert!(self.pre.is_none());
         self.pre = Some(bs);

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -9,8 +9,10 @@ macro_rules! ready {
 
 pub(crate) mod buf;
 #[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(feature = "server")]
 pub(crate) mod date;
 #[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(feature = "server")]
 pub(crate) mod drain;
 #[cfg(any(feature = "http1", feature = "http2"))]
 pub(crate) mod exec;
@@ -24,8 +26,6 @@ pub(crate) mod sync_wrapper;
 pub(crate) mod task;
 pub(crate) mod watch;
 
-//#[cfg(any(feature = "http1", feature = "http2"))]
-//pub(crate) use self::exec::{BoxSendFuture, Exec};
 #[cfg(any(feature = "http1", feature = "http2"))]
 #[cfg(feature = "client")]
 pub(crate) use self::lazy::{lazy, Started as Lazy};
@@ -33,6 +33,7 @@ pub use self::never::Never;
 pub(crate) use self::task::Poll;
 
 // group up types normally needed for `Future`
-#[cfg(any(feature = "http1", feature = "http2"))]
-pub(crate) use std::marker::Unpin;
+cfg_proto! {
+    pub(crate) use std::marker::Unpin;
+}
 pub(crate) use std::{future::Future, pin::Pin};

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,10 +36,15 @@ pub(crate) enum Kind {
     /// Error occurred while connecting.
     Connect,
     /// Error creating a TcpListener.
-    #[cfg(all(any(feature = "http1", feature = "http2"), feature = "tcp"))]
+    #[cfg(all(
+        any(feature = "http1", feature = "http2"),
+        feature = "tcp",
+        feature = "server"
+    ))]
     Listen,
     /// Error accepting on an Incoming stream.
     #[cfg(any(feature = "http1", feature = "http2"))]
+    #[cfg(feature = "server")]
     Accept,
     /// Error while reading a body from connection.
     #[cfg(any(feature = "http1", feature = "http2", feature = "stream"))]
@@ -77,6 +82,7 @@ pub(crate) enum User {
     Body,
     /// Error calling user's MakeService.
     #[cfg(any(feature = "http1", feature = "http2"))]
+    #[cfg(feature = "server")]
     MakeService,
     /// Error from future of user's Service.
     #[cfg(any(feature = "http1", feature = "http2"))]
@@ -85,6 +91,7 @@ pub(crate) enum User {
     ///
     /// For example, sending both `content-length` and `transfer-encoding`.
     #[cfg(feature = "http1")]
+    #[cfg(feature = "server")]
     UnexpectedHeader,
     /// User tried to create a Request with bad version.
     #[cfg(any(feature = "http1", feature = "http2"))]
@@ -96,6 +103,7 @@ pub(crate) enum User {
     UnsupportedRequestMethod,
     /// User tried to respond with a 1xx (not 101) response code.
     #[cfg(feature = "http1")]
+    #[cfg(feature = "server")]
     UnsupportedStatusCode,
     /// User tried to send a Request with Client with non-absolute URI.
     #[cfg(any(feature = "http1", feature = "http2"))]
@@ -178,6 +186,7 @@ impl Error {
     }
 
     #[cfg(feature = "http1")]
+    #[cfg(feature = "server")]
     pub(crate) fn kind(&self) -> &Kind {
         &self.inner.kind
     }
@@ -234,11 +243,13 @@ impl Error {
     }
 
     #[cfg(all(any(feature = "http1", feature = "http2"), feature = "tcp"))]
+    #[cfg(feature = "server")]
     pub(crate) fn new_listen<E: Into<Cause>>(cause: E) -> Error {
         Error::new(Kind::Listen).with(cause)
     }
 
     #[cfg(any(feature = "http1", feature = "http2"))]
+    #[cfg(feature = "server")]
     pub(crate) fn new_accept<E: Into<Cause>>(cause: E) -> Error {
         Error::new(Kind::Accept).with(cause)
     }
@@ -272,6 +283,7 @@ impl Error {
     }
 
     #[cfg(feature = "http1")]
+    #[cfg(feature = "server")]
     pub(crate) fn new_user_header() -> Error {
         Error::new_user(User::UnexpectedHeader)
     }
@@ -289,6 +301,7 @@ impl Error {
     }
 
     #[cfg(feature = "http1")]
+    #[cfg(feature = "server")]
     pub(crate) fn new_user_unsupported_status_code() -> Error {
         Error::new_user(User::UnsupportedStatusCode)
     }
@@ -309,6 +322,7 @@ impl Error {
     }
 
     #[cfg(any(feature = "http1", feature = "http2"))]
+    #[cfg(feature = "server")]
     pub(crate) fn new_user_make_service<E: Into<Cause>>(cause: E) -> Error {
         Error::new_user(User::MakeService).with(cause)
     }
@@ -354,8 +368,10 @@ impl Error {
             Kind::Connect => "error trying to connect",
             Kind::Canceled => "operation was canceled",
             #[cfg(all(any(feature = "http1", feature = "http2"), feature = "tcp"))]
+            #[cfg(feature = "server")]
             Kind::Listen => "error creating server listener",
             #[cfg(any(feature = "http1", feature = "http2"))]
+            #[cfg(feature = "server")]
             Kind::Accept => "error accepting connection",
             #[cfg(any(feature = "http1", feature = "http2", feature = "stream"))]
             Kind::Body => "error reading a body from connection",
@@ -372,10 +388,12 @@ impl Error {
             #[cfg(any(feature = "http1", feature = "http2"))]
             Kind::User(User::Body) => "error from user's HttpBody stream",
             #[cfg(any(feature = "http1", feature = "http2"))]
+            #[cfg(feature = "server")]
             Kind::User(User::MakeService) => "error from user's MakeService",
             #[cfg(any(feature = "http1", feature = "http2"))]
             Kind::User(User::Service) => "error from user's Service",
             #[cfg(feature = "http1")]
+            #[cfg(feature = "server")]
             Kind::User(User::UnexpectedHeader) => "user sent unexpected header",
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "client")]
@@ -384,6 +402,7 @@ impl Error {
             #[cfg(feature = "client")]
             Kind::User(User::UnsupportedRequestMethod) => "request has unsupported HTTP method",
             #[cfg(feature = "http1")]
+            #[cfg(feature = "server")]
             Kind::User(User::UnsupportedStatusCode) => {
                 "response has 1xx status code, not supported by server"
             }

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -30,6 +30,7 @@ fn connection_has(value: &HeaderValue, needle: &str) -> bool {
 }
 
 #[cfg(feature = "http1")]
+#[cfg(feature = "server")]
 pub fn content_length_parse(value: &HeaderValue) -> Option<u64> {
     value.to_str().ok().and_then(|s| s.parse().ok())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,12 +68,9 @@ pub mod rt;
 pub mod service;
 pub mod upgrade;
 
-cfg_any_http! {
+cfg_proto! {
     mod headers;
     mod proto;
-    pub mod server;
-
-    pub use crate::server::Server;
 }
 
 cfg_feature! {
@@ -81,4 +78,11 @@ cfg_feature! {
 
     pub mod client;
     pub use crate::client::Client;
+}
+
+cfg_feature! {
+    #![all(feature = "server", any(feature = "http1", feature = "http2"))]
+
+    pub mod server;
+    pub use crate::server::Server;
 }

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -57,6 +57,7 @@ where
         }
     }
 
+    #[cfg(feature = "server")]
     pub fn set_flush_pipeline(&mut self, enabled: bool) {
         self.io.set_flush_pipeline(enabled);
     }
@@ -83,6 +84,7 @@ where
         self.state.title_case_headers = true;
     }
 
+    #[cfg(feature = "server")]
     pub(crate) fn set_allow_half_close(&mut self) {
         self.state.allow_half_close = true;
     }
@@ -485,6 +487,7 @@ where
             Encode {
                 head: &mut head,
                 body,
+                #[cfg(feature = "server")]
                 keep_alive: self.state.wants_keep_alive(),
                 req_method: &mut self.state.method,
                 title_case_headers: self.state.title_case_headers,
@@ -690,6 +693,7 @@ where
         self.state.close_write();
     }
 
+    #[cfg(feature = "server")]
     pub fn disable_keep_alive(&mut self) {
         if self.state.is_idle() {
             trace!("disable_keep_alive; closing idle connection");

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -35,6 +35,7 @@ enum Kind {
     ///
     /// This is mostly only used with HTTP/1.0 with a length. This kind requires
     /// the connection to be closed when the body is finished.
+    #[cfg(feature = "server")]
     CloseDelimited,
 }
 
@@ -61,6 +62,7 @@ impl Encoder {
         Encoder::new(Kind::Length(len))
     }
 
+    #[cfg(feature = "server")]
     pub fn close_delimited() -> Encoder {
         Encoder::new(Kind::CloseDelimited)
     }
@@ -72,6 +74,7 @@ impl Encoder {
         }
     }
 
+    #[cfg(feature = "server")]
     pub fn set_last(mut self, is_last: bool) -> Self {
         self.is_last = is_last;
         self
@@ -83,6 +86,7 @@ impl Encoder {
 
     pub fn is_close_delimited(&self) -> bool {
         match self.kind {
+            #[cfg(feature = "server")]
             Kind::CloseDelimited => true,
             _ => false,
         }
@@ -94,6 +98,7 @@ impl Encoder {
             Kind::Chunked => Ok(Some(EncodedBuf {
                 kind: BufKind::ChunkedEnd(b"0\r\n\r\n"),
             })),
+            #[cfg(feature = "server")]
             Kind::CloseDelimited => Ok(None),
             Kind::Length(_) => Err(NotEof),
         }
@@ -125,6 +130,7 @@ impl Encoder {
                     BufKind::Exact(msg)
                 }
             }
+            #[cfg(feature = "server")]
             Kind::CloseDelimited => {
                 trace!("close delimited write {}B", len);
                 BufKind::Exact(msg)
@@ -168,6 +174,7 @@ impl Encoder {
                     }
                 }
             }
+            #[cfg(feature = "server")]
             Kind::CloseDelimited => {
                 trace!("close delimited write {}B", len);
                 dst.buffer(msg);

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -66,6 +66,7 @@ where
         }
     }
 
+    #[cfg(feature = "server")]
     pub fn set_flush_pipeline(&mut self, enabled: bool) {
         debug_assert!(!self.write_buf.has_remaining());
         self.flush_pipeline = enabled;

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -18,10 +18,13 @@ mod encode;
 mod io;
 mod role;
 
-pub(crate) type ServerTransaction = role::Server;
 
 cfg_client! {
     pub(crate) type ClientTransaction = role::Client;
+}
+
+cfg_server! {
+    pub(crate) type ServerTransaction = role::Server;
 }
 
 pub(crate) trait Http1Transaction {
@@ -73,6 +76,7 @@ pub(crate) struct ParseContext<'a> {
 pub(crate) struct Encode<'a, T> {
     head: &'a mut MessageHead<T>,
     body: Option<BodyLength>,
+    #[cfg(feature = "server")]
     keep_alive: bool,
     req_method: &'a mut Option<Method>,
     title_case_headers: bool,

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -10,6 +10,7 @@ use http::header::{self, Entry, HeaderName, HeaderValue};
 use http::{HeaderMap, Method, StatusCode, Version};
 
 use crate::body::DecodedLength;
+#[cfg(feature = "server")]
 use crate::common::date;
 use crate::error::Parse;
 use crate::headers;
@@ -94,10 +95,13 @@ where
 
 // There are 2 main roles, Client and Server.
 
+#[cfg(feature = "client")]
 pub(crate) enum Client {}
 
+#[cfg(feature = "server")]
 pub(crate) enum Server {}
 
+#[cfg(feature = "server")]
 impl Http1Transaction for Server {
     type Incoming = RequestLine;
     type Outgoing = StatusCode;
@@ -618,6 +622,7 @@ impl Http1Transaction for Server {
     }
 }
 
+#[cfg(feature = "server")]
 impl Server {
     fn can_have_body(method: &Option<Method>, status: StatusCode) -> bool {
         Server::can_chunked(method, status)
@@ -640,6 +645,7 @@ impl Server {
     }
 }
 
+#[cfg(feature = "client")]
 impl Http1Transaction for Client {
     type Incoming = StatusCode;
     type Outgoing = RequestLine;
@@ -779,6 +785,7 @@ impl Http1Transaction for Client {
     }
 }
 
+#[cfg(feature = "client")]
 impl Client {
     /// Returns Some(length, wants_upgrade) if successful.
     ///
@@ -846,9 +853,6 @@ impl Client {
             Ok(Some((DecodedLength::CLOSE_DELIMITED, false)))
         }
     }
-}
-
-impl Client {
     fn set_length(head: &mut RequestHead, body: Option<BodyLength>) -> Encoder {
         let body = if let Some(body) = body {
             body

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -14,14 +14,16 @@ use crate::common::{task, Future, Pin, Poll};
 use crate::headers::content_length_parse_all;
 
 pub(crate) mod ping;
-pub(crate) mod server;
 
 cfg_client! {
     pub(crate) mod client;
     pub(crate) use self::client::ClientTask;
 }
 
-pub(crate) use self::server::Server;
+cfg_server! {
+    pub(crate) mod server;
+    pub(crate) use self::server::Server;
+}
 
 /// Default initial stream window size defined in HTTP2 spec.
 pub(crate) const SPEC_WINDOW_SIZE: u32 = 65_535;

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -3,10 +3,12 @@
 cfg_http1! {
     pub(crate) mod h1;
 
-    pub(crate) use self::h1::{Conn, ServerTransaction};
+    pub(crate) use self::h1::Conn;
 
     #[cfg(feature = "client")]
     pub(crate) use self::h1::dispatch;
+    #[cfg(feature = "server")]
+    pub(crate) use self::h1::ServerTransaction;
 }
 
 cfg_http2! {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -49,6 +49,7 @@ pub(crate) use self::http::HttpService;
 #[cfg(feature = "client")]
 pub(crate) use self::make::MakeConnection;
 #[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(feature = "server")]
 pub(crate) use self::make::MakeServiceRef;
 #[cfg(any(feature = "http1", feature = "http2"))]
 #[cfg(feature = "client")]


### PR DESCRIPTION
BREAKING CHANGE: The HTTP server code is now an optional feature. To
  enable the server, add `features = ["server"]` to the dependency in
  your `Cargo.toml`.

