### PR TITLE
fix(h1): ignore chunked trailers

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -431,6 +431,69 @@ test! {
 }
 
 test! {
+    name: client_get_req_body_chunked_with_trailer,
+
+    server:
+        expected: "\
+            GET / HTTP/1.1\r\n\
+            host: {addr}\r\n\
+            \r\n\
+            ",
+        reply: "\
+            HTTP/1.1 200 OK\r\n\
+            Transfer-Encoding: chunked\r\n\
+            \r\n\
+            5\r\n\
+            hello\r\n\
+            0\r\n\
+            Trailer: value\r\n\
+            \r\n\
+            ",
+
+    client:
+        request: {
+            method: GET,
+            url: "http://{addr}/",
+        },
+        response:
+            status: OK,
+            headers: {},
+            body: &b"hello"[..],
+}
+
+test! {
+    name: client_get_req_body_chunked_with_multiple_trailers,
+
+    server:
+        expected: "\
+            GET / HTTP/1.1\r\n\
+            host: {addr}\r\n\
+            \r\n\
+            ",
+        reply: "\
+            HTTP/1.1 200 OK\r\n\
+            Transfer-Encoding: chunked\r\n\
+            \r\n\
+            5\r\n\
+            hello\r\n\
+            0\r\n\
+            Trailer: value\r\n\
+            another-trainer: another-value\r\n\
+            \r\n\
+            ",
+
+    client:
+        request: {
+            method: GET,
+            url: "http://{addr}/",
+        },
+        response:
+            status: OK,
+            headers: {},
+            body: &b"hello"[..],
+}
+
+test! {
     name: client_get_req_body_sized,
 
     server:


### PR DESCRIPTION
Previously, hyper returned an "Invalid chunk end CR" error on chunked
responses with trailers, as described in RFC 7230 Section 4.1.2. This
commit adds code to ignore the trailers.

Closes #2171

