### PR TITLE
feat(ffi): add hyper_request_on_informational

### DIFF
--- a/capi/include/hyper.h
+++ b/capi/include/hyper.h
@@ -207,6 +207,8 @@ typedef int (*hyper_body_foreach_callback)(void*, const struct hyper_buf*);
 
 typedef int (*hyper_body_data_callback)(void*, struct hyper_context*, struct hyper_buf**);
 
+typedef void (*hyper_request_on_informational_callback)(void*, const struct hyper_response*);
+
 typedef int (*hyper_headers_foreach_callback)(void*, const uint8_t*, size_t, const uint8_t*, size_t);
 
 typedef size_t (*hyper_io_read_callback)(void*, struct hyper_context*, uint8_t*, size_t);
@@ -453,6 +455,27 @@ struct hyper_headers *hyper_request_headers(struct hyper_request *req);
  free it after setting it on the request.
  */
 enum hyper_code hyper_request_set_body(struct hyper_request *req, struct hyper_body *body);
+
+/*
+ Set an informational (1xx) response callback.
+
+ The callback is called each time hyper receives an informational (1xx)
+ response for this request.
+
+ The third argument is an opaque user data pointer, which is passed to
+ the callback each time.
+
+ The callback is passed the `void *` data pointer, and a
+ `hyper_response *` which can be inspected as any other response. The
+ body of the response will always be empty.
+
+ NOTE: The `const hyper_response *` is just borrowed data, and will not
+ be valid after the callback finishes. You must copy any data you wish
+ to persist.
+ */
+enum hyper_code hyper_request_on_informational(struct hyper_request *req,
+                                               hyper_request_on_informational_callback callback,
+                                               void *data);
 
 /*
  Free an HTTP response after using it.

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -81,6 +81,7 @@ struct UserDataPointer(*mut std::ffi::c_void);
 // We don't actually know anything about this pointer, it's up to the user
 // to do the right thing.
 unsafe impl Send for UserDataPointer {}
+unsafe impl Sync for UserDataPointer {}
 
 /// cbindgen:ignore
 static VERSION_CSTR: &str = concat!(env!("CARGO_PKG_VERSION"), "\0");

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -50,6 +50,8 @@ where
                 title_case_headers: false,
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
+                on_informational: None,
+                #[cfg(feature = "ffi")]
                 raw_headers: false,
                 notify_read: false,
                 reading: Reading::Init,
@@ -170,6 +172,8 @@ where
                 preserve_header_case: self.state.preserve_header_case,
                 h09_responses: self.state.h09_responses,
                 #[cfg(feature = "ffi")]
+                on_informational: &mut self.state.on_informational,
+                #[cfg(feature = "ffi")]
                 raw_headers: self.state.raw_headers,
             }
         )) {
@@ -184,6 +188,12 @@ where
 
         // Prevent accepting HTTP/0.9 responses after the initial one, if any.
         self.state.h09_responses = false;
+
+        // Drop any OnInformational callbacks, we're done there!
+        #[cfg(feature = "ffi")]
+        {
+            self.state.on_informational = None;
+        }
 
         self.state.busy();
         self.state.keep_alive &= msg.keep_alive;
@@ -525,6 +535,14 @@ where
                 debug_assert!(self.state.cached_headers.is_none());
                 debug_assert!(head.headers.is_empty());
                 self.state.cached_headers = Some(head.headers);
+
+                #[cfg(feature = "ffi")]
+                {
+                    self.state.on_informational = head
+                        .extensions
+                        .remove::<crate::ffi::OnInformational>();
+                }
+
                 Some(encoder)
             }
             Err(err) => {
@@ -775,6 +793,11 @@ struct State {
     preserve_header_case: bool,
     title_case_headers: bool,
     h09_responses: bool,
+    /// If set, called with each 1xx informational response received for
+    /// the current request. MUST be unset after a non-1xx response is
+    /// received.
+    #[cfg(feature = "ffi")]
+    on_informational: Option<crate::ffi::OnInformational>,
     #[cfg(feature = "ffi")]
     raw_headers: bool,
     /// Set to true when the Dispatcher should poll read operations

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -598,11 +598,7 @@ cfg_client! {
             match msg {
                 Ok((msg, body)) => {
                     if let Some(cb) = self.callback.take() {
-                        let mut res = http::Response::new(body);
-                        *res.status_mut() = msg.subject;
-                        *res.headers_mut() = msg.headers;
-                        *res.version_mut() = msg.version;
-                        *res.extensions_mut() = msg.extensions;
+                        let res = msg.into_response(body);
                         cb.send(Ok(res));
                         Ok(())
                     } else {

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -168,6 +168,8 @@ where
                     preserve_header_case: parse_ctx.preserve_header_case,
                     h09_responses: parse_ctx.h09_responses,
                     #[cfg(feature = "ffi")]
+                    on_informational: parse_ctx.on_informational,
+                    #[cfg(feature = "ffi")]
                     raw_headers: parse_ctx.raw_headers,
                 },
             )? {
@@ -677,6 +679,8 @@ mod tests {
                 h1_parser_config: Default::default(),
                 preserve_header_case: false,
                 h09_responses: false,
+                #[cfg(feature = "ffi")]
+                on_informational: &mut None,
                 #[cfg(feature = "ffi")]
                 raw_headers: false,
             };

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -75,6 +75,8 @@ pub(crate) struct ParseContext<'a> {
     preserve_header_case: bool,
     h09_responses: bool,
     #[cfg(feature = "ffi")]
+    on_informational: &'a mut Option<crate::ffi::OnInformational>,
+    #[cfg(feature = "ffi")]
     raw_headers: bool,
 }
 

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -991,6 +991,13 @@ impl Http1Transaction for Client {
                 }));
             }
 
+            #[cfg(feature = "ffi")]
+            if head.subject.is_informational() {
+                if let Some(callback) = ctx.on_informational {
+                    callback.call(head.into_response(crate::Body::empty()));
+                }
+            }
+
             // Parsing a 1xx response could have consumed the buffer, check if
             // it is empty now...
             if buf.is_empty() {
@@ -1428,6 +1435,8 @@ mod tests {
                 preserve_header_case: false,
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
+                on_informational: &mut None,
+                #[cfg(feature = "ffi")]
                 raw_headers: false,
             },
         )
@@ -1453,6 +1462,8 @@ mod tests {
             preserve_header_case: false,
             h09_responses: false,
             #[cfg(feature = "ffi")]
+            on_informational: &mut None,
+            #[cfg(feature = "ffi")]
             raw_headers: false,
         };
         let msg = Client::parse(&mut raw, ctx).unwrap().unwrap();
@@ -1473,6 +1484,8 @@ mod tests {
             preserve_header_case: false,
             h09_responses: false,
             #[cfg(feature = "ffi")]
+            on_informational: &mut None,
+            #[cfg(feature = "ffi")]
             raw_headers: false,
         };
         Server::parse(&mut raw, ctx).unwrap_err();
@@ -1490,6 +1503,8 @@ mod tests {
             h1_parser_config: Default::default(),
             preserve_header_case: false,
             h09_responses: true,
+            #[cfg(feature = "ffi")]
+            on_informational: &mut None,
             #[cfg(feature = "ffi")]
             raw_headers: false,
         };
@@ -1510,6 +1525,8 @@ mod tests {
             h1_parser_config: Default::default(),
             preserve_header_case: false,
             h09_responses: false,
+            #[cfg(feature = "ffi")]
+            on_informational: &mut None,
             #[cfg(feature = "ffi")]
             raw_headers: false,
         };
@@ -1535,6 +1552,8 @@ mod tests {
             preserve_header_case: false,
             h09_responses: false,
             #[cfg(feature = "ffi")]
+            on_informational: &mut None,
+            #[cfg(feature = "ffi")]
             raw_headers: false,
         };
         let msg = Client::parse(&mut raw, ctx).unwrap().unwrap();
@@ -1556,6 +1575,8 @@ mod tests {
             preserve_header_case: false,
             h09_responses: false,
             #[cfg(feature = "ffi")]
+            on_informational: &mut None,
+            #[cfg(feature = "ffi")]
             raw_headers: false,
         };
         Client::parse(&mut raw, ctx).unwrap_err();
@@ -1571,6 +1592,8 @@ mod tests {
             h1_parser_config: Default::default(),
             preserve_header_case: true,
             h09_responses: false,
+            #[cfg(feature = "ffi")]
+            on_informational: &mut None,
             #[cfg(feature = "ffi")]
             raw_headers: false,
         };
@@ -1609,6 +1632,8 @@ mod tests {
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
+                    on_informational: &mut None,
+                    #[cfg(feature = "ffi")]
                     raw_headers: false,
                 },
             )
@@ -1626,6 +1651,8 @@ mod tests {
                     h1_parser_config: Default::default(),
                     preserve_header_case: false,
                     h09_responses: false,
+                    #[cfg(feature = "ffi")]
+                    on_informational: &mut None,
                     #[cfg(feature = "ffi")]
                     raw_headers: false,
                 },
@@ -1854,6 +1881,8 @@ mod tests {
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
+                    on_informational: &mut None,
+                    #[cfg(feature = "ffi")]
                     raw_headers: false,
                 }
             )
@@ -1872,6 +1901,8 @@ mod tests {
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
+                    on_informational: &mut None,
+                    #[cfg(feature = "ffi")]
                     raw_headers: false,
                 },
             )
@@ -1889,6 +1920,8 @@ mod tests {
                     h1_parser_config: Default::default(),
                     preserve_header_case: false,
                     h09_responses: false,
+                    #[cfg(feature = "ffi")]
+                    on_informational: &mut None,
                     #[cfg(feature = "ffi")]
                     raw_headers: false,
                 },
@@ -2383,6 +2416,8 @@ mod tests {
                 preserve_header_case: false,
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
+                on_informational: &mut None,
+                #[cfg(feature = "ffi")]
                 raw_headers: false,
             },
         )
@@ -2465,6 +2500,8 @@ mod tests {
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
+                    on_informational: &mut None,
+                    #[cfg(feature = "ffi")]
                     raw_headers: false,
                 },
             )
@@ -2502,6 +2539,8 @@ mod tests {
                     h1_parser_config: Default::default(),
                     preserve_header_case: false,
                     h09_responses: false,
+                    #[cfg(feature = "ffi")]
+                    on_informational: &mut None,
                     #[cfg(feature = "ffi")]
                     raw_headers: false,
                 },

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -57,3 +57,14 @@ pub(crate) enum Dispatched {
     #[cfg(feature = "http1")]
     Upgrade(crate::upgrade::Pending),
 }
+
+impl MessageHead<http::StatusCode> {
+    fn into_response<B>(self, body: B) -> http::Response<B> {
+        let mut res = http::Response::new(body);
+        *res.status_mut() = self.subject;
+        *res.headers_mut() = self.headers;
+        *res.version_mut() = self.version;
+        *res.extensions_mut() = self.extensions;
+        res
+    }
+}


### PR DESCRIPTION
This defines an extension type used in requests for the client that is
used to setup a callback for receipt of informational (1xx) responses.
The type isn't currently public, and is only usable in the C API.

cc #2565 

