### PR TITLE
fix: missing import in examples/http_proxy.rs

### DIFF
--- a/examples/http_proxy.rs
+++ b/examples/http_proxy.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 
 use hyper::service::{make_service_fn, service_fn};
 use hyper::upgrade::Upgraded;
-use hyper::{Body, Client, Method, Request, Response, Server};
+use hyper::{http, Body, Client, Method, Request, Response, Server};
 
 use tokio::net::TcpStream;
 


### PR DESCRIPTION
The HTTP Proxy example references `hyper::http` directly, but it is not
used directly. This change adds the missing `use` statement for it.