### PR TITLE
refactor(lib): Switch from pin-project to pin-project-lite (again)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ httparse = "1.4"
 h2 = { version = "0.3.3", optional = true }
 itoa = "0.4.1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-pin-project = "1.0"
+pin-project-lite = "0.2.4"
 tower-service = "0.3"
 tokio = { version = "1", features = ["sync"] }
 want = "0.3"

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use futures_util::future::Either;
 use http::uri::{Scheme, Uri};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use tokio::net::{TcpSocket, TcpStream};
 use tokio::time::Sleep;
 
@@ -373,18 +373,19 @@ impl HttpInfo {
     }
 }
 
-// Not publicly exported (so missing_docs doesn't trigger).
-//
-// We return this `Future` instead of the `Pin<Box<dyn Future>>` directly
-// so that users don't rely on it fitting in a `Pin<Box<dyn Future>>` slot
-// (and thus we can change the type in the future).
-#[must_use = "futures do nothing unless polled"]
-#[pin_project]
-#[allow(missing_debug_implementations)]
-pub struct HttpConnecting<R> {
-    #[pin]
-    fut: BoxConnecting,
-    _marker: PhantomData<R>,
+pin_project! {
+    // Not publicly exported (so missing_docs doesn't trigger).
+    //
+    // We return this `Future` instead of the `Pin<Box<dyn Future>>` directly
+    // so that users don't rely on it fitting in a `Pin<Box<dyn Future>>` slot
+    // (and thus we can change the type in the future).
+    #[must_use = "futures do nothing unless polled"]
+    #[allow(missing_debug_implementations)]
+    pub struct HttpConnecting<R> {
+        #[pin]
+        fut: BoxConnecting,
+        _marker: PhantomData<R>,
+    }
 }
 
 type ConnectResult = Result<TcpStream, ConnectError>;

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -11,7 +11,7 @@ use futures_channel::oneshot;
 use tokio::time::{Duration, Instant, Interval};
 
 use super::client::Ver;
-use crate::common::{task, exec::Exec, Future, Pin, Poll, Unpin};
+use crate::common::{exec::Exec, task, Future, Pin, Poll, Unpin};
 
 // FIXME: allow() required due to `impl Trait` leaking types to this lint
 #[allow(missing_debug_implementations)]
@@ -714,16 +714,17 @@ impl Expiration {
 }
 
 #[cfg(feature = "runtime")]
-#[pin_project::pin_project]
-struct IdleTask<T> {
-    #[pin]
-    interval: Interval,
-    pool: WeakOpt<Mutex<PoolInner<T>>>,
-    // This allows the IdleTask to be notified as soon as the entire
-    // Pool is fully dropped, and shutdown. This channel is never sent on,
-    // but Err(Canceled) will be received when the Pool is dropped.
-    #[pin]
-    pool_drop_notifier: oneshot::Receiver<crate::common::Never>,
+pin_project_lite::pin_project! {
+    struct IdleTask<T> {
+        #[pin]
+        interval: Interval,
+        pool: WeakOpt<Mutex<PoolInner<T>>>,
+        // This allows the IdleTask to be notified as soon as the entire
+        // Pool is fully dropped, and shutdown. This channel is never sent on,
+        // but Err(Canceled) will be received when the Pool is dropped.
+        #[pin]
+        pool_drop_notifier: oneshot::Receiver<crate::common::Never>,
+    }
 }
 
 #[cfg(feature = "runtime")]
@@ -776,7 +777,7 @@ mod tests {
     use std::time::Duration;
 
     use super::{Connecting, Key, Pool, Poolable, Reservation, WeakOpt};
-    use crate::common::{task, exec::Exec, Future, Pin};
+    use crate::common::{exec::Exec, task, Future, Pin};
 
     /// Test unique reservations.
     #[derive(Debug, PartialEq, Eq)]

--- a/src/common/drain.rs
+++ b/src/common/drain.rs
@@ -1,6 +1,6 @@
 use std::mem;
 
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use tokio::sync::watch;
 
 use super::{task, Future, Pin, Poll};
@@ -21,14 +21,15 @@ pub(crate) struct Watch {
     rx: watch::Receiver<()>,
 }
 
-#[allow(missing_debug_implementations)]
-#[pin_project]
-pub struct Watching<F, FN> {
-    #[pin]
-    future: F,
-    state: State<FN>,
-    watch: Pin<Box<dyn Future<Output = ()> + Send + Sync>>,
-    _rx: watch::Receiver<()>,
+pin_project! {
+    #[allow(missing_debug_implementations)]
+    pub struct Watching<F, FN> {
+        #[pin]
+        future: F,
+        state: State<FN>,
+        watch: Pin<Box<dyn Future<Output = ()> + Send + Sync>>,
+        _rx: watch::Receiver<()>,
+    }
 }
 
 enum State<F> {

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -44,10 +44,13 @@ cfg_server! {
 }
 
 cfg_client! {
-    pub(crate) struct Client<B> {
-        callback: Option<crate::client::dispatch::Callback<Request<B>, http::Response<Body>>>,
-        rx: ClientRx<B>,
-        rx_closed: bool,
+    pin_project_lite::pin_project! {
+        pub(crate) struct Client<B> {
+            callback: Option<crate::client::dispatch::Callback<Request<B>, http::Response<Body>>>,
+            #[pin]
+            rx: ClientRx<B>,
+            rx_closed: bool,
+        }
     }
 
     type ClientRx<B> = crate::client::dispatch::Receiver<Request<B>, http::Response<Body>>;

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -5,7 +5,7 @@ use http::header::{
     TRANSFER_ENCODING, UPGRADE,
 };
 use http::HeaderMap;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::error::Error as StdError;
 use std::io::{self, Cursor, IoSlice};
 use std::mem;
@@ -88,15 +88,16 @@ fn strip_connection_headers(headers: &mut HeaderMap, is_request: bool) {
 
 // body adapters used by both Client and Server
 
-#[pin_project]
-struct PipeToSendStream<S>
-where
-    S: HttpBody,
-{
-    body_tx: SendStream<SendBuf<S::Data>>,
-    data_done: bool,
-    #[pin]
-    stream: S,
+pin_project! {
+    struct PipeToSendStream<S>
+    where
+        S: HttpBody,
+    {
+        body_tx: SendStream<SendBuf<S::Data>>,
+        data_done: bool,
+        #[pin]
+        stream: S,
+    }
 }
 
 impl<S> PipeToSendStream<S>

--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -9,7 +9,7 @@
 #[cfg(feature = "stream")]
 use futures_core::Stream;
 #[cfg(feature = "stream")]
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 use crate::common::{
     task::{self, Poll},
@@ -86,8 +86,12 @@ pub fn from_stream<S, IO, E>(stream: S) -> impl Accept<Conn = IO, Error = E>
 where
     S: Stream<Item = Result<IO, E>>,
 {
-    #[pin_project]
-    struct FromStream<S>(#[pin] S);
+    pin_project! {
+        struct FromStream<S> {
+            #[pin]
+            stream: S,
+        }
+    }
 
     impl<S, IO, E> Accept for FromStream<S>
     where
@@ -99,9 +103,9 @@ where
             self: Pin<&mut Self>,
             cx: &mut task::Context<'_>,
         ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
-            self.project().0.poll_next(cx)
+            self.project().stream.poll_next(cx)
         }
     }
 
-    FromStream(stream)
+    FromStream { stream }
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -6,7 +6,7 @@ use std::net::{SocketAddr, TcpListener as StdTcpListener};
 #[cfg(feature = "tcp")]
 use std::time::Duration;
 
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::accept::Accept;
@@ -21,16 +21,17 @@ use super::shutdown::{Graceful, GracefulWatcher};
 #[cfg(feature = "tcp")]
 use super::tcp::AddrIncoming;
 
-/// A listening HTTP server that accepts connections in both HTTP1 and HTTP2 by default.
-///
-/// `Server` is a `Future` mapping a bound listener with a set of service
-/// handlers. It is built using the [`Builder`](Builder), and the future
-/// completes when the server has been shutdown. It should be run by an
-/// `Executor`.
-#[pin_project]
-pub struct Server<I, S, E = Exec> {
-    #[pin]
-    spawn_all: SpawnAll<I, S, E>,
+pin_project! {
+    /// A listening HTTP server that accepts connections in both HTTP1 and HTTP2 by default.
+    ///
+    /// `Server` is a `Future` mapping a bound listener with a set of service
+    /// handlers. It is built using the [`Builder`](Builder), and the future
+    /// completes when the server has been shutdown. It should be run by an
+    /// `Executor`.
+    pub struct Server<I, S, E = Exec> {
+        #[pin]
+        spawn_all: SpawnAll<I, S, E>,
+    }
 }
 
 /// A builder for a [`Server`](Server).

--- a/src/server/shutdown.rs
+++ b/src/server/shutdown.rs
@@ -1,33 +1,36 @@
 use std::error::Error as StdError;
 
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use super::conn::{SpawnAll, UpgradeableConnection, Watcher};
 use super::accept::Accept;
+use super::conn::{SpawnAll, UpgradeableConnection, Watcher};
 use crate::body::{Body, HttpBody};
 use crate::common::drain::{self, Draining, Signal, Watch, Watching};
 use crate::common::exec::{ConnStreamExec, NewSvcExec};
 use crate::common::{task, Future, Pin, Poll, Unpin};
 use crate::service::{HttpService, MakeServiceRef};
 
-#[allow(missing_debug_implementations)]
-#[pin_project]
-pub struct Graceful<I, S, F, E> {
-    #[pin]
-    state: State<I, S, F, E>,
+pin_project! {
+    #[allow(missing_debug_implementations)]
+    pub struct Graceful<I, S, F, E> {
+        #[pin]
+        state: State<I, S, F, E>,
+    }
 }
 
-#[pin_project(project = StateProj)]
-pub(super) enum State<I, S, F, E> {
-    Running {
-        drain: Option<(Signal, Watch)>,
-        #[pin]
-        spawn_all: SpawnAll<I, S, E>,
-        #[pin]
-        signal: F,
-    },
-    Draining(Draining),
+pin_project! {
+    #[project = StateProj]
+    pub(super) enum State<I, S, F, E> {
+        Running {
+            drain: Option<(Signal, Watch)>,
+            #[pin]
+            spawn_all: SpawnAll<I, S, E>,
+            #[pin]
+            signal: F,
+        },
+        Draining { draining: Draining },
+    }
 }
 
 impl<I, S, F, E> Graceful<I, S, F, E> {
@@ -71,14 +74,16 @@ where
                         Poll::Ready(()) => {
                             debug!("signal received, starting graceful shutdown");
                             let sig = drain.take().expect("drain channel").0;
-                            State::Draining(sig.drain())
+                            State::Draining {
+                                draining: sig.drain(),
+                            }
                         }
                         Poll::Pending => {
                             let watch = drain.as_ref().expect("drain channel").1.clone();
                             return spawn_all.poll_watch(cx, &GracefulWatcher(watch));
                         }
                     },
-                    StateProj::Draining(ref mut draining) => {
+                    StateProj::Draining { ref mut draining } => {
                         return Pin::new(draining).poll(cx).map(Ok);
                     }
                 }

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -199,13 +199,14 @@ mod addr_stream {
 
     use crate::common::{task, Pin, Poll};
 
-    /// A transport returned yieled by `AddrIncoming`.
-    #[pin_project::pin_project]
-    #[derive(Debug)]
-    pub struct AddrStream {
-        #[pin]
-        inner: TcpStream,
-        pub(super) remote_addr: SocketAddr,
+    pin_project_lite::pin_project! {
+        /// A transport returned yieled by `AddrIncoming`.
+        #[derive(Debug)]
+        pub struct AddrStream {
+            #[pin]
+            inner: TcpStream,
+            pub(super) remote_addr: SocketAddr,
+        }
     }
 
     impl AddrStream {

--- a/src/service/oneshot.rs
+++ b/src/service/oneshot.rs
@@ -1,6 +1,6 @@
 // TODO: Eventually to be replaced with tower_util::Oneshot.
 
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use tower_service::Service;
 
 use crate::common::{task, Future, Pin, Poll};
@@ -10,25 +10,35 @@ where
     S: Service<Req>,
 {
     Oneshot {
-        state: State::NotReady(svc, req),
+        state: State::NotReady { svc, req },
     }
 }
 
-// A `Future` consuming a `Service` and request, waiting until the `Service`
-// is ready, and then calling `Service::call` with the request, and
-// waiting for that `Future`.
-#[allow(missing_debug_implementations)]
-#[pin_project]
-pub struct Oneshot<S: Service<Req>, Req> {
-    #[pin]
-    state: State<S, Req>,
+pin_project! {
+    // A `Future` consuming a `Service` and request, waiting until the `Service`
+    // is ready, and then calling `Service::call` with the request, and
+    // waiting for that `Future`.
+    #[allow(missing_debug_implementations)]
+    pub struct Oneshot<S: Service<Req>, Req> {
+        #[pin]
+        state: State<S, Req>,
+    }
 }
 
-#[pin_project(project = StateProj, project_replace = StateProjOwn)]
-enum State<S: Service<Req>, Req> {
-    NotReady(S, Req),
-    Called(#[pin] S::Future),
-    Tmp,
+pin_project! {
+    #[project = StateProj]
+    #[project_replace = StateProjOwn]
+    enum State<S: Service<Req>, Req> {
+        NotReady {
+            svc: S,
+            req: Req,
+        },
+        Called {
+            #[pin]
+            fut: S::Future,
+        },
+        Tmp,
+    }
 }
 
 impl<S, Req> Future for Oneshot<S, Req>
@@ -42,19 +52,19 @@ where
 
         loop {
             match me.state.as_mut().project() {
-                StateProj::NotReady(ref mut svc, _) => {
+                StateProj::NotReady { ref mut svc, .. } => {
                     ready!(svc.poll_ready(cx))?;
                     // fallthrough out of the match's borrow
                 }
-                StateProj::Called(fut) => {
+                StateProj::Called { fut } => {
                     return fut.poll(cx);
                 }
                 StateProj::Tmp => unreachable!(),
             }
 
             match me.state.as_mut().project_replace(State::Tmp) {
-                StateProjOwn::NotReady(mut svc, req) => {
-                    me.state.set(State::Called(svc.call(req)));
+                StateProjOwn::NotReady { mut svc, req } => {
+                    me.state.set(State::Called { fut: svc.call(req) });
                 }
                 _ => unreachable!(),
             }


### PR DESCRIPTION
Second try, turned out to require a bunch more changes in `src/client/conn.rs` and `src/server/conn.rs` due to the `ProtoClient` and `ProtoServer` enums which previously had `cfg`-conditional variants (which aren't supported by pin-project-lite). Now the variants that previously were disabled by `cfg(not(feature = "http1"))` and `cfg(not(feature = "http2"))` are instead made to be uninhabited.

The code would be a decent amount simpler if the non-exhaustive variants could be omitted in `match`es (https://github.com/rust-lang/rust/issues/51085).