### PR TITLE
feat(tcp): add support for custom socket options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ want = "0.3"
 # Optional
 
 libc = { version = "0.2", optional = true }
-socket2 = { version = "0.3.16", optional = true }
+socket2 = { version = "0.3.16", optional = true, features = ["reuseport"] }
 
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
This change extends to AddrIncoming API to support setting custom
options before binding the server socket.  This change introduces one
such option: `reuse_port`, which enables the `SO_REUSEPORT` option on
the socket on UNIX platforms.

Example:

    use hyper::server::conn::{AddrIncoming, SocketOptions};
    let incoming = AddrIncoming::bind_with_option(
        "0.0.0.0:80".parse().unwrap(),
        SocketOptions::new().reuse_port(true)
    );

