### PR TITLE
docs(client): fix typo in httpbin.org domain

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -147,7 +147,7 @@ where
     ///
     /// let req = Request::builder()
     ///     .method("POST")
-    ///     .uri("http://httpin.org/post")
+    ///     .uri("http://httpbin.org/post")
     ///     .body(Body::from("Hallo!"))
     ///     .expect("request builder");
     ///


### PR DESCRIPTION
Saving the next dev that copy pastes this example from banging their head trying to figure out what's wrong with their DNS 😁