### PR TITLE
chore(ci): use --feature-powerset --depth 2 in features check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -111,8 +111,8 @@ jobs:
       - name: Install cargo-hack
         run: cargo install cargo-hack
 
-      - name: check --each-feature
-        run: cargo hack check --each-feature --skip ffi -Z avoid-dev-deps
+      - name: check --feature-powerset
+        run: cargo hack check --feature-powerset --depth 2 --skip ffi -Z avoid-dev-deps
 
   ffi:
     name: Test C API (FFI)


### PR DESCRIPTION
This allows catching the issue like https://github.com/hyperium/hyper/issues/2421.

> > _also_ our CI didn't notice the failure of combining `--features http1,client,server`.
>
> This can be fixed by using `cargo hack --feature-powerset` ([all combination of features](https://github.com/taiki-e/cargo-hack#--feature-powerset)) instead of `cargo hack --each-feature` ([each feature](https://github.com/taiki-e/cargo-hack#--each-feature)) in CI. 
> However, if we use `--feature-powerset`, there will be more than 700 feature combinations, so we may need to use `--depth` ([specify a max number of simultaneous feature flags of --feature-powerset](https://github.com/taiki-e/cargo-hack/issues/58)) flag to limit the number of combinations.

We have too many features to check the full powerset (776), so limit the max number of simultaneous feature flags to 2 by [`--depth` option](https://github.com/taiki-e/cargo-hack/pull/59). I think this should be sufficient in most cases as carllerche said in https://github.com/taiki-e/cargo-hack/issues/58.

> Tokio has too many features to test the power set. However, **most** issues can be reproduced by testing at most 2 features simultaneously.

In fact, #2421 can be reproduced with a combination of two feature flags. (--features client,http1)