### PR TITLE
docs(common): remove favicon doc from sync_wrapper module

### DIFF
--- a/src/common/sync_wrapper.rs
+++ b/src/common/sync_wrapper.rs
@@ -1,11 +1,6 @@
 /*
  * This is a copy of the sync_wrapper crate.
  */
-//! A mutual exclusion primitive that relies on static type information only
-//!
-//! This library is inspired by [this discussion](https://internals.rust-lang.org/t/what-shall-sync-mean-across-an-await/12020/2).
-#![doc(html_logo_url = "https://developer.actyx.com/img/logo.svg")]
-#![doc(html_favicon_url = "https://developer.actyx.com/img/favicon.ico")]
 
 /// A mutual exclusion primitive that relies on static type information only
 ///


### PR DESCRIPTION
I noticed this triggered an error on nightly, so removing.