### PR TITLE
feat: update `bytes` to 0.6, update http-body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ include = [
 ]
 
 [dependencies]
-bytes = "0.5"
+bytes = "0.6"
 futures-core = { version = "0.3", default-features = false }
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 http = "0.2"
-http-body = "0.3.1"
+http-body = { git = "https://github.com/hyperium/http-body" }
 httpdate = "0.3"
 httparse = "1.0"
 h2 = { git = "https://github.com/hyperium/h2", optional = true }
@@ -63,7 +63,7 @@ tokio = { version = "0.3", features = [
     "test-util",
 ] }
 tokio-test = "0.3"
-tokio-util = { version = "0.4", features = ["codec"] }
+tokio-util = { version = "0.5", features = ["codec"] }
 tower-util = "0.3"
 url = "1.0"
 

--- a/examples/client_json.rs
+++ b/examples/client_json.rs
@@ -4,7 +4,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-use bytes::buf::BufExt as _;
+use bytes::Buf as _;
 use hyper::Client;
 
 // A simple type alias so as to DRY.

--- a/examples/web_api.rs
+++ b/examples/web_api.rs
@@ -1,6 +1,6 @@
 #![deny(warnings)]
 
-use bytes::buf::BufExt;
+use bytes::Buf;
 use futures_util::{stream, StreamExt};
 use hyper::client::HttpConnector;
 use hyper::service::{make_service_fn, service_fn};

--- a/src/body/to_bytes.rs
+++ b/src/body/to_bytes.rs
@@ -23,7 +23,7 @@ where
     let second = if let Some(buf) = body.data().await {
         buf?
     } else {
-        return Ok(first.to_bytes());
+        return Ok(first.copy_to_bytes(first.bytes().len()));
     };
 
     // With more than 1 buf, we gotta flatten into a Vec first.

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io::IoSlice;
 
-use bytes::buf::ext::{BufExt, Chain, Take};
+use bytes::buf::{Chain, Take};
 use bytes::Buf;
 
 use super::io::WriteBuf;


### PR DESCRIPTION
This branch updates `bytes` and `http-body` to the latest versions. The
`http-body` version that uses `bytes` 0.6 hasn't been released yet, so
we depend on it via a git dep for now. Presumably Hyper and `http-body`
will synchronize their releases.

Other than that, this is a pretty mechanical update. Should fix the
build and unblock the `h2` update to use vectored writes.

