### PR TITLE
fix(h2): preserve proxy authentication headers

### DIFF
--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -1,9 +1,6 @@
 use bytes::{Buf, Bytes};
 use h2::{RecvStream, SendStream};
-use http::header::{
-    HeaderName, CONNECTION, PROXY_AUTHENTICATE, PROXY_AUTHORIZATION, TE, TRAILER,
-    TRANSFER_ENCODING, UPGRADE,
-};
+use http::header::{HeaderName, CONNECTION, TE, TRAILER, TRANSFER_ENCODING, UPGRADE};
 use http::HeaderMap;
 use pin_project_lite::pin_project;
 use std::error::Error as StdError;
@@ -40,8 +37,6 @@ fn strip_connection_headers(headers: &mut HeaderMap, is_request: bool) {
     let connection_headers = [
         HeaderName::from_lowercase(b"keep-alive").unwrap(),
         HeaderName::from_lowercase(b"proxy-connection").unwrap(),
-        PROXY_AUTHENTICATE,
-        PROXY_AUTHORIZATION,
         TRAILER,
         TRANSFER_ENCODING,
         UPGRADE,


### PR DESCRIPTION
That Proxy-Authenticate and Proxy-Authorization are forbidden over h2
is not actually specified anywhere, plus h2 also supports CONNECT
requests, which are specifically made to do requests over a proxy,
and those proxies may require authentication, sometimes through
Proxy-Authorization.

Note that there is an openwebdocs project that just started to clear
up any MDN-induced confusion in implementations:

> https://github.com/openwebdocs/project/issues/43

Also, Daniel Stenberg (curl) also recently commented about
Proxy-Connection not being stripped out by curl, Hyper may want to
also remove Proxy-Connection from the list for that reason:

> https://twitter.com/bagder/status/1415967315817082880

