### PR TITLE
feat(error): add predicates for too-large and status parse errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -132,6 +132,17 @@ impl Error {
         matches!(self.inner.kind, Kind::Parse(_))
     }
 
+    /// Returns true if this was an HTTP parse error caused by a message that was too large.
+    pub fn is_parse_too_large(&self) -> bool {
+        matches!(self.inner.kind, Kind::Parse(Parse::TooLarge))
+    }
+
+    /// Returns true if this was an HTTP parse error caused by an invalid response status code or
+    /// reason phrase.
+    pub fn is_parse_status(&self) -> bool {
+        matches!(self.inner.kind, Kind::Parse(Parse::Status))
+    }
+
     /// Returns true if this error was caused by user code.
     pub fn is_user(&self) -> bool {
         matches!(self.inner.kind, Kind::User(_))


### PR DESCRIPTION
The discussion in #2462 opened up some larger questions about more comprehensive approaches to the error API, with the agreement that additional methods would be desirable in the short term. These methods address an immediate need of our customers, so I would like to get them in first before we flesh out a future solution.

One potentially controversial choice here is to still return `true` from `is_parse_error()` for these variants. I hope the naming of the methods make it clear that the new predicates are refinements of the existing one, but I didn't want to change the behavior of `is_parse_error()` which would require a major version bump.