### PR TITLE
Backport fix for multiple Transfer-Encoding to 0.12 branch

### DIFF
--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -170,6 +170,8 @@ impl Http1Transaction for Server {
                     if headers::is_chunked_(&value) {
                         is_te_chunked = true;
                         decoder = DecodedLength::CHUNKED;
+                    } else {
+                        is_te_chunked = false;
                     }
                 },
                 header::CONTENT_LENGTH => {
@@ -1226,6 +1228,15 @@ mod tests {
             \r\n\
         ", "transfer-encoding doesn't end in chunked");
 
+        parse_err(
+            "\
+             POST / HTTP/1.1\r\n\
+             transfer-encoding: chunked\r\n\
+             transfer-encoding: afterlol\r\n\
+             \r\n\
+             ",
+            "transfer-encoding multiple lines doesn't end in chunked",
+        );
 
         // http/1.0
 


### PR DESCRIPTION
This PR backports https://github.com/hyperium/hyper/commit/8f93123efef5c1361086688fe4f34c83c89cec02 to 0.12, which is the first affected branch (but fix was made and released for 0.13+).

I know it's old and unmaintained, and don't really expect a new release, but we still use it in some LTS products. If it's still used elsewhere it may make more sense to share the backports here than to do it in a private fork.