### PR TITLE
feat(body): reexport http_body::SizeHint

### DIFF
--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -17,6 +17,7 @@
 
 pub use bytes::{Buf, Bytes};
 pub use http_body::Body as HttpBody;
+pub use http_body::SizeHint;
 
 pub use self::aggregate::aggregate;
 pub use self::body::{Body, Sender};


### PR DESCRIPTION
Fix a minor papercut: you can't implement `hyper::body::HttpBody::size_hint` without importing `SizeHint` from another crate.

