### PR TITLE
feat(upgrade): Moved HTTP upgrades off `Body` to a new API

### DIFF
--- a/examples/http_proxy.rs
+++ b/examples/http_proxy.rs
@@ -58,7 +58,7 @@ async fn proxy(client: HttpClient, req: Request<Body>) -> Result<Response<Body>,
         // `on_upgrade` future.
         if let Some(addr) = host_addr(req.uri()) {
             tokio::task::spawn(async move {
-                match req.into_body().on_upgrade().await {
+                match hyper::upgrade::on(req).await {
                     Ok(upgraded) => {
                         if let Err(e) = tunnel(upgraded, addr).await {
                             eprintln!("server io error: {}", e);

--- a/src/body/body.rs
+++ b/src/body/body.rs
@@ -187,13 +187,15 @@ impl Body {
         Body::new(Kind::Wrapped(SyncWrapper::new(Box::pin(mapped))))
     }
 
-    /// Converts this `Body` into a `Future` of a pending HTTP upgrade.
-    ///
-    /// See [the `upgrade` module](crate::upgrade) for more.
-    pub fn on_upgrade(self) -> OnUpgrade {
-        self.extra
-            .map(|ex| ex.on_upgrade)
-            .unwrap_or_else(OnUpgrade::none)
+    // TODO: Eventually the pending upgrade should be stored in the
+    // `Extensions`, and all these pieces can be removed. In v0.14, we made
+    // the breaking changes, so now this TODO can be done without breakage.
+    pub(crate) fn take_upgrade(&mut self) -> OnUpgrade {
+        if let Some(ref mut extra) = self.extra {
+            std::mem::replace(&mut extra.on_upgrade, OnUpgrade::none())
+        } else {
+            OnUpgrade::none()
+        }
     }
 
     fn new(kind: Kind) -> Body {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1790,9 +1790,7 @@ mod dispatch_impl {
         let res = rt.block_on(future::join(res, rx).map(|r| r.0)).unwrap();
 
         assert_eq!(res.status(), 101);
-        let upgraded = rt
-            .block_on(res.into_body().on_upgrade())
-            .expect("on_upgrade");
+        let upgraded = rt.block_on(hyper::upgrade::on(res)).expect("on_upgrade");
 
         let parts = upgraded.downcast::<DebugStream>().unwrap();
         assert_eq!(s(&parts.read_buf), "foobar=ready");

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1341,7 +1341,7 @@ async fn upgrades_new() {
 
     let (upgrades_tx, upgrades_rx) = mpsc::channel();
     let svc = service_fn(move |req: Request<Body>| {
-        let on_upgrade = req.into_body().on_upgrade();
+        let on_upgrade = hyper::upgrade::on(req);
         let _ = upgrades_tx.send(on_upgrade);
         future::ok::<_, hyper::Error>(
             Response::builder()
@@ -1448,7 +1448,7 @@ async fn http_connect_new() {
 
     let (upgrades_tx, upgrades_rx) = mpsc::channel();
     let svc = service_fn(move |req: Request<Body>| {
-        let on_upgrade = req.into_body().on_upgrade();
+        let on_upgrade = hyper::upgrade::on(req);
         let _ = upgrades_tx.send(on_upgrade);
         future::ok::<_, hyper::Error>(
             Response::builder()


### PR DESCRIPTION
Closes #2086 

BREAKING CHANGE: The method `Body::on_upgrade()` is gone. It is
  essentially replaced with `hyper::upgrade::on(msg)`.

