### PR TITLE
fix(examples): updated imports in examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,7 @@ matches = "0.1"
 num_cpus = "1.0"
 pretty_env_logger = "0.4"
 spmc = "0.3"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = [
     "fs",

--- a/examples/client_json.rs
+++ b/examples/client_json.rs
@@ -1,11 +1,9 @@
 #![deny(warnings)]
 #![warn(rust_2018_idioms)]
 
-#[macro_use]
-extern crate serde_derive;
-
-use bytes::Buf as _;
+use hyper::body::Buf;
 use hyper::Client;
+use serde::Deserialize;
 
 // A simple type alias so as to DRY.
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;


### PR DESCRIPTION
- remove ```extern crate``` import to comply with 2018 edition
- change from ```use bytes::Buf``` to ```use hyper::body::Buf```, remove one extra import of the bytes module
