### PR TITLE
server: implement set_sleep_on_errors() for generic Accept implementations

### DIFF
--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -6,10 +6,16 @@
 //!   connections.
 //! - Utilities like `poll_fn` to ease creating a custom `Accept`.
 
+use std::fmt;
+use std::time::Duration;
+use std::future::Future;
+
 #[cfg(feature = "stream")]
 use futures_core::Stream;
 #[cfg(feature = "stream")]
 use pin_project_lite::pin_project;
+
+use tokio::time::Sleep;
 
 use crate::common::{
     task::{self, Poll},
@@ -28,6 +34,82 @@ pub trait Accept {
         self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
     ) -> Poll<Option<Result<Self::Conn, Self::Error>>>;
+}
+
+/// Structure that implements the Accept trait and is able to sleep on errors when configured.
+pub struct AcceptWithSleep<A: Accept> {
+    accept: A,
+    sleep_on_errors: bool,
+    timeout: Option<Pin<Box<Sleep>>>,
+}
+
+impl<A: Accept> fmt::Debug for AcceptWithSleep<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AcceptWithSleep")
+            .field("sleep_on_errors", &self.sleep_on_errors)
+            .finish()
+    }
+}
+
+impl<A: Accept> AcceptWithSleep<A> {
+    /// Set whether to sleep on accept errors.
+    ///
+    /// A possible scenario is that the process has hit the max open files
+    /// allowed, and so trying to accept a new connection will fail with
+    /// `EMFILE`. In some cases, it's preferable to just wait for some time, if
+    /// the application will likely close some files (or connections), and try
+    /// to accept the connection again. If this option is `true`, the error
+    /// will be logged at the `error` level, since it is still a big deal,
+    /// and then the listener will sleep for 1 second.
+    ///
+    /// In other cases, hitting the max open files should be treat similarly
+    /// to being out-of-memory, and simply error (and shutdown). Setting
+    /// this option to `false` will allow that.
+    ///
+    /// Default is `true`.
+    pub fn set_sleep_on_errors(&mut self, val: bool) {
+        self.sleep_on_errors = val;
+    }
+}
+
+impl<A: Accept + Unpin> Accept for AcceptWithSleep<A>
+{
+    type Conn = A::Conn;
+    type Error = A::Error;
+
+    fn poll_accept(
+        mut self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+        // Check if a previous timeout is active that was set by IO errors.
+        if let Some(ref mut to) = self.timeout {
+            ready!(Pin::new(to).poll(cx));
+        }
+        self.timeout = None;
+
+        loop {
+            match ready!(Pin::new(&mut self.accept).poll_accept(cx)) {
+                None => return Poll::Ready(None),
+                Some(Ok(item)) => return Poll::Ready(Some(Ok(item))),
+                Some(Err(e)) => if self.sleep_on_errors {
+                    // Sleep 1s.
+                    let mut timeout = Box::pin(tokio::time::sleep(Duration::from_secs(1)));
+                    match timeout.as_mut().poll(cx) {
+                        Poll::Ready(()) => {
+                            // Wow, it's been a second already? Ok then...
+                            continue;
+                        }
+                        Poll::Pending => {
+                            self.timeout = Some(timeout);
+                            return Poll::Pending;
+                        }
+                    }
+                } else {
+                    return Poll::Ready(Some(Err(e)));
+                }
+            }
+        }
+    }
 }
 
 /// Create an `Accept` with a polling function.
@@ -49,7 +131,7 @@ pub trait Accept {
 ///
 /// let builder = Server::builder(once);
 /// ```
-pub fn poll_fn<F, IO, E>(func: F) -> impl Accept<Conn = IO, Error = E>
+pub fn poll_fn<F, IO, E>(func: F) -> AcceptWithSleep<impl Accept<Conn = IO, Error = E>>
 where
     F: FnMut(&mut task::Context<'_>) -> Poll<Option<Result<IO, E>>>,
 {
@@ -60,7 +142,7 @@ where
 
     impl<F, IO, E> Accept for PollFn<F>
     where
-        F: FnMut(&mut task::Context<'_>) -> Poll<Option<Result<IO, E>>>,
+        F: FnMut(&mut task::Context<'_>) -> Poll<Option<Result<IO, E>>>
     {
         type Conn = IO;
         type Error = E;
@@ -72,7 +154,7 @@ where
         }
     }
 
-    PollFn(func)
+    AcceptWithSleep { accept: PollFn(func), sleep_on_errors: true, timeout: None }
 }
 
 /// Adapt a `Stream` of incoming connections into an `Accept`.
@@ -82,9 +164,9 @@ where
 /// This function requires enabling the `stream` feature in your
 /// `Cargo.toml`.
 #[cfg(feature = "stream")]
-pub fn from_stream<S, IO, E>(stream: S) -> impl Accept<Conn = IO, Error = E>
+pub fn from_stream<S, IO, E>(stream: S) -> AcceptWithSleep<impl Accept<Conn = IO, Error = E>>
 where
-    S: Stream<Item = Result<IO, E>>,
+    S: Stream<Item = Result<IO, E>>
 {
     pin_project! {
         struct FromStream<S> {
@@ -107,5 +189,5 @@ where
         }
     }
 
-    FromStream { stream }
+    AcceptWithSleep { accept: FromStream { stream }, sleep_on_errors: true, timeout: None }
 }


### PR DESCRIPTION
This adds AcceptWithSleep struct which implements Accept trait and adds a functionality to sleep on errors similar to the AddrIncoming for TcpListener. The reason for this is that this feature is missing for UnixSocket listeners,
and other custom listeners implementing Accept, but it's not really specific to TcpListener. I'm not sure if/how you would prefer to have this implemented, so opening this PR to get the ball rolling.

