### PR TITLE
docs(ffi): copy-paste error

### DIFF
--- a/capi/include/hyper.h
+++ b/capi/include/hyper.h
@@ -718,7 +718,9 @@ struct hyper_waker *hyper_context_waker(struct hyper_context *cx);
 void hyper_waker_free(struct hyper_waker *waker);
 
 /*
- Free a waker that hasn't been woken.
+ Wake up the task associated with a waker.
+
+ NOTE: This consumes the waker. You should not use or free the waker afterwards.
  */
 void hyper_waker_wake(struct hyper_waker *waker);
 

--- a/src/ffi/task.rs
+++ b/src/ffi/task.rs
@@ -418,7 +418,9 @@ ffi_fn! {
 }
 
 ffi_fn! {
-    /// Free a waker that hasn't been woken.
+    /// Wake up the task associated with a waker.
+    ///
+    /// NOTE: This consumes the waker. You should not use or free the waker afterwards.
     fn hyper_waker_wake(waker: *mut hyper_waker) {
         let waker = unsafe { Box::from_raw(waker) };
         waker.waker.wake();


### PR DESCRIPTION
The docs for `hyper_waker_wake` were accidentally copied over from `hyper_waker_free`, so I rewrote it.