### PR TITLE
0.13.x security fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tower-util = "0.3"
 url = "1.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dev-dependencies]
-pnet = "0.25.0"
+pnet = "0.27.2"
 
 [features]
 default = [

--- a/src/common/sync_wrapper.rs
+++ b/src/common/sync_wrapper.rs
@@ -4,8 +4,8 @@
 //! A mutual exclusion primitive that relies on static type information only
 //!
 //! This library is inspired by [this discussion](https://internals.rust-lang.org/t/what-shall-sync-mean-across-an-await/12020/2).
-#![doc(html_logo_url = "https://developer.actyx.com/img/logo.svg")]
-#![doc(html_favicon_url = "https://developer.actyx.com/img/favicon.ico")]
+//#![doc(html_logo_url = "https://developer.actyx.com/img/logo.svg")]
+//#![doc(html_favicon_url = "https://developer.actyx.com/img/favicon.ico")]
 
 /// A mutual exclusion primitive that relies on static type information only
 ///

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -505,7 +505,7 @@ mod tests {
                     }
                 };
                 if state == ChunkedState::Body || state == ChunkedState::End {
-                    panic!(format!("Was Ok. Expected Err for {:?}", s));
+                    panic!("Was Ok. Expected Err for {:?}", s);
                 }
             }
         }

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -211,19 +211,32 @@ impl ChunkedState {
         size: &mut u64,
     ) -> Poll<Result<ChunkedState, io::Error>> {
         trace!("Read chunk hex size");
+
+        macro_rules! or_overflow {
+            ($e:expr) => (
+                match $e {
+                    Some(val) => val,
+                    None => return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "invalid chunk size: overflow",
+                    ))),
+                }
+            )
+        }
+
         let radix = 16;
         match byte!(rdr, cx) {
             b @ b'0'..=b'9' => {
-                *size *= radix;
-                *size += (b - b'0') as u64;
+                *size = or_overflow!(size.checked_mul(radix));
+                *size = or_overflow!(size.checked_add((b - b'0') as u64));
             }
             b @ b'a'..=b'f' => {
-                *size *= radix;
-                *size += (b + 10 - b'a') as u64;
+                *size = or_overflow!(size.checked_mul(radix));
+                *size = or_overflow!(size.checked_add((b + 10 - b'a') as u64));
             }
             b @ b'A'..=b'F' => {
-                *size *= radix;
-                *size += (b + 10 - b'A') as u64;
+                *size = or_overflow!(size.checked_mul(radix));
+                *size = or_overflow!(size.checked_add((b + 10 - b'A') as u64));
             }
             b'\t' | b' ' => return Poll::Ready(Ok(ChunkedState::SizeLws)),
             b';' => return Poll::Ready(Ok(ChunkedState::Extension)),
@@ -451,7 +464,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_chunk_size() {
-        use std::io::ErrorKind::{InvalidInput, UnexpectedEof};
+        use std::io::ErrorKind::{InvalidData, InvalidInput, UnexpectedEof};
 
         async fn read(s: &str) -> u64 {
             let mut state = ChunkedState::Size;
@@ -526,6 +539,8 @@ mod tests {
         read_err("1 invalid extension\r\n", InvalidInput).await;
         read_err("1 A\r\n", InvalidInput).await;
         read_err("1;no CRLF", UnexpectedEof).await;
+        // Overflow
+        read_err("f0000000000000003\r\n", InvalidData).await;
     }
 
     #[tokio::test]

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -402,6 +402,44 @@ fn get_chunked_response_with_ka() {
 }
 
 #[test]
+fn post_with_content_length_body() {
+    let server = serve();
+    let mut req = connect(server.addr());
+    req.write_all(
+        b"\
+        POST / HTTP/1.1\r\n\
+        Content-Length: 5\r\n\
+        \r\n\
+        hello\
+    ",
+    )
+    .unwrap();
+    req.read(&mut [0; 256]).unwrap();
+
+    assert_eq!(server.body(), b"hello");
+}
+
+#[test]
+fn post_with_invalid_prefix_content_length() {
+    let server = serve();
+    let mut req = connect(server.addr());
+    req.write_all(
+        b"\
+        POST / HTTP/1.1\r\n\
+        Content-Length: +5\r\n\
+        \r\n\
+        hello\
+    ",
+    )
+    .unwrap();
+
+    let mut buf = [0; 256];
+    let _n = req.read(&mut buf).unwrap();
+    let expected = "HTTP/1.1 400 Bad Request\r\n";
+    assert_eq!(s(&buf[..expected.len()]), expected);
+}
+
+#[test]
 fn post_with_chunked_body() {
     let server = serve();
     let mut req = connect(server.addr());

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -428,6 +428,35 @@ fn post_with_chunked_body() {
 }
 
 #[test]
+fn post_with_chunked_overflow() {
+    let server = serve();
+    let mut req = connect(server.addr());
+    req.write_all(
+        b"\
+        POST / HTTP/1.1\r\n\
+        Host: example.domain\r\n\
+        Transfer-Encoding: chunked\r\n\
+        \r\n\
+        f0000000000000003\r\n\
+        abc\r\n\
+        0\r\n\
+        \r\n\
+        GET /sneaky HTTP/1.1\r\n\
+        \r\n\
+    ",
+    )
+    .unwrap();
+    req.read(&mut [0; 256]).unwrap();
+
+    let err = server.body_err().to_string();
+    assert!(
+        err.contains("overflow"),
+        "error should be overflow: {:?}",
+        err
+    );
+}
+
+#[test]
 fn post_with_incomplete_body() {
     let _ = pretty_env_logger::try_init();
     let server = serve();


### PR DESCRIPTION
We have a large codebase utilizing tokio 0.2 and hyper 0.13. It would not be possible for us to promptly upgrade everything to tokio 1 and hyper 0.14. So here's the backport of security fixes for 0.13.x branch.