### PR TITLE
feat(h2): log negotiated concurrency limits at DEBUG

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ http = "0.2"
 http-body = "0.4"
 httpdate = "0.3"
 httparse = "1.0"
-h2 = { version = "0.3", optional = true }
+h2 = { version = "0.3.1", optional = true }
 itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 pin-project = "1.0"

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -7,6 +7,7 @@ use futures_util::future::{self, Either, FutureExt as _, TryFutureExt as _};
 use futures_util::stream::StreamExt as _;
 use h2::client::{Builder, SendRequest};
 use tokio::io::{AsyncRead, AsyncWrite};
+use tracing::debug;
 
 use super::{decode_content_length, ping, PipeToSendStream, SendBuf};
 use crate::body::HttpBody;
@@ -104,6 +105,11 @@ where
         .handshake::<_, SendBuf<B::Data>>(io)
         .await
         .map_err(crate::Error::new_h2)?;
+
+    debug!(
+        server.max_concurrent_send_streams = conn.max_concurrent_send_streams(),
+        "HTTP/2 handshake complete"
+    );
 
     // An mpsc channel is used entirely to detect when the
     // 'Client' has been dropped. This is to get around a bug

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -7,6 +7,7 @@ use h2::server::{Connection, Handshake, SendResponse};
 use h2::Reason;
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tracing::debug;
 
 use super::{decode_content_length, ping, PipeToSendStream, SendBuf};
 use crate::body::HttpBody;
@@ -175,6 +176,10 @@ where
                     ref ping_config,
                 } => {
                     let mut conn = ready!(Pin::new(hs).poll(cx).map_err(crate::Error::new_h2))?;
+                    debug!(
+                        client.max_concurrent_recv_streams = conn.max_concurrent_recv_streams(),
+                        "HTTP/2 handshake complete"
+                    );
                     let ping = if ping_config.is_enabled() {
                         let pp = conn.ping_pong().expect("conn.ping_pong");
                         Some(ping::channel(pp, ping_config.clone()))


### PR DESCRIPTION
Upstream PRs hyperium/h2#513 and hyperium/h2#516 added functions for
exposing the connection concurrency limits negotiated by a remote peer.
Recording these settings can be useful for debugging purposes.

In the higher-level `Client` and `Server` APIs, it's not easily possible to
provide a way for users to directly access settings on a particular
connection, since the client abstracts over a connection pool and the
server abstracts over a connect loop. Therefore, the user can't access
these settings directly. Instead, this branch adds new log messages at
the DEBUG level for recording negotiated concurrency limits.

In a follow-up, we can also add accessors to the `Connection` types in
the lower-level `client::conn` and `server::conn` APIs.

