### PR TITLE
fix (header): rustsec-2021-0078 Content-Length cannot contain plus sign

### DIFF
--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -4,7 +4,7 @@ use header::{HeaderFormat, Header, parsing};
 
 /// `Content-Length` header, defined in
 /// [RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.2)
-/// 
+///
 /// When a message does not have a `Transfer-Encoding` header field, a
 /// Content-Length header field can provide the anticipated size, as a
 /// decimal number of octets, for a potential payload body.  For messages
@@ -13,19 +13,19 @@ use header::{HeaderFormat, Header, parsing};
 /// body (and message) ends.  For messages that do not include a payload
 /// body, the Content-Length indicates the size of the selected
 /// representation.
-/// 
+///
 /// # ABNF
 /// ```plain
 /// Content-Length = 1*DIGIT
 /// ```
-/// 
+///
 /// # Example values
 /// * `3495`
-/// 
+///
 /// # Example
 /// ```
 /// use hyper::header::{Headers, ContentLength};
-/// 
+///
 /// let mut headers = Headers::new();
 /// headers.set(ContentLength(1024u64));
 /// ```
@@ -43,7 +43,7 @@ impl Header for ContentLength {
         // correctly. If not, then it's an error.
         raw.iter()
             .map(::std::ops::Deref::deref)
-            .map(parsing::from_raw_str)
+            .map(parsing::from_digits)
             .fold(None, |prev, x| {
                 match (prev, x) {
                     (None, x) => Some(x),

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -540,7 +540,7 @@ impl<'a> FromIterator<HeaderView<'a>> for Headers {
     }
 }
 
-#[deprecated(note="The semantics of formatting a HeaderFormat directly are not clear")]
+
 impl<'a> fmt::Display for &'a (HeaderFormat + Send + Sync) {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -716,6 +716,12 @@ mod tests {
     fn test_trailing_whitespace() {
         let headers = Headers::from_raw(&raw!(b"Content-Length: 10   ")).unwrap();
         assert_eq!(headers.get::<ContentLength>(), Some(&ContentLength(10)));
+    }
+
+    #[test]
+    fn test_deny_plus_for_content_length() {
+        let headers = Headers::from_raw(&raw!(b"Content-Length: +10")).unwrap();
+        assert_eq!(headers.get::<ContentLength>(), None);
     }
 
     #[test]

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -540,7 +540,7 @@ impl<'a> FromIterator<HeaderView<'a>> for Headers {
     }
 }
 
-
+#[deprecated(note="The semantics of formatting a HeaderFormat directly are not clear")]
 impl<'a> fmt::Display for &'a (HeaderFormat + Send + Sync) {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
change of the content-length header parsing to use a parser that expects
the content-length content to be of type digits (u64)

Since Rust Rocket v0.4.x is still using the old hyper library, this is
important applications to parse the security audit.

BREAKING CHANGE: None, unless some systems rely on a security flaw in
hyper.