### PR TITLE
Chore: Move OnUpgrade state from Body to Request/Response

### DIFF
--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -270,6 +270,7 @@ impl Http1Transaction for Server {
                 version,
                 subject,
                 headers,
+                extensions: http::Extensions::default(),
             },
             decode: decoder,
             expect_continue,
@@ -713,6 +714,7 @@ impl Http1Transaction for Client {
                 version,
                 subject: status,
                 headers,
+                extensions: http::Extensions::default(),
             };
             if let Some((decode, is_upgrade)) = Client::decoder(&head, ctx.req_method)? {
                 return Ok(Some(ParsedMessage {

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -16,7 +16,7 @@ cfg_http2! {
 }
 
 /// An Incoming Message head. Includes request/status line, and headers.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Debug, Default)]
 pub struct MessageHead<S> {
     /// HTTP version of the message.
     pub version: http::Version,
@@ -24,6 +24,9 @@ pub struct MessageHead<S> {
     pub subject: S,
     /// Headers of the Incoming message.
     pub headers: http::HeaderMap,
+
+    /// Extensions.
+    extensions: http::Extensions,
 }
 
 /// An incoming request message.

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -317,26 +317,34 @@ mod sealed {
     }
 
     impl CanUpgrade for http::Request<crate::Body> {
-        fn on_upgrade(self) -> OnUpgrade {
-            self.into_body().take_upgrade()
+        fn on_upgrade(mut self) -> OnUpgrade {
+            self.extensions_mut()
+                .remove::<OnUpgrade>()
+                .unwrap_or_else(OnUpgrade::none)
         }
     }
 
     impl CanUpgrade for &'_ mut http::Request<crate::Body> {
         fn on_upgrade(self) -> OnUpgrade {
-            self.body_mut().take_upgrade()
+            self.extensions_mut()
+                .remove::<OnUpgrade>()
+                .unwrap_or_else(OnUpgrade::none)
         }
     }
 
     impl CanUpgrade for http::Response<crate::Body> {
-        fn on_upgrade(self) -> OnUpgrade {
-            self.into_body().take_upgrade()
+        fn on_upgrade(mut self) -> OnUpgrade {
+            self.extensions_mut()
+                .remove::<OnUpgrade>()
+                .unwrap_or_else(OnUpgrade::none)
         }
     }
 
     impl CanUpgrade for &'_ mut http::Response<crate::Body> {
         fn on_upgrade(self) -> OnUpgrade {
-            self.body_mut().take_upgrade()
+            self.extensions_mut()
+                .remove::<OnUpgrade>()
+                .unwrap_or_else(OnUpgrade::none)
         }
     }
 }


### PR DESCRIPTION
Move OnUpgrade state from Body to http::Request/http::Response extensions.

Fixes #2340.