### PR TITLE
Upgrade libpnet depedency to 0.27.2 [#2347]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ tower-util = "0.3"
 url = "1.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dev-dependencies]
-pnet = "0.25.0"
+pnet_datalink = "0.27.2"
 
 [features]
 # Nothing by default

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -723,7 +723,7 @@ mod tests {
         let mut ip_v4 = None;
         let mut ip_v6 = None;
 
-        let ips = pnet::datalink::interfaces()
+        let ips = pnet_datalink::interfaces()
             .into_iter()
             .flat_map(|i| i.ips.into_iter().map(|n| n.ip()));
 


### PR DESCRIPTION
Additionally, only depend on pnet_datalink to reduce compile times.

Closes #2347

