### PR TITLE
fix(client): drop HTTP_2 -> HTTP_11 coerce warning

### DIFF
--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -333,7 +333,7 @@ impl Http1Transaction for Server {
                 Version::HTTP_10 => extend(dst, b"HTTP/1.0 "),
                 Version::HTTP_11 => extend(dst, b"HTTP/1.1 "),
                 Version::HTTP_2 => {
-                    warn!("response with HTTP2 version coerced to HTTP/1.1");
+                    debug!("response with HTTP2 version coerced to HTTP/1.1");
                     extend(dst, b"HTTP/1.1 ");
                 }
                 other => panic!("unexpected response version: {:?}", other),
@@ -757,7 +757,7 @@ impl Http1Transaction for Client {
             Version::HTTP_10 => extend(dst, b"HTTP/1.0"),
             Version::HTTP_11 => extend(dst, b"HTTP/1.1"),
             Version::HTTP_2 => {
-                warn!("request with HTTP2 version coerced to HTTP/1.1");
+                debug!("request with HTTP2 version coerced to HTTP/1.1");
                 extend(dst, b"HTTP/1.1");
             }
             other => panic!("unexpected request version: {:?}", other),


### PR DESCRIPTION
We use hyper in a proxy-like way where an incoming HTTP/2 request is
proxied to a HTTP/1 backend and it was reported that the warnings
were a limiting factor in the total throughput of the system.

While it can be worked around by explicitly setting the request version
to HTTP_11, it seems likely other people will hit this performance snag,
and I don't see much value in warning for this particular condition, so
I suggest removing them.