### PR TITLE
Allow to config h2 max concurrent reset streams.

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -1151,6 +1151,21 @@ impl Builder {
         self
     }
 
+    /// Sets the maximum number of HTTP2 concurrent locally reset streams.
+    ///
+    /// See the documentation of [`h2::client::Builder::max_concurrent_reset_streams`] for more
+    /// details.
+    ///
+    /// The default value is determined by the `h2` crate.
+    ///
+    /// [`h2::client::Builder::max_concurrent_reset_streams`]: https://docs.rs/h2/client/struct.Builder.html#method.max_concurrent_reset_streams
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_concurrent_reset_streams(&mut self, max: usize) -> &mut Self {
+        self.conn_builder.http2_max_concurrent_reset_streams(max);
+        self
+    }
+
     /// Set whether to retry requests that get disrupted before ever starting
     /// to write.
     ///

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -530,7 +530,8 @@ impl Builder {
         &mut self,
         enabled: bool,
     ) -> &mut Builder {
-        self.h1_parser_config.allow_spaces_after_header_name_in_responses(enabled);
+        self.h1_parser_config
+            .allow_spaces_after_header_name_in_responses(enabled);
         self
     }
 
@@ -698,6 +699,21 @@ impl Builder {
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_while_idle(&mut self, enabled: bool) -> &mut Self {
         self.h2_builder.keep_alive_while_idle = enabled;
+        self
+    }
+
+    /// Sets the maximum number of HTTP2 concurrent locally reset streams.
+    ///
+    /// See the documentation of [`h2::client::Builder::max_concurrent_reset_streams`] for more
+    /// details.
+    ///
+    /// The default value is determined by the `h2` crate.
+    ///
+    /// [`h2::client::Builder::max_concurrent_reset_streams`]: https://docs.rs/h2/client/struct.Builder.html#method.max_concurrent_reset_streams
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_concurrent_reset_streams(&mut self, max: usize) -> &mut Self {
+        self.h2_builder.max_concurrent_reset_streams = Some(max);
         self
     }
 


### PR DESCRIPTION
Setting streams to 0 makes h2 work on wasm platforms without `Instant::now` implementation.

Related to:

* https://github.com/hyperium/h2/pull/511
* https://github.com/hyperium/h2/pull/537