### PR TITLE
feat: Join headers from http/2 requests on http/1 connections

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2389,7 +2389,7 @@ mod conn {
             let n = sock.read(&mut buf).expect("read 1");
 
             // Not HTTP/2, nor panicked
-            let expected = "GET /a HTTP/1.1\r\n\r\n";
+            let expected = "GET /a HTTP/1.1\r\ncookie: a=b; c=d\r\n\r\n";
             assert_eq!(s(&buf[..n]), expected);
 
             sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
@@ -2406,6 +2406,8 @@ mod conn {
         let req = Request::builder()
             .uri("/a")
             .version(hyper::Version::HTTP_2)
+            .header(header::COOKIE, "a=b")
+            .header(header::COOKIE, "c=d")
             .body(Default::default())
             .unwrap();
 


### PR DESCRIPTION
Closes #2528.

Added a test for the function re-joining the headers, and extended the coercion integration test!