### PR TITLE
fix(server): export UpgradeableConnection

### DIFF
--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -1176,13 +1176,12 @@ pub(crate) mod spawn_all {
     }
 }
 
-mod upgrades {
+pub mod upgrades {
     use super::*;
 
-    // A future binding a connection with a Service with Upgrade support.
-    //
-    // This type is unnameable outside the crate, and so basically just an
-    // `impl Future`, without requiring Rust 1.26.
+    /// A future binding a connection with a Service with Upgrade support.
+    ///
+    /// Polling this future will drive HTTP forward.
     #[must_use = "futures do nothing unless polled"]
     #[allow(missing_debug_implementations)]
     pub struct UpgradeableConnection<T, S, E>


### PR DESCRIPTION
This struct is part of the public API (returned from
Connection::with_upgrades), but was previously not exported.

Why this is a problem doesn't require explanation I think :wink:
