### PR TITLE
fix(client): remove ipv6 square brackets before resolving

### DIFF
--- a/src/client/connect/dns.rs
+++ b/src/client/connect/dns.rs
@@ -191,7 +191,6 @@ impl SocketAddrs {
                 iter: vec![SocketAddr::V4(addr)].into_iter(),
             });
         }
-        let host = host.trim_start_matches('[').trim_end_matches(']');
         if let Ok(addr) = host.parse::<Ipv6Addr>() {
             let addr = SocketAddrV6::new(addr, port, 0, 0);
             return Some(SocketAddrs {

--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -326,6 +326,7 @@ where
         let config = &self.config;
 
         let (host, port) = get_host_port(config, &dst)?;
+        let host = host.trim_start_matches('[').trim_end_matches(']');
 
         // If the host is already an IP addr (v4 or v6),
         // skip resolving the dns and start connecting right away.


### PR DESCRIPTION
Greetings,

When trying to send a request to an IPv6 link local address such as

```
http://[fe80::1234%2]:8080/foo
```
the changes that came from https://github.com/hyperium/hyper/pull/1937 go a long ways toward making things work. However, when the address is passed to the resolver it still contains the square brackets. These square brackets are specific to URL-encoded [[1]] addresses and do not constitute a valid IPv6 address representation on their own AFAICT. So when `[fe80::1234%2]` gets passed to the `getaddrinfo` resolver on some platforms it's not recognized as an IPV6 address with a scope and an attempt at DNS resolution results.

This patch moves the stripping of the square brackets a bit earlier in the call chain so that both `try_parse` and `resolve` see an IPv6 address with URL-specific encoding removed.

### Minimum Reproducible Example

Running the following on [illumos](https://illumos.org) results in a failed DNS lookup, substituting in appropriate values for the address and interface index. After applying this patch, the communication works as expected.

```rust
use tokio;
use hyper;
use std::str::FromStr;

type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;

#[tokio::main]
async fn main() -> Result<()> {

    let client = hyper::Client::new();
    let uri = hyper::Uri::from_str("http://[fe80::1234%2]:914/foo").unwrap();
    let resp = client.get(uri).await?;
    println!("response: {:#?}", resp);

    Ok(())
}
```

[1]: https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2