### PR TITLE
refac: use tokio's TcpSocket for more sockopts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "1.0"
 tower-service = "0.3"
-tokio = { version = "0.3", features = ["sync", "stream"] }
+tokio = { version = "0.3.4", features = ["sync", "stream"] }
 want = "0.3"
 
 # Optional


### PR DESCRIPTION
We still need `socket2` specifically for TCP keepalive, but we may just
end up removing that soon?

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

