### PR TITLE
fix(http1): http1_title_case_headers should move Builder

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -239,7 +239,7 @@ impl<I, E> Builder<I, E> {
     /// Default is false.
     #[cfg(feature = "http1")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
-    pub fn http1_title_case_headers(&mut self, val: bool) -> &mut Self {
+    pub fn http1_title_case_headers(mut self, val: bool) -> Self {
         self.protocol.http1_title_case_headers(val);
         self
     }


### PR DESCRIPTION
ref #2480 

@seanmonstar It was released in v0.14.6. Consider making a v0.14.7 and yank it. 😅