### PR TITLE
docs(headers) no_inline doc on HeaderMap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,10 @@ extern crate tracing;
 #[cfg(all(test, feature = "nightly"))]
 extern crate test;
 
-pub use http::{header, HeaderMap, Method, Request, Response, StatusCode, Uri, Version};
+pub use crate::http::{header, Method, Request, Response, StatusCode, Uri, Version};
+
+#[doc(no_inline)]
+pub use crate::http::HeaderMap;
 
 pub use crate::body::Body;
 pub use crate::error::{Error, Result};


### PR DESCRIPTION
Need to use no_inline doc to fix broken links

https://github.com/hyperium/http/blob/1179d6fa90fc6d680c718450b18f223cb0b25aeb/src/lib.rs#L187