### PR TITLE
fix(error): don't include error's cause in `Display` impl

### DIFF
--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -447,13 +447,7 @@ impl fmt::Debug for ConnectError {
 
 impl fmt::Display for ConnectError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.msg)?;
-
-        if let Some(ref cause) = self.cause {
-            write!(f, ": {}", cause)?;
-        }
-
-        Ok(())
+        f.write_str(&self.msg)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -433,11 +433,7 @@ impl fmt::Debug for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(ref cause) = self.inner.cause {
-            write!(f, "{}: {}", self.description(), cause)
-        } else {
-            f.write_str(self.description())
-        }
+        f.write_str(self.description())
     }
 }
 


### PR DESCRIPTION
At Embark we have a little helper function that converts a `&dyn
std::error::Error` into a `String` by walking the full chain of sources
(with `std::error::Error::source`) and joining them into a `String`.

We use that where we log errors to get as much information as possible
about whats causing an error. Works particularly well with anyhow's
`.context()` method.

However since `hyper::Error` and `ConnectError` include their cause
their `Display` impl we get the sources more than once. For error
example we're seeing logs like this:

```
WARN foo::bar::baz > Internal error: error trying to connect: tcp connect error:
A connection attempt failed because the connected party did not properly respond
after a period of time, or established connection failed because connected host
has failed to respond. (os error 10060) -> tcp connect error: A connection
attempt failed because the connected party did not properly respond after a
period of time, or established connection failed because connected host has
failed to respond. (os error 10060) -> A connection attempt failed because the
connected party did not properly respond after a period of time, or established
connection failed because connected host has failed to respond. (os error 10060)
```

As the cause can already be obtained through `std::error::Error::source`
no information should be lost by doing this.

