### PR TITLE
Minimize the amount of instantiated code

### DIFF
--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -63,6 +63,32 @@ impl Default for Config {
     }
 }
 
+fn new_builder(config: &Config) -> Builder {
+    let mut builder = Builder::default();
+    builder
+        .initial_window_size(config.initial_stream_window_size)
+        .initial_connection_window_size(config.initial_conn_window_size)
+        .max_frame_size(config.max_frame_size)
+        .enable_push(false);
+    builder
+}
+
+fn new_ping_config(config: &Config) -> ping::Config {
+    ping::Config {
+        bdp_initial_window: if config.adaptive_window {
+            Some(config.initial_stream_window_size)
+        } else {
+            None
+        },
+        #[cfg(feature = "runtime")]
+        keep_alive_interval: config.keep_alive_interval,
+        #[cfg(feature = "runtime")]
+        keep_alive_timeout: config.keep_alive_timeout,
+        #[cfg(feature = "runtime")]
+        keep_alive_while_idle: config.keep_alive_while_idle,
+    }
+}
+
 pub(crate) async fn handshake<T, B>(
     io: T,
     req_rx: ClientRx<B>,
@@ -74,11 +100,7 @@ where
     B: HttpBody,
     B::Data: Send + 'static,
 {
-    let (h2_tx, mut conn) = Builder::default()
-        .initial_window_size(config.initial_stream_window_size)
-        .initial_connection_window_size(config.initial_conn_window_size)
-        .max_frame_size(config.max_frame_size)
-        .enable_push(false)
+    let (h2_tx, mut conn) = new_builder(config)
         .handshake::<_, SendBuf<B::Data>>(io)
         .await
         .map_err(crate::Error::new_h2)?;
@@ -96,19 +118,7 @@ where
         }
     });
 
-    let ping_config = ping::Config {
-        bdp_initial_window: if config.adaptive_window {
-            Some(config.initial_stream_window_size)
-        } else {
-            None
-        },
-        #[cfg(feature = "runtime")]
-        keep_alive_interval: config.keep_alive_interval,
-        #[cfg(feature = "runtime")]
-        keep_alive_timeout: config.keep_alive_timeout,
-        #[cfg(feature = "runtime")]
-        keep_alive_while_idle: config.keep_alive_while_idle,
-    };
+    let ping_config = new_ping_config(&config);
 
     let (conn, ping) = if ping_config.is_enabled() {
         let pp = conn.ping_pong().expect("conn.ping_pong");


### PR DESCRIPTION
Companion to https://github.com/hyperium/h2/pull/503 which does not manage to improve things as much  (421370 / 433142 = 0.97282184595).

There could be more gains here but it would require more invasive changes as a lot more functions ends up getting parametrized by `T: AsyncRead + AsyncWrite` which ends up beeing `AddrStream` for servers and `TcpStream` for clients. This seems possible to change to `TcpStream` for servers as well though, at least for simple setups as hyper itself never uses the `AddrStream` wrapper. However that is a breaking change and in uses where you more manually construct the server `AddrStream` may then be useful again (I have gotten the code down to 407528 / 433142 = 0.9408646587 in a branch which changes this).

```
cargo llvm-lines --release --example http_proxy --features=full | tee ../llvm-lines | sponge | head -50
```

## Before
```
  Lines          Copies        Function name
  -----          ------        -------------
  433142 (100%)  13492 (100%)  (TOTAL)
   23082 (5.3%)   1480 (11.0%) core::ptr::drop_in_place
   11690 (2.7%)    263 (1.9%)  tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
   11142 (2.6%)      2 (0.0%)  h2::codec::framed_read::FramedRead<T>::decode_frame
    6820 (1.6%)    157 (1.2%)  tokio::loom::std::unsafe_cell::UnsafeCell<T>::with
    6336 (1.5%)     24 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::poll
    5928 (1.4%)    112 (0.8%)  core::ptr::swap_nonoverlapping_one
    5700 (1.3%)      2 (0.0%)  h2::proto::connection::Connection<T,P,B>::poll2
    3925 (0.9%)     71 (0.5%)  alloc::alloc::box_free
    3792 (0.9%)      2 (0.0%)  h2::codec::framed_write::FramedWrite<T,B>::buffer
    3688 (0.9%)     25 (0.2%)  <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll
    3550 (0.8%)    175 (1.3%)  core::ptr::read
    3548 (0.8%)      2 (0.0%)  h2::proto::connection::Connection<T,P,B>::poll
    3312 (0.8%)     24 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::try_read_output
    3198 (0.7%)      2 (0.0%)  h2::codec::framed_write::FramedWrite<T,B>::flush
    3096 (0.7%)     24 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::cancel_task
    2973 (0.7%)     48 (0.4%)  core::result::Result<T,E>::map_err
    2904 (0.7%)     24 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::complete
    2895 (0.7%)    102 (0.8%)  core::mem::replace
    2880 (0.7%)     48 (0.4%)  std::panicking::try
    2610 (0.6%)      2 (0.0%)  hyper::proto::h1::dispatch::Dispatcher<D,Bs,I,T>::poll_write
    2520 (0.6%)     24 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::poll::{{closure}}
    2340 (0.5%)      1 (0.0%)  hyper::client::connect::http::HttpConnector<R>::call_async::{{closure}}
    2304 (0.5%)     12 (0.1%)  h2::codec::framed_read::FramedRead<T>::decode_frame::{{closure}}
    2301 (0.5%)     39 (0.3%)  core::pin::Pin<P>::set
    2232 (0.5%)     48 (0.4%)  tokio::runtime::task::harness::Harness<T,S>::set_join_waker::{{closure}}
    2177 (0.5%)      1 (0.0%)  h2::proto::streams::prioritize::Prioritize::pop_frame
    2110 (0.5%)     38 (0.3%)  <alloc::sync::Weak<T> as core::ops::drop::Drop>::drop
    2010 (0.5%)      2 (0.0%)  hyper::proto::h1::conn::Conn<I,B,T>::poll_read_body
    1968 (0.5%)     24 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::set_join_waker
    1926 (0.4%)     34 (0.3%)  alloc::boxed::Box<T,A>::into_unique
    1836 (0.4%)      2 (0.0%)  <h2::codec::framed_read::FramedRead<T> as futures_core::stream::Stream>::poll_next
    1806 (0.4%)      1 (0.0%)  hyper::client::connect::http::ConnectingTcpRemote::connect::{{closure}}
    1776 (0.4%)      2 (0.0%)  h2::proto::streams::streams::Streams<B,P>::recv_push_promise
    1709 (0.4%)    179 (1.3%)  core::mem::maybe_uninit::MaybeUninit<T>::assume_init
    1699 (0.4%)      1 (0.0%)  <hyper::proto::h2::client::ClientTask<B> as core::future::future::Future>::poll
    1694 (0.4%)      2 (0.0%)  hyper::proto::h1::dispatch::Dispatcher<D,Bs,I,T>::poll_read
    1662 (0.4%)     81 (0.6%)  core::ops::function::FnOnce::call_once
    1662 (0.4%)      2 (0.0%)  h2::proto::streams::streams::Streams<B,P>::recv_headers
    1662 (0.4%)      2 (0.0%)  hyper::proto::h1::conn::Conn<I,B,T>::require_empty_read
    1642 (0.4%)      2 (0.0%)  hyper::proto::h1::decode::Decoder::decode
    1636 (0.4%)      2 (0.0%)  h2::proto::streams::prioritize::Prioritize::poll_complete
    1634 (0.4%)      2 (0.0%)  hyper::proto::h1::dispatch::Dispatcher<D,Bs,I,T>::poll_read_head
    1598 (0.4%)      2 (0.0%)  hyper::proto::h2::client::conn_task::{{closure}}
    1573 (0.4%)     21 (0.2%)  h2::proto::streams::counts::Counts::transition
    1560 (0.4%)     24 (0.2%)  tokio::runtime::task::raw::RawTask::new
    1552 (0.4%)     38 (0.3%)  alloc::sync::Weak<T>::inner
    1548 (0.4%)      2 (0.0%)  h2::proto::streams::streams::Streams<B,P>::recv_data
```

## After
```
  Lines          Copies        Function name
  -----          ------        -------------
  421370 (100%)  13075 (100%)  (TOTAL)
   22500 (5.3%)   1445 (11.1%) core::ptr::drop_in_place
   11142 (2.6%)      2 (0.0%)  h2::codec::framed_read::FramedRead<T>::decode_frame
   10798 (2.6%)    243 (1.9%)  tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
    6296 (1.5%)    145 (1.1%)  tokio::loom::std::unsafe_cell::UnsafeCell<T>::with
    5808 (1.4%)     22 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::poll
    5771 (1.4%)    109 (0.8%)  core::ptr::swap_nonoverlapping_one
    5700 (1.4%)      2 (0.0%)  h2::proto::connection::Connection<T,P,B>::poll2
    3823 (0.9%)     69 (0.5%)  alloc::alloc::box_free
    3792 (0.9%)      2 (0.0%)  h2::codec::framed_write::FramedWrite<T,B>::buffer
    3548 (0.8%)      2 (0.0%)  h2::proto::connection::Connection<T,P,B>::poll
    3546 (0.8%)     24 (0.2%)  <futures_util::future::future::map::Map<Fut,F> as core::future::future::Future>::poll
    3414 (0.8%)    168 (1.3%)  core::ptr::read
    3198 (0.8%)      2 (0.0%)  h2::codec::framed_write::FramedWrite<T,B>::flush
    3036 (0.7%)     22 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::try_read_output
    2915 (0.7%)     47 (0.4%)  core::result::Result<T,E>::map_err
    2838 (0.7%)     22 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::cancel_task
    2813 (0.7%)     99 (0.8%)  core::mem::replace
    2662 (0.6%)     22 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::complete
    2640 (0.6%)     44 (0.3%)  std::panicking::try
    2610 (0.6%)      2 (0.0%)  hyper::proto::h1::dispatch::Dispatcher<D,Bs,I,T>::poll_write
    2310 (0.5%)     22 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::poll::{{closure}}
    2304 (0.5%)     12 (0.1%)  h2::codec::framed_read::FramedRead<T>::decode_frame::{{closure}}
    2242 (0.5%)     38 (0.3%)  core::pin::Pin<P>::set
    2177 (0.5%)      1 (0.0%)  h2::proto::streams::prioritize::Prioritize::pop_frame
    2110 (0.5%)     38 (0.3%)  <alloc::sync::Weak<T> as core::ops::drop::Drop>::drop
    2046 (0.5%)     44 (0.3%)  tokio::runtime::task::harness::Harness<T,S>::set_join_waker::{{closure}}
    2010 (0.5%)      2 (0.0%)  hyper::proto::h1::conn::Conn<I,B,T>::poll_read_body
    1836 (0.4%)      2 (0.0%)  <h2::codec::framed_read::FramedRead<T> as futures_core::stream::Stream>::poll_next
    1818 (0.4%)     32 (0.2%)  alloc::boxed::Box<T,A>::into_unique
    1806 (0.4%)      1 (0.0%)  hyper::client::connect::http::ConnectingTcpRemote::connect::{{closure}}
    1804 (0.4%)     22 (0.2%)  tokio::runtime::task::harness::Harness<T,S>::set_join_waker
    1776 (0.4%)      2 (0.0%)  h2::proto::streams::streams::Streams<B,P>::recv_push_promise
    1699 (0.4%)      1 (0.0%)  <hyper::proto::h2::client::ClientTask<B> as core::future::future::Future>::poll
    1694 (0.4%)      2 (0.0%)  hyper::proto::h1::dispatch::Dispatcher<D,Bs,I,T>::poll_read
    1662 (0.4%)      2 (0.0%)  h2::proto::streams::streams::Streams<B,P>::recv_headers
    1662 (0.4%)      2 (0.0%)  hyper::proto::h1::conn::Conn<I,B,T>::require_empty_read
    1648 (0.4%)    172 (1.3%)  core::mem::maybe_uninit::MaybeUninit<T>::assume_init
    1642 (0.4%)      2 (0.0%)  hyper::proto::h1::decode::Decoder::decode
    1636 (0.4%)      2 (0.0%)  h2::proto::streams::prioritize::Prioritize::poll_complete
    1634 (0.4%)      2 (0.0%)  hyper::proto::h1::dispatch::Dispatcher<D,Bs,I,T>::poll_read_head
    1614 (0.4%)      1 (0.0%)  hyper::client::connect::http::HttpConnector<R>::call_async::{{closure}}
    1573 (0.4%)     21 (0.2%)  h2::proto::streams::counts::Counts::transition
    1552 (0.4%)     38 (0.3%)  alloc::sync::Weak<T>::inner
    1548 (0.4%)     77 (0.6%)  core::ops::function::FnOnce::call_once
    1548 (0.4%)      2 (0.0%)  h2::proto::streams::streams::Streams<B,P>::recv_data
    1450 (0.3%)      1 (0.0%)  h2::client::Connection<T,B>::handshake2::{{closure}}
    1436 (0.3%)      2 (0.0%)  hyper::proto::h1::io::Buffered<T,B>::parse
```