### PR TITLE
feat(http2): allow HTTP/2 requests by ALPN when http2_only is unset

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -167,11 +167,7 @@ where
                     )));
                 }
             }
-            other_h2 @ Version::HTTP_2 => {
-                if self.config.ver != Ver::Http2 {
-                    return ResponseFuture::error_version(other_h2);
-                }
-            }
+            Version::HTTP_2 => (),
             // completely unsupported HTTP version (like HTTP/0.9)!
             other => return ResponseFuture::error_version(other),
         };
@@ -227,6 +223,13 @@ where
         let mut pooled = self.connection_for(pool_key).await?;
 
         if pooled.is_http1() {
+            if req.version() == Version::HTTP_2 {
+                warn!("Connection is HTTP/1, but request requires HTTP/2");
+                return Err(ClientError::Normal(
+                    crate::Error::new_user_unsupported_version(),
+                ));
+            }
+
             if self.config.set_host {
                 let uri = req.uri().clone();
                 req.headers_mut().entry(HOST).or_insert_with(|| {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2039,8 +2039,18 @@ mod dispatch_impl {
         // so the unwrapped responses futures show it still worked.
         assert_eq!(connects.load(Ordering::SeqCst), 3);
 
-        let res4 = client.get(url);
+        let res4 = client.get(url.clone());
         rt.block_on(res4).unwrap();
+
+        // HTTP/2 request allowed
+        let res5 = client.request(
+            Request::builder()
+                .uri(url)
+                .version(hyper::Version::HTTP_2)
+                .body(Default::default())
+                .unwrap(),
+        );
+        rt.block_on(res5).unwrap();
 
         assert_eq!(
             connects.load(Ordering::SeqCst),


### PR DESCRIPTION
Previously, Hyper would unconditionally reject requests with `Version::HTTP_2` if `http2_only(true)` was not provided when building the client. This change allows such requests to succeed as long as the underlying connection is actually negotiated as HTTP/2.