### PR TITLE
Body docs: Link to to_bytes and aggregate

### DIFF
--- a/src/body/body.rs
+++ b/src/body/body.rs
@@ -29,6 +29,9 @@ type TrailersSender = oneshot::Sender<HeaderMap>;
 ///
 /// A good default [`HttpBody`](crate::body::HttpBody) to use in many
 /// applications.
+///
+/// Note: To read the full body, use [`body::to_bytes`](crate::body::to_bytes)
+/// or [`body::aggregate`](crate::body::aggregate).
 #[must_use = "streams do nothing unless polled"]
 pub struct Body {
     kind: Kind,


### PR DESCRIPTION
Since these two functions are not methods on the `Body`, they aren't very discoverable. So a note in the docs would definitely be helpful.

![2021-03-13-191948_605x192_scrot](https://user-images.githubusercontent.com/105168/111039945-1a091980-8431-11eb-894b-257d6c0a81f9.png)
