### PR TITLE
feat(lib): re-enable writev support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ http = "0.2"
 http-body = { git = "https://github.com/hyperium/http-body" }
 httpdate = "0.3"
 httparse = "1.0"
-h2 = { git = "https://github.com/hyperium/h2", optional = true }
+h2 = { git = "https://github.com/hyperium/h2", optional = true, branch = "eliza/writev" }
 itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ http = "0.2"
 http-body = { git = "https://github.com/hyperium/http-body" }
 httpdate = "0.3"
 httparse = "1.0"
-h2 = { git = "https://github.com/hyperium/h2", optional = true, branch = "eliza/writev" }
+h2 = { git = "https://github.com/hyperium/h2", optional = true }
 itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "1.0"

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -82,7 +82,6 @@ where
 #[derive(Clone, Debug)]
 pub struct Builder {
     pub(super) exec: Exec,
-    h1_writev: Option<bool>,
     h1_title_case_headers: bool,
     h1_read_buf_exact_size: Option<usize>,
     h1_max_buf_size: Option<usize>,
@@ -453,7 +452,6 @@ impl Builder {
     pub fn new() -> Builder {
         Builder {
             exec: Exec::Default,
-            h1_writev: None,
             h1_read_buf_exact_size: None,
             h1_title_case_headers: false,
             h1_max_buf_size: None,
@@ -472,11 +470,6 @@ impl Builder {
         E: Executor<BoxSendFuture> + Send + Sync + 'static,
     {
         self.exec = Exec::Executor(Arc::new(exec));
-        self
-    }
-
-    pub(super) fn h1_writev(&mut self, enabled: bool) -> &mut Builder {
-        self.h1_writev = Some(enabled);
         self
     }
 
@@ -663,13 +656,6 @@ impl Builder {
                 #[cfg(feature = "http1")]
                 Proto::Http1 => {
                     let mut conn = proto::Conn::new(io);
-                    if let Some(writev) = opts.h1_writev {
-                        if writev {
-                            conn.set_write_strategy_queue();
-                        } else {
-                            conn.set_write_strategy_flatten();
-                        }
-                    }
                     if opts.h1_title_case_headers {
                         conn.set_title_case_headers();
                     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -62,7 +62,7 @@ use http::{Method, Request, Response, Uri, Version};
 use self::connect::{sealed::Connect, Alpn, Connected, Connection};
 use self::pool::{Key as PoolKey, Pool, Poolable, Pooled, Reservation};
 use crate::body::{Body, HttpBody};
-use crate::common::{lazy as hyper_lazy, task, exec::BoxSendFuture, Future, Lazy, Pin, Poll};
+use crate::common::{exec::BoxSendFuture, lazy as hyper_lazy, task, Future, Lazy, Pin, Poll};
 use crate::rt::Executor;
 
 #[cfg(feature = "tcp")]
@@ -986,23 +986,6 @@ impl Builder {
     }
 
     // HTTP/1 options
-
-    /// Set whether HTTP/1 connections should try to use vectored writes,
-    /// or always flatten into a single buffer.
-    ///
-    /// Note that setting this to false may mean more copies of body data,
-    /// but may also improve performance when an IO transport doesn't
-    /// support vectored writes well, such as most TLS implementations.
-    ///
-    /// Setting this to true will force hyper to use queued strategy
-    /// which may eliminate unnecessary cloning on some TLS backends
-    ///
-    /// Default is `auto`. In this mode hyper will try to guess which
-    /// mode to use
-    pub fn http1_writev(&mut self, val: bool) -> &mut Self {
-        self.conn_builder.h1_writev(val);
-        self
-    }
 
     /// Sets the exact size of the read buffer to *always* use.
     ///

--- a/src/common/io/mod.rs
+++ b/src/common/io/mod.rs
@@ -1,3 +1,4 @@
 mod rewind;
 
 pub(crate) use self::rewind::Rewind;
+pub(crate) const MAX_WRITEV_BUFS: usize = 64;

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -84,12 +84,24 @@ where
         Pin::new(&mut self.inner).poll_write(cx, buf)
     }
 
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
+    }
+
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.inner).poll_flush(cx)
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
     }
 }
 

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -71,14 +71,6 @@ where
         self.io.set_read_buf_exact_size(sz);
     }
 
-    pub fn set_write_strategy_flatten(&mut self) {
-        self.io.set_write_strategy_flatten();
-    }
-
-    pub fn set_write_strategy_queue(&mut self) {
-        self.io.set_write_strategy_queue();
-    }
-
     #[cfg(feature = "client")]
     pub fn set_title_case_headers(&mut self) {
         self.state.title_case_headers = true;

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -823,33 +823,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_buf_auto_flatten() {
-        let _ = pretty_env_logger::try_init();
-
-        let mock = Mock::new()
-            // Expects write_buf to only consume first buffer
-            .write(b"hello ")
-            // And then the Auto strategy will have flattened
-            .write(b"world, it's hyper!")
-            .build();
-
-        let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(mock);
-
-        // we have 4 buffers, but hope to detect that vectored IO isn't
-        // being used, and switch to flattening automatically,
-        // resulting in only 2 writes
-        buffered.headers_buf().extend(b"hello ");
-        buffered.buffer(Cursor::new(b"world, ".to_vec()));
-        buffered.buffer(Cursor::new(b"it's ".to_vec()));
-        buffered.buffer(Cursor::new(b"hyper!".to_vec()));
-        assert_eq!(buffered.write_buf.queue.bufs_cnt(), 3);
-
-        buffered.flush().await.expect("flush");
-
-        assert_eq!(buffered.write_buf.queue.bufs_cnt(), 0);
-    }
-
-    #[tokio::test]
     async fn write_buf_queue_disable_auto() {
         let _ = pretty_env_logger::try_init();
 

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -229,6 +229,8 @@ where
     }
 
     pub fn poll_flush(&mut self, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+        const MAX_WRITEV_VECS: usize = 64;
+
         if self.flush_pipeline && !self.read_buf.is_empty() {
             Poll::Ready(Ok(()))
         } else if self.write_buf.remaining() == 0 {
@@ -245,7 +247,7 @@ where
                      write support, this is a bug"
                 );
                 let n = {
-                    let mut iovs = [IoSlice::new(&[]); MAX_BUF_LIST_BUFFERS];
+                    let mut iovs = [IoSlice::new(&[]); MAX_WRITEV_VECS];
                     let len = self.write_buf.bytes_vectored(&mut iovs);
                     ready!(Pin::new(&mut self.io).poll_write_vectored(cx, &iovs[..len]))?
                 };

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -241,11 +241,6 @@ where
             }
 
             loop {
-                debug_assert!(
-                    self.io.is_write_vectored(),
-                    "using vectored writes on an IO that does not provide fast vectored \
-                     write support, this is a bug"
-                );
                 let n = {
                     let mut iovs = [IoSlice::new(&[]); MAX_WRITEV_VECS];
                     let len = self.write_buf.bytes_vectored(&mut iovs);

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -222,8 +222,6 @@ where
     }
 
     pub fn poll_flush(&mut self, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
-        const MAX_WRITEV_VECS: usize = 64;
-
         if self.flush_pipeline && !self.read_buf.is_empty() {
             Poll::Ready(Ok(()))
         } else if self.write_buf.remaining() == 0 {
@@ -235,7 +233,7 @@ where
 
             loop {
                 let n = {
-                    let mut iovs = [IoSlice::new(&[]); MAX_WRITEV_VECS];
+                    let mut iovs = [IoSlice::new(&[]); crate::common::io::MAX_WRITEV_BUFS];
                     let len = self.write_buf.bytes_vectored(&mut iovs);
                     ready!(Pin::new(&mut self.io).poll_write_vectored(cx, &iovs[..len]))?
                 };

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -98,13 +98,6 @@ where
         self.write_buf.set_strategy(WriteStrategy::Flatten);
     }
 
-    pub fn set_write_strategy_queue(&mut self) {
-        // this should always be called only at construction time,
-        // so this assert is here to catch myself
-        debug_assert!(self.write_buf.queue.bufs_cnt() == 0);
-        self.write_buf.set_strategy(WriteStrategy::Queue);
-    }
-
     pub fn read_buf(&self) -> &[u8] {
         self.read_buf.as_ref()
     }

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -1,4 +1,3 @@
-use std::cell::Cell;
 use std::cmp;
 use std::fmt;
 use std::io::{self, IoSlice};
@@ -57,13 +56,14 @@ where
     B: Buf,
 {
     pub fn new(io: T) -> Buffered<T, B> {
+        let write_buf = WriteBuf::new(&io);
         Buffered {
             flush_pipeline: false,
             io,
             read_blocked: false,
             read_buf: BytesMut::with_capacity(0),
             read_buf_strategy: ReadStrategy::default(),
-            write_buf: WriteBuf::new(),
+            write_buf,
         }
     }
 
@@ -237,13 +237,18 @@ where
             if let WriteStrategy::Flatten = self.write_buf.strategy {
                 return self.poll_flush_flattened(cx);
             }
+
             loop {
-                // TODO(eliza): this basically ignores all of `WriteBuf`...put
-                // back vectored IO and `poll_write_buf` when the appropriate Tokio
-                // changes land...
-                let n = ready!(Pin::new(&mut self.io)
-                    // .poll_write_buf(cx, &mut self.write_buf.auto()))?;
-                    .poll_write(cx, self.write_buf.auto().bytes()))?;
+                debug_assert!(
+                    self.io.is_write_vectored(),
+                    "using vectored writes on an IO that does not provide fast vectored \
+                     write support, this is a bug"
+                );
+                let n = {
+                    let mut iovs = [IoSlice::new(&[]); MAX_BUF_LIST_BUFFERS];
+                    let len = self.write_buf.bytes_vectored(&mut iovs);
+                    ready!(Pin::new(&mut self.io).poll_write_vectored(cx, &iovs[..len]))?
+                };
                 // TODO(eliza): we have to do this manually because
                 // `poll_write_buf` doesn't exist in Tokio 0.3 yet...when
                 // `poll_write_buf` comes back, the manual advance will need to leave!
@@ -462,12 +467,17 @@ pub(super) struct WriteBuf<B> {
 }
 
 impl<B: Buf> WriteBuf<B> {
-    fn new() -> WriteBuf<B> {
+    fn new(io: &impl AsyncWrite) -> WriteBuf<B> {
+        let strategy = if io.is_write_vectored() {
+            WriteStrategy::Queue
+        } else {
+            WriteStrategy::Flatten
+        };
         WriteBuf {
             headers: Cursor::new(Vec::with_capacity(INIT_BUFFER_SIZE)),
             max_buf_size: DEFAULT_MAX_BUFFER_SIZE,
             queue: BufList::new(),
-            strategy: WriteStrategy::Auto,
+            strategy,
         }
     }
 }
@@ -478,12 +488,6 @@ where
 {
     fn set_strategy(&mut self, strategy: WriteStrategy) {
         self.strategy = strategy;
-    }
-
-    // TODO(eliza): put back writev!
-    #[inline]
-    fn auto(&mut self) -> WriteBufAuto<'_, B> {
-        WriteBufAuto::new(self)
     }
 
     pub(super) fn buffer<BB: Buf + Into<B>>(&mut self, mut buf: BB) {
@@ -505,7 +509,7 @@ where
                     buf.advance(adv);
                 }
             }
-            WriteStrategy::Auto | WriteStrategy::Queue => {
+            WriteStrategy::Queue => {
                 self.queue.push(buf.into());
             }
         }
@@ -514,7 +518,7 @@ where
     fn can_buffer(&self) -> bool {
         match self.strategy {
             WriteStrategy::Flatten => self.remaining() < self.max_buf_size,
-            WriteStrategy::Auto | WriteStrategy::Queue => {
+            WriteStrategy::Queue => {
                 self.queue.bufs_cnt() < MAX_BUF_LIST_BUFFERS && self.remaining() < self.max_buf_size
             }
         }
@@ -573,65 +577,8 @@ impl<B: Buf> Buf for WriteBuf<B> {
     }
 }
 
-/// Detects when wrapped `WriteBuf` is used for vectored IO, and
-/// adjusts the `WriteBuf` strategy if not.
-struct WriteBufAuto<'a, B: Buf> {
-    bytes_called: Cell<bool>,
-    bytes_vec_called: Cell<bool>,
-    inner: &'a mut WriteBuf<B>,
-}
-
-impl<'a, B: Buf> WriteBufAuto<'a, B> {
-    fn new(inner: &'a mut WriteBuf<B>) -> WriteBufAuto<'a, B> {
-        WriteBufAuto {
-            bytes_called: Cell::new(false),
-            bytes_vec_called: Cell::new(false),
-            inner,
-        }
-    }
-}
-
-impl<'a, B: Buf> Buf for WriteBufAuto<'a, B> {
-    #[inline]
-    fn remaining(&self) -> usize {
-        self.inner.remaining()
-    }
-
-    #[inline]
-    fn bytes(&self) -> &[u8] {
-        self.bytes_called.set(true);
-        self.inner.bytes()
-    }
-
-    #[inline]
-    fn advance(&mut self, cnt: usize) {
-        self.inner.advance(cnt)
-    }
-
-    #[inline]
-    fn bytes_vectored<'t>(&'t self, dst: &mut [IoSlice<'t>]) -> usize {
-        self.bytes_vec_called.set(true);
-        self.inner.bytes_vectored(dst)
-    }
-}
-
-impl<'a, B: Buf + 'a> Drop for WriteBufAuto<'a, B> {
-    fn drop(&mut self) {
-        if let WriteStrategy::Auto = self.inner.strategy {
-            if self.bytes_vec_called.get() {
-                self.inner.strategy = WriteStrategy::Queue;
-            } else if self.bytes_called.get() {
-                trace!("detected no usage of vectored write, flattening");
-                self.inner.strategy = WriteStrategy::Flatten;
-                self.inner.headers.bytes.put(&mut self.inner.queue);
-            }
-        }
-    }
-}
-
 #[derive(Debug)]
 enum WriteStrategy {
-    Auto,
     Flatten,
     Queue,
 }
@@ -643,8 +590,8 @@ mod tests {
 
     use tokio_test::io::Builder as Mock;
 
-    #[cfg(feature = "nightly")]
-    use test::Bencher;
+    // #[cfg(feature = "nightly")]
+    // use test::Bencher;
 
     /*
     impl<T: Read> MemRead for AsyncIo<T> {
@@ -928,19 +875,19 @@ mod tests {
         assert_eq!(buffered.write_buf.queue.bufs_cnt(), 0);
     }
 
-    #[cfg(feature = "nightly")]
-    #[bench]
-    fn bench_write_buf_flatten_buffer_chunk(b: &mut Bencher) {
-        let s = "Hello, World!";
-        b.bytes = s.len() as u64;
+    // #[cfg(feature = "nightly")]
+    // #[bench]
+    // fn bench_write_buf_flatten_buffer_chunk(b: &mut Bencher) {
+    //     let s = "Hello, World!";
+    //     b.bytes = s.len() as u64;
 
-        let mut write_buf = WriteBuf::<bytes::Bytes>::new();
-        write_buf.set_strategy(WriteStrategy::Flatten);
-        b.iter(|| {
-            let chunk = bytes::Bytes::from(s);
-            write_buf.buffer(chunk);
-            ::test::black_box(&write_buf);
-            write_buf.headers.bytes.clear();
-        })
-    }
+    //     let mut write_buf = WriteBuf::<bytes::Bytes>::new();
+    //     write_buf.set_strategy(WriteStrategy::Flatten);
+    //     b.iter(|| {
+    //         let chunk = bytes::Bytes::from(s);
+    //         write_buf.buffer(chunk);
+    //         ::test::black_box(&write_buf);
+    //         write_buf.headers.bytes.clear();
+    //     })
+    // }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -284,27 +284,6 @@ impl<I, E> Builder<I, E> {
         self
     }
 
-    /// Set whether HTTP/1 connections should try to use vectored writes,
-    /// or always flatten into a single buffer.
-    ///
-    /// # Note
-    ///
-    /// Setting this to `false` may mean more copies of body data,
-    /// but may also improve performance when an IO transport doesn't
-    /// support vectored writes well, such as most TLS implementations.
-    ///
-    /// Setting this to true will force hyper to use queued strategy
-    /// which may eliminate unnecessary cloning on some TLS backends
-    ///
-    /// Default is `auto`. In this mode hyper will try to guess which
-    /// mode to use.
-    #[cfg(feature = "http1")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
-    pub fn http1_writev(mut self, val: bool) -> Self {
-        self.protocol.http1_writev(val);
-        self
-    }
-
     /// Sets whether HTTP/1 is required.
     ///
     /// Default is `false`.

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -297,7 +297,7 @@ mod addr_stream {
         fn poll_write_vectored(
             self: Pin<&mut Self>,
             cx: &mut task::Context<'_>,
-            bufs: &[io::IoVec<'_>],
+            bufs: &[io::IoSlice<'_>],
         ) -> Poll<io::Result<usize>> {
             self.project().inner.poll_write_vectored(cx, bufs)
         }

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -294,6 +294,15 @@ mod addr_stream {
         }
 
         #[inline]
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            cx: &mut task::Context<'_>,
+            bufs: &[io::IoVec<'_>],
+        ) -> Poll<io::Result<usize>> {
+            self.project().inner.poll_write_vectored(cx, bufs)
+        }
+
+        #[inline]
         fn poll_flush(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
             // TCP flush is a noop
             Poll::Ready(Ok(()))
@@ -302,6 +311,15 @@ mod addr_stream {
         #[inline]
         fn poll_shutdown(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
             self.project().inner.poll_shutdown(cx)
+        }
+
+        #[inline]
+        fn is_write_vectored(&self) -> bool {
+            // Note that since `self.inner` is a `TcpStream`, this could
+            // *probably* be hard-coded to return `true`...but it seems more
+            // correct to ask it anyway (maybe we're on some platform without
+            // scatter-gather IO?)
+            self.inner.is_write_vectored()
         }
     }
 

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -124,12 +124,24 @@ impl AsyncWrite for Upgraded {
         Pin::new(&mut self.io).poll_write(cx, buf)
     }
 
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.io).poll_write_vectored(cx, bufs)
+    }
+
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.io).poll_flush(cx)
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.io).poll_shutdown(cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.io.is_write_vectored()
     }
 }
 
@@ -261,12 +273,24 @@ impl<T: AsyncWrite + Unpin> AsyncWrite for ForwardsWriteBuf<T> {
         Pin::new(&mut self.0).poll_write(cx, buf)
     }
 
+    fn poll_write_vectored(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.0).poll_write_vectored(cx, bufs)
+    }
+
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.0).poll_flush(cx)
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.0).poll_shutdown(cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
     }
 }
 


### PR DESCRIPTION
Tokio's `AsyncWrite` trait once again has support for vectored writes in
Tokio 0.3.4 (see tokio-rs/tokio#3149.

This branch re-enables vectored writes in Hyper. Using vectored writes
in HTTP/2 requires a git dependency on a `h2` branch that adds writev
support in `h2`.

I've removed the adaptive write buffer implementation
that attempts to detect whether vectored IO is or is not available,
since the Tokio 0.3.4 `AsyncWrite` trait exposes this directly via the
`is_write_vectored` method. Now, we just ask the IO whether or not it
supports vectored writes, and configure the buffer accordingly. This
makes the implementation somewhat simpler.

This makes a pretty noticeable performance improvement in the
HTTP/1 end to end benchmarks.

Before:
```
http1_body_both_100kb                                  ...     48,741 ns/iter (+/- 795) = 4201 MB/s
http1_body_both_10mb                                   ...  5,052,611 ns/iter (+/- 191,704) = 4150 MB/s
http1_get                                              ...     13,266 ns/iter (+/- 175)
http1_parallel_x10_empty                               ...    111,058 ns/iter (+/- 2,880)
http1_parallel_x10_req_10kb_100_chunks                 ... 44,978,795 ns/iter (+/- 331,374) = 227 MB/s
http1_parallel_x10_req_10mb                            ... 30,488,288 ns/iter (+/- 966,618) = 3439 MB/s
http1_parallel_x10_res_10mb                            ... 31,197,686 ns/iter (+/- 1,015,384) = 3361 MB/s
http1_parallel_x10_res_1mb                             ...  2,604,156 ns/iter (+/- 32,000) = 4026 MB/s
http1_post                                             ...     15,416 ns/iter (+/- 443) = 1 MB/s
http2_get                                              ...     29,779 ns/iter (+/- 1,478)
http2_parallel_x10_empty                               ...    113,465 ns/iter (+/- 4,347)
http2_parallel_x10_req_10kb_100_chunks                 ...  5,494,508 ns/iter (+/- 76,573) = 1863 MB/s
http2_parallel_x10_req_10kb_100_chunks_adaptive_window ...  5,617,054 ns/iter (+/- 539,833) = 1823 MB/s
http2_parallel_x10_req_10kb_100_chunks_max_window      ...  9,015,224 ns/iter (+/- 4,297,176) = 1135 MB/s
http2_parallel_x10_req_10mb                            ... 28,161,933 ns/iter (+/- 1,425,776) = 3723 MB/s
http2_parallel_x10_res_10mb                            ... 28,270,177 ns/iter (+/- 1,931,240) = 3709 MB/s
http2_parallel_x10_res_1mb                             ...  2,934,070 ns/iter (+/- 232,372) = 3573 MB/s
http2_post                                             ...     34,705 ns/iter (+/- 1,664)
http2_req_100kb                                        ...     71,128 ns/iter (+/- 1,697) = 1439 MB/s
```

...and after:

```
http1_body_both_100kb                                  ...      40,922 ns/iter (+/- 948) = 5004 MB/s
http1_body_both_10mb                                   ...   3,133,403 ns/iter (+/- 120,270) = 6692 MB/s
http1_get                                              ...      13,267 ns/iter (+/- 980)
http1_parallel_x10_empty                               ...     113,016 ns/iter (+/- 5,812)
http1_parallel_x10_req_10kb_100_chunks                 ...  44,988,730 ns/iter (+/- 584,882) = 227 MB/s
http1_parallel_x10_req_10mb                            ...  21,539,385 ns/iter (+/- 823,233) = 4868 MB/s
http1_parallel_x10_res_10mb                            ...  22,341,524 ns/iter (+/- 733,779) = 4693 MB/s
http1_parallel_x10_res_1mb                             ...   2,056,770 ns/iter (+/- 28,341) = 5098 MB/s
http1_post                                             ...      15,152 ns/iter (+/- 536) = 1 MB/s
http2_get                                              ...      28,229 ns/iter (+/- 3,301)
http2_parallel_x10_empty                               ...     108,068 ns/iter (+/- 3,227)
http2_parallel_x10_req_10kb_100_chunks                 ...   5,287,486 ns/iter (+/- 4,289,142) = 1936 MB/s
http2_parallel_x10_req_10kb_100_chunks_adaptive_window ...   5,482,784 ns/iter (+/- 156,002) = 1867 MB/s
http2_parallel_x10_req_10kb_100_chunks_max_window      ...   9,049,895 ns/iter (+/- 4,306,978) = 1131 MB/s
http2_parallel_x10_req_10mb                            ...  27,244,510 ns/iter (+/- 1,719,769) = 3848 MB/s
http2_parallel_x10_res_10mb                            ...  37,240,130 ns/iter (+/- 9,692,352) = 2815 MB/s
http2_parallel_x10_res_1mb                             ...   2,863,063 ns/iter (+/- 221,709) = 3662 MB/s
http2_post                                             ...      32,634 ns/iter (+/- 1,770)
http2_req_100kb                                        ...      69,138 ns/iter (+/- 5,281) = 1481 MB/s
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

BREAKING CHANGE:

Removed `http1_writev` methods from `client::Builder`,
`client::conn::Builder`, `server::Builder`, and `server::conn::Builder`.

Vectored writes are now enabled based on whether the `AsyncWrite`
implementation in use supports them, rather than though adaptive
detection. To explicitly disable vectored writes, users may wrap the IO
in a newtype that implements `AsyncRead` and `AsyncWrite` and returns
`false` from its `AsyncWrite::is_write_vectored` method.
