### PR TITLE
Remove useless uses of Pin

### DIFF
--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -213,7 +213,7 @@ where
                 }
             };
 
-            match Pin::new(&mut self.req_rx).poll_next(cx) {
+            match self.req_rx.poll_recv(cx) {
                 Poll::Ready(Some((req, cb))) => {
                     // check that future hasn't been canceled already
                     if cb.is_canceled() {


### PR DESCRIPTION
While looking further into #2388 I noticed `UnboundedReceiver` was getting pinned even though [`UnboundedReceiver::poll_recv`](https://docs.rs/tokio/1.0.2/tokio/sync/mpsc/struct.UnboundedReceiver.html#method.poll_recv) takes `&mut self`. This detail was probably missed in the migration from tokio 0.3, which [previously used `Stream::poll_next`](https://github.com/hyperium/hyper/pull/2369/files#diff-414def8886b02bb26f69e6e93e08fa35e230e7faf2b37cf1614cdf58fe987a5dL153-R154), but can now be applied, unblocking #2393.