### PR TITLE
feat(server): add server::Builder::serve_service

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -34,8 +34,40 @@
 //!     // Construct our SocketAddr to listen on...
 //!     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
 //!
+//!     // Then bind and serve...
+//!     let server = Server::bind(&addr).serve_service(service_fn(handle));
+//!
+//!     // And run forever...
+//!     if let Err(e) = server.await {
+//!         eprintln!("server error: {}", e);
+//!     }
+//! }
+//! # #[cfg(not(feature = "runtime"))]
+//! # fn main() {}
+//! ```
+//!
+//! If you need the incoming connection to handle the request you can use [`make_service_fn`] to
+//! create a [`Service`] on demand:
+//!
+//! ```no_run
+//! use std::convert::Infallible;
+//! use std::net::SocketAddr;
+//! use hyper::{Body, Request, Response, Server};
+//! use hyper::service::{make_service_fn, service_fn};
+//! use hyper::server::conn::AddrStream;
+//!
+//! async fn handle(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
+//!     Ok(Response::new(Body::from("Hello World")))
+//! }
+//!
+//! # #[cfg(feature = "runtime")]
+//! #[tokio::main]
+//! async fn main() {
+//!     // Construct our SocketAddr to listen on...
+//!     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+//!
 //!     // And a MakeService to handle each connection...
-//!     let make_service = make_service_fn(|_conn| async {
+//!     let make_service = make_service_fn(|conn: &AddrStream| async {
 //!         Ok::<_, Infallible>(service_fn(handle))
 //!     });
 //!
@@ -51,40 +83,9 @@
 //! # fn main() {}
 //! ```
 //!
-//! If you don't need the connection and your service implements `Clone` you can use
-//! [`tower::make::Shared`] instead of `make_service_fn` which is a bit simpler:
-//!
-//! ```no_run
-//! # use std::convert::Infallible;
-//! # use std::net::SocketAddr;
-//! # use hyper::{Body, Request, Response, Server};
-//! # use hyper::service::{make_service_fn, service_fn};
-//! # use tower::make::Shared;
-//! # async fn handle(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
-//! #     Ok(Response::new(Body::from("Hello World")))
-//! # }
-//! # #[cfg(feature = "runtime")]
-//! #[tokio::main]
-//! async fn main() {
-//!     // Construct our SocketAddr to listen on...
-//!     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-//!
-//!     // Shared is a MakeService that produces services by cloning an inner service...
-//!     let make_service = Shared::new(service_fn(handle));
-//!
-//!     // Then bind and serve...
-//!     let server = Server::bind(&addr).serve(make_service);
-//!
-//!     // And run forever...
-//!     if let Err(e) = server.await {
-//!         eprintln!("server error: {}", e);
-//!     }
-//! }
-//! # #[cfg(not(feature = "runtime"))]
-//! # fn main() {}
-//! ```
-//!
-//! [`tower::make::Shared`]: https://docs.rs/tower/latest/tower/make/struct.Shared.html
+//! [`make_service_fn`]: crate::service::make_service_fn
+//! [`Server::serve_service`]: crate::server::Server::serve_service
+//! [`Service`]: crate::service::Service
 
 pub mod accept;
 

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -47,7 +47,7 @@ pub(super) use self::http::HttpService;
 #[cfg(all(any(feature = "http1", feature = "http2"), feature = "client"))]
 pub(super) use self::make::MakeConnection;
 #[cfg(all(any(feature = "http1", feature = "http2"), feature = "server"))]
-pub(super) use self::make::MakeServiceRef;
+pub(super) use self::make::{MakeServiceRef, Shared, SharedFuture};
 #[cfg(all(any(feature = "http1", feature = "http2"), feature = "client"))]
 pub(super) use self::oneshot::{oneshot, Oneshot};
 


### PR DESCRIPTION
This adds `server::Builder::serve_service` which is a convenience for doing

```rust
Server::bind(&addr).serve(make_service_fn(|_| async move {
    Ok::<_, Infallible>(service_fn(handler))
}));
```

That now becomes

```rust
Server::bind(&addr).serve_service(service_fn(handler));
```

It basically copies [`tower::make::Shared`][] into Hyper so users don't need
to add another dependency to do this.

Also adjusted the docs for `hyper::server` a bit to make `server_service`
the top example as I believe its the more common use-case.

Fixes #2154

[`tower::make::Shared`]: https://docs.rs/tower/0.4.7/tower/make/struct.Shared.html