### PR TITLE
refactor(http1): Quite trace in opentelemetry contexts

### DIFF
--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -67,8 +67,7 @@ where
         return Ok(None);
     }
 
-    let span = trace_span!("parse_headers");
-    let _s = span.enter();
+    let span = span!("parse_headers").entered();
     T::parse(bytes, ctx)
 }
 
@@ -79,8 +78,7 @@ pub(super) fn encode_headers<T>(
 where
     T: Http1Transaction,
 {
-    let span = trace_span!("encode_headers");
-    let _s = span.enter();
+    let span = span!("encode_headers").entered();
     T::encode(enc, dst)
 }
 


### PR DESCRIPTION
Setting up tracing+opentelemetry+jaeger, with only a root span, produces
no trace data except for output produced by these two `trace_span!` usages.
The test stack was Tokio+Hyper so there either should have been a lot
or no trace output.

