### PR TITLE
fix(http2): Ignore request body when the method has no defined payload semantics

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -334,6 +334,13 @@ t! {
 }
 
 t! {
-    http2_parallel_10,
-    parallel: 0..10
+    http2_parallel_get_10,
+    parallel: 0..10,
+    method: "GET",
+}
+
+t! {
+    http2_parallel_post_10,
+    parallel: 0..10,
+    method: "POST",
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -20,7 +20,8 @@ pub use std::net::SocketAddr;
 macro_rules! t {
     (
         $name:ident,
-        parallel: $range:expr
+        parallel: $range:expr,
+        method: $method:expr,
     ) => (
         #[test]
         fn $name() {
@@ -32,7 +33,8 @@ macro_rules! t {
                 c.push((
                     __CReq {
                         uri: "/",
-                        body: vec![b'x'; 8192],
+                        body: if $method == "GET" { Vec::new() } else { vec![b'x'; 8192] },
+                        method: $method,
                         ..Default::default()
                     },
                     __CRes {
@@ -43,7 +45,8 @@ macro_rules! t {
                 s.push((
                     __SReq {
                         uri: "/",
-                        body: vec![b'x'; 8192],
+                        body: if $method == "GET" { Vec::new() } else { vec![b'x'; 8192] },
+                        method: $method,
                         ..Default::default()
                     },
                     __SRes {


### PR DESCRIPTION
Fixes #2279

- Assume end of stream when the request method is GET, HEAD, CONNECT or DELETE.
- Also noticed that the `http2_parallel_10` integration test case sends a request body in a GET request as it started to fail after my change. So I split it into two test cases, a GET without body and a POST with body.