### PR TITLE
Upgrade socket2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ want = "0.3"
 
 # Optional
 
-socket2 = { version = "0.3", optional = true }
+socket2 = { version = "0.3.16", optional = true }
 
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Upgrades to a version not making invalid assumptions about the memory layout of std::net::SocketAddr

Helps unblock https://github.com/rust-lang/rust/pull/78802. See that PR for more details.