### PR TITLE
Return Parse::Internal error if there's an illegal header name or value

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -73,6 +73,7 @@ pub(super) enum Parse {
     Header,
     TooLarge,
     Status,
+    #[cfg_attr(debug_assertions, allow(unused))]
     Internal,
 }
 
@@ -487,18 +488,6 @@ impl From<httparse::Error> for Parse {
 impl From<http::method::InvalidMethod> for Parse {
     fn from(_: http::method::InvalidMethod) -> Parse {
         Parse::Method
-    }
-}
-
-impl From<http::header::InvalidHeaderName> for Parse {
-    fn from(_: http::header::InvalidHeaderName) -> Parse {
-        Parse::Internal
-    }
-}
-
-impl From<http::header::InvalidHeaderValue> for Parse {
-    fn from(_: http::header::InvalidHeaderValue) -> Parse {
-        Parse::Internal
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,6 +73,7 @@ pub(super) enum Parse {
     Header,
     TooLarge,
     Status,
+    Internal,
 }
 
 #[derive(Debug, PartialEq)]
@@ -363,6 +364,7 @@ impl Error {
             Kind::Parse(Parse::Header) => "invalid HTTP header parsed",
             Kind::Parse(Parse::TooLarge) => "message head is too large",
             Kind::Parse(Parse::Status) => "invalid HTTP status-code parsed",
+            Kind::Parse(Parse::Internal) => "internal error inside Hyper and/or its dependencies, please report",
             Kind::IncompleteMessage => "connection closed before message completed",
             #[cfg(feature = "http1")]
             Kind::UnexpectedMessage => "received unexpected message from connection",
@@ -474,6 +476,18 @@ impl From<httparse::Error> for Parse {
 impl From<http::method::InvalidMethod> for Parse {
     fn from(_: http::method::InvalidMethod) -> Parse {
         Parse::Method
+    }
+}
+
+impl From<http::header::InvalidHeaderName> for Parse {
+    fn from(_: http::header::InvalidHeaderName) -> Parse {
+        Parse::Internal
+    }
+}
+
+impl From<http::header::InvalidHeaderValue> for Parse {
+    fn from(_: http::header::InvalidHeaderValue) -> Parse {
+        Parse::Internal
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -376,7 +376,9 @@ impl Error {
             Kind::Parse(Parse::Header) => "invalid HTTP header parsed",
             Kind::Parse(Parse::TooLarge) => "message head is too large",
             Kind::Parse(Parse::Status) => "invalid HTTP status-code parsed",
-            Kind::Parse(Parse::Internal) => "internal error inside Hyper and/or its dependencies, please report",
+            Kind::Parse(Parse::Internal) => {
+                "internal error inside Hyper and/or its dependencies, please report"
+            }
             Kind::IncompleteMessage => "connection closed before message completed",
             #[cfg(feature = "http1")]
             Kind::UnexpectedMessage => "received unexpected message from connection",

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -31,7 +31,7 @@ macro_rules! header_name {
     ($bytes:expr) => {{
         {
             match HeaderName::from_bytes($bytes) {
-                Ok(name) => Ok(name),
+                Ok(name) => name,
                 Err(e) => maybe_panic!(e),
             }
         }
@@ -43,7 +43,7 @@ macro_rules! header_value {
         {
             let __hvb: ::bytes::Bytes = $bytes;
             match HeaderValue::from_maybe_shared(__hvb.clone()) {
-                Ok(name) => Ok(name),
+                Ok(name) => name,
                 Err(e) => maybe_panic!(e),
             }
         }
@@ -57,7 +57,7 @@ macro_rules! maybe_panic {
             panic!("{:?}", _err);
         } else {
             error!("Internal Hyper error, please report {:?}", _err);
-            Err(_err)
+            return Err(Parse::Internal)
         }
     })
 }
@@ -198,8 +198,8 @@ impl Http1Transaction for Server {
         headers.reserve(headers_len);
 
         for header in &headers_indices[..headers_len] {
-            let name = header_name!(&slice[header.name.0..header.name.1])?;
-            let value = header_value!(slice.slice(header.value.0..header.value.1))?;
+            let name = header_name!(&slice[header.name.0..header.name.1]);
+            let value = header_value!(slice.slice(header.value.0..header.value.1));
 
             match name {
                 header::TRANSFER_ENCODING => {
@@ -941,8 +941,8 @@ impl Http1Transaction for Client {
 
             headers.reserve(headers_len);
             for header in &headers_indices[..headers_len] {
-                let name = header_name!(&slice[header.name.0..header.name.1])?;
-                let value = header_value!(slice.slice(header.value.0..header.value.1))?;
+                let name = header_name!(&slice[header.name.0..header.name.1]);
+                let value = header_value!(slice.slice(header.value.0..header.value.1));
 
                 if let header::CONNECTION = name {
                     // keep_alive was previously set to default for Version


### PR DESCRIPTION
Initial implementation that aims to solve #2534 by returning a `Parse::Internal` error instead of panic.  

I intentionally added a new Parse error instead of a new Kind since i think this is still relevant and the diff is much cleaner.
cc @nox  for [this message](https://github.com/hyperium/hyper/issues/2534#issuecomment-835436759), if this is very important to add here, let me know.



