### PR TITLE
Introduce Error::is_header_section_too_large (fixes #2462)

### DIFF
--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -43,7 +43,7 @@ impl DecodedLength {
             Ok(DecodedLength(len))
         } else {
             warn!("content-length bigger than maximum: {} > {}", len, MAX_LEN);
-            Err(crate::error::Parse::TooLarge)
+            Err(crate::error::Parse::HeaderSectionTooLarge)
         }
     }
 

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -18,7 +18,7 @@ pub(crate) const INIT_BUFFER_SIZE: usize = 8192;
 pub(crate) const MINIMUM_MAX_BUFFER_SIZE: usize = INIT_BUFFER_SIZE;
 
 /// The default maximum read buffer size. If the buffer gets this big and
-/// a message is still not complete, a `TooLarge` error is triggered.
+/// a message is still not complete, a `HeaderSectionTooLarge` error is triggered.
 // Note: if this changes, update server::conn::Http::max_buf_size docs.
 pub(crate) const DEFAULT_MAX_BUFFER_SIZE: usize = 8192 + 4096 * 100;
 
@@ -172,7 +172,7 @@ where
                     let max = self.read_buf_strategy.max();
                     if self.read_buf.len() >= max {
                         debug!("max_buf_size ({}) reached, closing", max);
-                        return Poll::Ready(Err(crate::Error::new_too_large()));
+                        return Poll::Ready(Err(crate::Error::new_header_section_too_large()));
                     }
                 }
             }

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -609,7 +609,7 @@ impl Http1Transaction for Server {
             | Kind::Parse(Parse::Header)
             | Kind::Parse(Parse::Uri)
             | Kind::Parse(Parse::Version) => StatusCode::BAD_REQUEST,
-            Kind::Parse(Parse::TooLarge) => StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
+            Kind::Parse(Parse::HeaderSectionTooLarge) => StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
             _ => return None,
         };
 
@@ -1097,7 +1097,7 @@ fn record_header_indices(
     for (header, indices) in headers.iter().zip(indices.iter_mut()) {
         if header.name.len() >= (1 << 16) {
             debug!("header name larger than 64kb: {:?}", header.name);
-            return Err(crate::error::Parse::TooLarge);
+            return Err(crate::error::Parse::HeaderSectionTooLarge);
         }
         let name_start = header.name.as_ptr() as usize - bytes_ptr;
         let name_end = name_start + header.name.len();

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1567,7 +1567,7 @@ async fn max_buf_size() {
         .max_buf_size(MAX)
         .serve_connection(socket, HelloWorld)
         .await
-        .expect_err("should TooLarge error");
+        .expect_err("should HeaderSectionTooLarge error");
 }
 
 #[cfg(feature = "stream")]


### PR DESCRIPTION
We rename Parse::TooLarge into Parse::HeaderSectionTooLarge while at it.

