### PR TITLE
examples/Makefile: fix typo in the upload build

### DIFF
--- a/capi/examples/Makefile
+++ b/capi/examples/Makefile
@@ -19,7 +19,7 @@ $(TARGET): $(OBJS)
 	$(CC) -o $(TARGET) $(OBJS) $(LDFLAGS) $(LIBS)
 
 $(TARGET2): $(OBJS2)
-	$(CC) -o $(TARGET2) $(OBJS) $(LDFLAGS) $(LIBS)
+	$(CC) -o $(TARGET2) $(OBJS2) $(LDFLAGS) $(LIBS)
 
 clean:
 	rm -f $(OBJS) $(TARGET) $(OBJS2) $(TARGET2)


### PR DESCRIPTION
Sorry, it used the wrong object to build `upload`...