### PR TITLE
Export more things with Cargo features [server, !http1, !http2]

### DIFF
--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -50,6 +50,8 @@ impl DecodedLength {
     /// Checks the `u64` is within the maximum allowed for content-length.
     #[cfg(any(feature = "http1", feature = "http2"))]
     pub(crate) fn checked_new(len: u64) -> Result<Self, crate::error::Parse> {
+        use tracing::warn;
+
         if len <= MAX_LEN {
             Ok(DecodedLength(len))
         } else {

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -24,24 +24,6 @@ macro_rules! cfg_proto {
 }
 
 cfg_proto! {
-    macro_rules! cfg_http1 {
-        ($($item:item)*) => {
-            cfg_feature! {
-                #![feature = "http1"]
-                $($item)*
-            }
-        }
-    }
-
-    macro_rules! cfg_http2 {
-        ($($item:item)*) => {
-            cfg_feature! {
-                #![feature = "http2"]
-                $($item)*
-            }
-        }
-    }
-
     macro_rules! cfg_client {
         ($($item:item)*) => {
             cfg_feature! {

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -8,6 +8,7 @@ use futures_util::future::{self, Either, FutureExt as _, TryFutureExt as _};
 use http::header::{HeaderValue, HOST};
 use http::uri::{Port, Scheme};
 use http::{Method, Request, Response, Uri, Version};
+use tracing::{debug, trace, warn};
 
 use super::conn;
 use super::connect::{self, sealed::Connect, Alpn, Connected, Connection};

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -60,6 +60,7 @@ use httparse::ParserConfig;
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
+use tracing::{debug, trace};
 
 use super::dispatch;
 use crate::body::HttpBody;

--- a/src/client/connect/dns.rs
+++ b/src/client/connect/dns.rs
@@ -31,6 +31,7 @@ use std::{fmt, io, vec};
 
 use tokio::task::JoinHandle;
 use tower_service::Service;
+use tracing::debug;
 
 pub(super) use self::sealed::Resolve;
 

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -14,6 +14,7 @@ use http::uri::{Scheme, Uri};
 use pin_project_lite::pin_project;
 use tokio::net::{TcpSocket, TcpStream};
 use tokio::time::Sleep;
+use tracing::{debug, trace, warn};
 
 use super::dns::{self, resolve, GaiResolver, Resolve};
 use super::{Connected, Connection};

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -235,6 +235,7 @@ impl<T, U> Callback<T, U> {
         mut when: impl Future<Output = Result<U, (crate::Error, Option<T>)>> + Unpin,
     ) {
         use futures_util::future;
+        use tracing::trace;
 
         let mut cb = Some(self);
 

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use futures_channel::oneshot;
 #[cfg(feature = "runtime")]
 use tokio::time::{Duration, Instant, Interval};
+use tracing::{debug, trace};
 
 use super::client::Ver;
 use crate::common::{exec::Exec, task, Future, Pin, Poll, Unpin};

--- a/src/client/service.rs
+++ b/src/client/service.rs
@@ -6,6 +6,8 @@ use std::error::Error as StdError;
 use std::future::Future;
 use std::marker::PhantomData;
 
+use tracing::debug;
+
 use super::conn::{Builder, SendRequest};
 use crate::{
     body::HttpBody,

--- a/src/common/exec.rs
+++ b/src/common/exec.rs
@@ -3,14 +3,16 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+#[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
+use crate::body::Body;
 #[cfg(feature = "server")]
-use crate::body::{Body, HttpBody};
+use crate::body::HttpBody;
 #[cfg(all(feature = "http2", feature = "server"))]
 use crate::proto::h2::server::H2Stream;
 use crate::rt::Executor;
-#[cfg(feature = "server")]
+#[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 use crate::server::conn::spawn_all::{NewSvcTask, Watcher};
-#[cfg(feature = "server")]
+#[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 use crate::service::HttpService;
 
 #[cfg(feature = "server")]
@@ -18,7 +20,7 @@ pub trait ConnStreamExec<F, B: HttpBody>: Clone {
     fn execute_h2stream(&mut self, fut: H2Stream<F, B>);
 }
 
-#[cfg(feature = "server")]
+#[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 pub trait NewSvcExec<I, N, S: HttpService<Body>, E, W: Watcher<I, S, E>>: Clone {
     fn execute_new_svc(&mut self, fut: NewSvcTask<I, N, S, E, W>);
 }
@@ -76,7 +78,7 @@ where
     }
 }
 
-#[cfg(feature = "server")]
+#[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 impl<I, N, S, E, W> NewSvcExec<I, N, S, E, W> for Exec
 where
     NewSvcTask<I, N, S, E, W>: Future<Output = ()> + Send + 'static,
@@ -102,7 +104,7 @@ where
     }
 }
 
-#[cfg(feature = "server")]
+#[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 impl<I, N, S, E, W> NewSvcExec<I, N, S, E, W> for E
 where
     E: Executor<NewSvcTask<I, N, S, E, W>> + Clone,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -25,12 +25,7 @@ pub(crate) mod watch;
 
 #[cfg(all(feature = "client", any(feature = "http1", feature = "http2")))]
 pub(crate) use self::lazy::{lazy, Started as Lazy};
-#[cfg(any(
-    feature = "client",
-    feature = "http1",
-    feature = "http2",
-    feature = "runtime"
-))]
+#[cfg(any(feature = "http1", feature = "http2", feature = "runtime"))]
 pub(crate) use self::never::Never;
 pub(crate) use self::task::Poll;
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod buf;
 pub(crate) mod date;
 #[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 pub(crate) mod drain;
-#[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(any(feature = "http1", feature = "http2", feature = "server"))]
 pub(crate) mod exec;
 pub(crate) mod io;
 #[cfg(all(feature = "client", any(feature = "http1", feature = "http2")))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,11 +38,7 @@ pub(super) enum Kind {
     #[allow(unused)]
     Connect,
     /// Error creating a TcpListener.
-    #[cfg(all(
-        any(feature = "http1", feature = "http2"),
-        feature = "tcp",
-        feature = "server"
-    ))]
+    #[cfg(all(feature = "tcp", feature = "server"))]
     Listen,
     /// Error accepting on an Incoming stream.
     #[cfg(any(feature = "http1", feature = "http2"))]
@@ -265,8 +261,7 @@ impl Error {
         Error::new(Kind::Io).with(cause)
     }
 
-    #[cfg(all(any(feature = "http1", feature = "http2"), feature = "tcp"))]
-    #[cfg(feature = "server")]
+    #[cfg(all(feature = "server", feature = "tcp"))]
     pub(super) fn new_listen<E: Into<Cause>>(cause: E) -> Error {
         Error::new(Kind::Listen).with(cause)
     }
@@ -410,8 +405,7 @@ impl Error {
             Kind::ChannelClosed => "channel closed",
             Kind::Connect => "error trying to connect",
             Kind::Canceled => "operation was canceled",
-            #[cfg(all(any(feature = "http1", feature = "http2"), feature = "tcp"))]
-            #[cfg(feature = "server")]
+            #[cfg(all(feature = "server", feature = "tcp"))]
             Kind::Listen => "error creating server listener",
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "server")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,6 @@ cfg_feature! {
     #![feature = "server"]
 
     pub mod server;
-    #[cfg(any(feature = "http1", feature = "http2"))]
     #[doc(no_inline)]
     pub use crate::server::Server;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,6 @@ mod error;
 mod ext;
 #[cfg(test)]
 mod mock;
-#[cfg(any(feature = "http1", feature = "http2",))]
 pub mod rt;
 pub mod service;
 pub mod upgrade;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ cfg_proto! {
 }
 
 cfg_feature! {
-    #![all(feature = "client")]
+    #![feature = "client"]
 
     pub mod client;
     #[cfg(any(feature = "http1", feature = "http2"))]
@@ -102,7 +102,7 @@ cfg_feature! {
 }
 
 cfg_feature! {
-    #![all(feature = "server")]
+    #![feature = "server"]
 
     pub mod server;
     #[cfg(any(feature = "http1", feature = "http2"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,13 +58,6 @@
 
 #[doc(hidden)]
 pub use http;
-#[cfg(any(
-    feature = "http1",
-    feature = "http2",
-    all(feature = "client", feature = "tcp")
-))]
-#[macro_use]
-extern crate tracing;
 
 #[cfg(all(test, feature = "nightly"))]
 extern crate test;

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -7,6 +7,7 @@ use http::header::{HeaderValue, CONNECTION};
 use http::{HeaderMap, Method, Version};
 use httparse::ParserConfig;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tracing::{debug, error, trace};
 
 use super::io::Buffered;
 use super::{Decoder, Encode, EncodedBuf, Encoder, Http1Transaction, ParseContext, Wants};
@@ -538,9 +539,8 @@ where
 
                 #[cfg(feature = "ffi")]
                 {
-                    self.state.on_informational = head
-                        .extensions
-                        .remove::<crate::ffi::OnInformational>();
+                    self.state.on_informational =
+                        head.extensions.remove::<crate::ffi::OnInformational>();
                 }
 
                 Some(encoder)

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -4,6 +4,7 @@ use std::io;
 use std::usize;
 
 use bytes::Bytes;
+use tracing::{debug, trace};
 
 use crate::common::{task, Poll};
 

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -3,6 +3,7 @@ use std::error::Error as StdError;
 use bytes::{Buf, Bytes};
 use http::Request;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tracing::{debug, trace};
 
 use super::{Http1Transaction, Wants};
 use crate::body::{Body, DecodedLength, HttpBody};

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -3,6 +3,7 @@ use std::io::IoSlice;
 
 use bytes::buf::{Chain, Take};
 use bytes::Buf;
+use tracing::trace;
 
 use super::io::WriteBuf;
 

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -6,6 +6,7 @@ use std::mem::MaybeUninit;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tracing::{debug, trace};
 
 use super::{Http1Transaction, ParseContext, ParsedMessage};
 use crate::common::buf::BufList;

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -9,6 +9,7 @@ use futures_util::stream::StreamExt as _;
 use h2::client::{Builder, SendRequest};
 use http::{Method, StatusCode};
 use tokio::io::{AsyncRead, AsyncWrite};
+use tracing::{debug, trace, warn};
 
 use super::{ping, H2Upgraded, PipeToSendStream, SendBuf};
 use crate::body::HttpBody;

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -8,6 +8,7 @@ use std::io::{self, Cursor, IoSlice};
 use std::mem;
 use std::task::Context;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tracing::{debug, trace, warn};
 
 use crate::body::HttpBody;
 use crate::common::{task, Future, Pin, Poll};

--- a/src/proto/h2/ping.rs
+++ b/src/proto/h2/ping.rs
@@ -34,6 +34,7 @@ use std::time::Instant;
 use h2::{Ping, PingPong};
 #[cfg(feature = "runtime")]
 use tokio::time::{Instant, Sleep};
+use tracing::{debug, trace};
 
 type WindowSize = u32;
 

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -9,6 +9,7 @@ use h2::{Reason, RecvStream};
 use http::{Method, Request};
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tracing::{debug, trace, warn};
 
 use super::{ping, PipeToSendStream, SendBuf};
 use crate::body::HttpBody;

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,6 +1,8 @@
 //! Pieces pertaining to the HTTP message protocol.
 
-cfg_http1! {
+cfg_feature! {
+    #![feature = "http1"]
+
     pub(crate) mod h1;
 
     pub(crate) use self::h1::Conn;
@@ -11,9 +13,8 @@ cfg_http1! {
     pub(crate) use self::h1::ServerTransaction;
 }
 
-cfg_http2! {
-    pub(crate) mod h2;
-}
+#[cfg(feature = "http2")]
+pub(crate) mod h2;
 
 /// An Incoming Message head. Includes request/status line, and headers.
 #[derive(Debug, Default)]

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -73,8 +73,7 @@ use crate::service::{HttpService, MakeServiceRef};
 use crate::upgrade::Upgraded;
 
 use self::spawn_all::NewSvcTask;
-pub(super) use self::spawn_all::NoopWatcher;
-pub(super) use self::spawn_all::Watcher;
+pub(super) use self::spawn_all::{NoopWatcher, Watcher};
 pub(super) use self::upgrades::UpgradeableConnection;
 
 #[cfg(feature = "tcp")]

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -55,6 +55,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tracing::trace;
 
 use super::accept::Accept;
 use crate::body::{Body, HttpBody};
@@ -1037,6 +1038,7 @@ where
 pub(crate) mod spawn_all {
     use std::error::Error as StdError;
     use tokio::io::{AsyncRead, AsyncWrite};
+    use tracing::debug;
 
     use super::{Connecting, UpgradeableConnection};
     use crate::body::{Body, HttpBody};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -157,10 +157,6 @@ cfg_feature! {
     pub mod conn;
     mod server;
     mod shutdown;
-
-    cfg_feature! {
-        #![feature = "tcp"]
-
-        mod tcp;
-    }
+    #[cfg(feature = "tcp")]
+    mod tcp;
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -148,15 +148,17 @@
 //! [`tower::make::Shared`]: https://docs.rs/tower/latest/tower/make/struct.Shared.html
 
 pub mod accept;
+pub mod conn;
+mod server;
+#[cfg(feature = "tcp")]
+mod tcp;
+
+pub use self::server::Server;
 
 cfg_feature! {
     #![any(feature = "http1", feature = "http2")]
 
-    pub use self::server::{Builder, Server};
+    pub use self::server::Builder;
 
-    pub mod conn;
-    mod server;
     mod shutdown;
-    #[cfg(feature = "tcp")]
-    mod tcp;
 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -353,8 +353,7 @@ impl<I, E> Builder<I, E> {
     /// # Cargo Feature
     ///
     /// Requires the `runtime` cargo feature to be enabled.
-    #[cfg(feature = "runtime")]
-    #[cfg(feature = "http2")]
+    #[cfg(all(feature = "runtime", feature = "http2"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_interval(mut self, interval: impl Into<Option<Duration>>) -> Self {
         self.protocol.http2_keep_alive_interval(interval);
@@ -371,8 +370,7 @@ impl<I, E> Builder<I, E> {
     /// # Cargo Feature
     ///
     /// Requires the `runtime` cargo feature to be enabled.
-    #[cfg(feature = "runtime")]
-    #[cfg(feature = "http2")]
+    #[cfg(all(feature = "runtime", feature = "http2"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_timeout(mut self, timeout: Duration) -> Self {
         self.protocol.http2_keep_alive_timeout(timeout);

--- a/src/server/shutdown.rs
+++ b/src/server/shutdown.rs
@@ -2,6 +2,7 @@ use std::error::Error as StdError;
 
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
+use tracing::debug;
 
 use super::accept::Accept;
 use super::conn::{SpawnAll, UpgradeableConnection, Watcher};

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use tokio::net::TcpListener;
 use tokio::time::Sleep;
+use tracing::{debug, error, trace};
 
 use crate::common::{task, Future, Pin, Poll};
 

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -14,6 +14,8 @@ use std::marker::Unpin;
 use bytes::Bytes;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::oneshot;
+#[cfg(any(feature = "http1", feature = "http2"))]
+use tracing::trace;
 
 use crate::common::io::Rewind;
 use crate::common::{task, Future, Pin, Poll};


### PR DESCRIPTION
I discovered in https://github.com/tokio-rs/axum/pull/286 that two items from hyper that axum uses (`Server`, `server::conn::AddrStream`) are not available without one of `http1`, `http2` being activated even though it seemed like they could be made available. This PR makes them available (among some other refactorings), albeit with `Server` not actually being usable.