### PR TITLE
docs(server): use cfg_feature! on hyper::server::conn::tcp instead of #[cfg]

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -61,6 +61,10 @@ cfg_feature! {
     pub mod conn;
     mod server;
     mod shutdown;
-    #[cfg(feature = "tcp")]
-    mod tcp;
+
+    cfg_feature! {
+        #![feature = "tcp"]
+
+        mod tcp;
+    }
 }


### PR DESCRIPTION
This is required to surface the required feature (`tcp`) in the generated docs
for `hyper::server::conn::{AddrIncoming, AddrStream}`. Before this change,
their docs only mentioned the features needed for the `hyper::server::conn` mod
itself.

Fixes #2425

