### PR TITLE
docs(lib): Warn about no length check

### DIFF
--- a/src/body/aggregate.rs
+++ b/src/body/aggregate.rs
@@ -7,6 +7,12 @@ use crate::common::buf::BufList;
 ///
 /// The returned `impl Buf` groups the `Buf`s from the `HttpBody` without
 /// copying them. This is ideal if you don't require a contiguous buffer.
+///
+/// # Note
+///
+/// Care needs to be taken if the remote is untrusted. The function doesn't implement any length
+/// checks and an malicious peer might make it consume arbitrary amounts of memory. Checking the
+/// `Content-Length` is a possibility, but it is not strictly mandated to be present.
 pub async fn aggregate<T>(body: T) -> Result<impl Buf, T::Error>
 where
     T: HttpBody,

--- a/src/body/to_bytes.rs
+++ b/src/body/to_bytes.rs
@@ -7,6 +7,12 @@ use super::HttpBody;
 /// This may require copying the data into a single buffer. If you don't need
 /// a contiguous buffer, prefer the [`aggregate`](crate::body::aggregate())
 /// function.
+///
+/// # Note
+///
+/// Care needs to be taken if the remote is untrusted. The function doesn't implement any length
+/// checks and an malicious peer might make it consume arbitrary amounts of memory. Checking the
+/// `Content-Length` is a possibility, but it is not strictly mandated to be present.
 pub async fn to_bytes<T>(body: T) -> Result<Bytes, T::Error>
 where
     T: HttpBody,


### PR DESCRIPTION
The to_bytes and aggregate don't check how long the body is, so the user
better be aware.

Relates to #2414.

