### PR TITLE
Add an accessor for the `Connect` implementation inside a Client to allow bypassing the connection pool.

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -392,6 +392,11 @@ where
         }
     }
 
+    /// Access the `Connect` implementation directly, bypassing the connection pool.
+    pub fn connector(&self) -> &C {
+        &self.connector
+    }
+
     fn connect_to(
         &self,
         pool_key: PoolKey,


### PR DESCRIPTION
I use hyper to (among other things) talk to Docker over TCP. Docker's API is primarily HTTP, however, the attach command hijacks the HTTP connection (see https://docs.docker.com/engine/api/v1.41/#operation/ContainerAttach).

I added this accessor to get the connection outside of the pool, and then use into_parts to break it into the raw i/o object to do the necessary communication.