### PR TITLE
fix(ffi): on_informational callback had no headers

### DIFF
--- a/capi/examples/upload.c
+++ b/capi/examples/upload.c
@@ -148,7 +148,7 @@ static int print_each_header(void *userdata,
     return HYPER_ITER_CONTINUE;
 }
 
-static void print_informational(void *userdata, const hyper_response *resp) {
+static void print_informational(void *userdata, hyper_response *resp) {
     uint16_t http_status = hyper_response_status(resp);
 
     printf("\nInformational (1xx): %d\n", http_status);

--- a/capi/include/hyper.h
+++ b/capi/include/hyper.h
@@ -207,7 +207,7 @@ typedef int (*hyper_body_foreach_callback)(void*, const struct hyper_buf*);
 
 typedef int (*hyper_body_data_callback)(void*, struct hyper_context*, struct hyper_buf**);
 
-typedef void (*hyper_request_on_informational_callback)(void*, const struct hyper_response*);
+typedef void (*hyper_request_on_informational_callback)(void*, struct hyper_response*);
 
 typedef int (*hyper_headers_foreach_callback)(void*, const uint8_t*, size_t, const uint8_t*, size_t);
 
@@ -469,7 +469,7 @@ enum hyper_code hyper_request_set_body(struct hyper_request *req, struct hyper_b
  `hyper_response *` which can be inspected as any other response. The
  body of the response will always be empty.
 
- NOTE: The `const hyper_response *` is just borrowed data, and will not
+ NOTE: The `hyper_response *` is just borrowed data, and will not
  be valid after the callback finishes. You must copy any data you wish
  to persist.
  */

--- a/src/ffi/http_types.rs
+++ b/src/ffi/http_types.rs
@@ -34,7 +34,7 @@ pub(crate) struct OnInformational {
     data: UserDataPointer,
 }
 
-type hyper_request_on_informational_callback = extern "C" fn(*mut c_void, *const hyper_response);
+type hyper_request_on_informational_callback = extern "C" fn(*mut c_void, *mut hyper_response);
 
 // ===== impl hyper_request =====
 
@@ -153,7 +153,7 @@ ffi_fn! {
     /// `hyper_response *` which can be inspected as any other response. The
     /// body of the response will always be empty.
     ///
-    /// NOTE: The `const hyper_response *` is just borrowed data, and will not
+    /// NOTE: The `hyper_response *` is just borrowed data, and will not
     /// be valid after the callback finishes. You must copy any data you wish
     /// to persist.
     fn hyper_request_on_informational(req: *mut hyper_request, callback: hyper_request_on_informational_callback, data: *mut c_void) -> hyper_code {
@@ -437,7 +437,7 @@ unsafe fn raw_name_value(
 
 impl OnInformational {
     pub(crate) fn call(&mut self, resp: Response<Body>) {
-        let mut resp = hyper_response(resp);
+        let mut resp = hyper_response::wrap(resp);
         (self.func)(self.data.0, &mut resp);
     }
 }

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1,5 +1,5 @@
 use std::fmt::{self, Write};
-use std::mem::{self, MaybeUninit};
+use std::mem::MaybeUninit;
 
 #[cfg(any(test, feature = "server", feature = "ffi"))]
 use bytes::Bytes;
@@ -360,7 +360,7 @@ impl Http1Transaction for Server {
         }
 
         let orig_headers;
-        let extensions = mem::take(&mut msg.head.extensions);
+        let extensions = std::mem::take(&mut msg.head.extensions);
         let orig_headers = match extensions.get::<HeaderCaseMap>() {
             None if msg.title_case_headers => {
                 orig_headers = HeaderCaseMap::default();


### PR DESCRIPTION
The response wasn't properly "wrapped", which builds up the original case map too. Noted in #2565.