### PR TITLE
Allow HTTP/0.9 responses behind a flag (fixes #2468)

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -972,6 +972,14 @@ impl Builder {
         self
     }
 
+    /// Set whether HTTP/0.9 responses should be tolerated.
+    ///
+    /// Default is false.
+    pub fn http09_responses(&mut self, val: bool) -> &mut Self {
+        self.conn_builder.h09_responses(val);
+        self
+    }
+
     /// Set whether the connection **must** use HTTP/2.
     ///
     /// The destination must either allow HTTP2 Prior Knowledge, or the

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -122,6 +122,7 @@ where
 #[derive(Clone, Debug)]
 pub struct Builder {
     pub(super) exec: Exec,
+    h09_responses: bool,
     h1_title_case_headers: bool,
     h1_read_buf_exact_size: Option<usize>,
     h1_max_buf_size: Option<usize>,
@@ -493,6 +494,7 @@ impl Builder {
     pub fn new() -> Builder {
         Builder {
             exec: Exec::Default,
+            h09_responses: false,
             h1_read_buf_exact_size: None,
             h1_title_case_headers: false,
             h1_max_buf_size: None,
@@ -511,6 +513,11 @@ impl Builder {
         E: Executor<BoxSendFuture> + Send + Sync + 'static,
     {
         self.exec = Exec::Executor(Arc::new(exec));
+        self
+    }
+
+    pub(super) fn h09_responses(&mut self, enabled: bool) -> &mut Builder {
+        self.h09_responses = enabled;
         self
     }
 
@@ -699,6 +706,9 @@ impl Builder {
                     let mut conn = proto::Conn::new(io);
                     if opts.h1_title_case_headers {
                         conn.set_title_case_headers();
+                    }
+                    if opts.h09_responses {
+                        conn.set_h09_responses();
                     }
                     if let Some(sz) = opts.h1_read_buf_exact_size {
                         conn.set_read_buf_exact_size(sz);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/hyper/0.14.4")]
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(rust_2018_idioms))]

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -161,6 +161,7 @@ where
                     req_method: parse_ctx.req_method,
                     #[cfg(feature = "ffi")]
                     preserve_header_case: parse_ctx.preserve_header_case,
+                    h09_responses: parse_ctx.h09_responses,
                 },
             )? {
                 Some(msg) => {
@@ -640,6 +641,7 @@ mod tests {
                 req_method: &mut None,
                 #[cfg(feature = "ffi")]
                 preserve_header_case: false,
+                h09_responses: false,
             };
             assert!(buffered
                 .parse::<ClientTransaction>(cx, parse_ctx)

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -72,6 +72,7 @@ pub(crate) struct ParseContext<'a> {
     req_method: &'a mut Option<Method>,
     #[cfg(feature = "ffi")]
     preserve_header_case: bool,
+    h09_responses: bool,
 }
 
 /// Passed to Http1Transaction::encode


### PR DESCRIPTION
The two first commits work around some issues I had with VS Code and rust-analyzer.