### PR TITLE
feat(h1): add server header read timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ full = [
 ]
 
 # HTTP versions
-http1 = []
+http1 = ["tokio/time"]
 http2 = ["h2"]
 
 # Client/Server

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ full = [
 ]
 
 # HTTP versions
-http1 = ["tokio/time"]
+http1 = []
 http2 = ["h2"]
 
 # Client/Server
@@ -100,6 +100,7 @@ stream = []
 runtime = [
     "tcp",
     "tokio/rt",
+    "tokio/time",
 ]
 tcp = [
     "socket2",

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,9 @@ pub(super) enum Kind {
     #[cfg(any(feature = "http1", feature = "http2"))]
     #[cfg(feature = "server")]
     Accept,
+    /// User took too long to send headers
+    #[cfg(all(feature = "http1", feature = "server", feature = "runtime"))]
+    HeaderTimeout,
     /// Error while reading a body from connection.
     #[cfg(any(feature = "http1", feature = "http2", feature = "stream"))]
     Body,
@@ -104,9 +107,6 @@ pub(super) enum User {
     #[cfg(any(feature = "http1", feature = "http2"))]
     #[cfg(feature = "server")]
     UnexpectedHeader,
-    /// User took too long to send headers
-    #[cfg(all(feature = "http1", feature = "runtime"))]
-    HeaderTimeout,
     /// User tried to create a Request with bad version.
     #[cfg(any(feature = "http1", feature = "http2"))]
     #[cfg(feature = "client")]
@@ -313,9 +313,9 @@ impl Error {
         Error::new_user(User::UnexpectedHeader)
     }
 
-    #[cfg(all(feature = "http1", feature = "runtime"))]
+    #[cfg(all(feature = "http1", feature = "server", feature = "runtime"))]
     pub(super) fn new_header_timeout() -> Error {
-        Error::new_user(User::HeaderTimeout)
+        Error::new(Kind::HeaderTimeout)
     }
 
     #[cfg(any(feature = "http1", feature = "http2"))]
@@ -427,6 +427,8 @@ impl Error {
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "server")]
             Kind::Accept => "error accepting connection",
+            #[cfg(all(feature = "http1", feature = "server", feature = "runtime"))]
+            Kind::HeaderTimeout => "read header from client timeout",
             #[cfg(any(feature = "http1", feature = "http2", feature = "stream"))]
             Kind::Body => "error reading a body from connection",
             #[cfg(any(feature = "http1", feature = "http2"))]
@@ -449,8 +451,6 @@ impl Error {
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "server")]
             Kind::User(User::UnexpectedHeader) => "user sent unexpected header",
-            #[cfg(all(feature = "http1", feature = "runtime"))]
-            Kind::User(User::HeaderTimeout) => "read header from client timeout",
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "client")]
             Kind::User(User::UnsupportedVersion) => "request has unsupported HTTP version",

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,7 +105,7 @@ pub(super) enum User {
     #[cfg(feature = "server")]
     UnexpectedHeader,
     /// User took too long to send headers
-    #[cfg(feature = "http1")]
+    #[cfg(all(feature = "http1", feature = "runtime"))]
     HeaderTimeout,
     /// User tried to create a Request with bad version.
     #[cfg(any(feature = "http1", feature = "http2"))]
@@ -313,7 +313,7 @@ impl Error {
         Error::new_user(User::UnexpectedHeader)
     }
 
-    #[cfg(feature = "http1")]
+    #[cfg(all(feature = "http1", feature = "runtime"))]
     pub(super) fn new_header_timeout() -> Error {
         Error::new_user(User::HeaderTimeout)
     }
@@ -449,7 +449,7 @@ impl Error {
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "server")]
             Kind::User(User::UnexpectedHeader) => "user sent unexpected header",
-            #[cfg(feature = "http1")]
+            #[cfg(all(feature = "http1", feature = "runtime"))]
             Kind::User(User::HeaderTimeout) => "read header from client timeout",
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "client")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,6 +104,9 @@ pub(super) enum User {
     #[cfg(any(feature = "http1", feature = "http2"))]
     #[cfg(feature = "server")]
     UnexpectedHeader,
+    /// User took too long to send headers
+    #[cfg(feature = "http1")]
+    HeaderTimeout,
     /// User tried to create a Request with bad version.
     #[cfg(any(feature = "http1", feature = "http2"))]
     #[cfg(feature = "client")]
@@ -310,6 +313,11 @@ impl Error {
         Error::new_user(User::UnexpectedHeader)
     }
 
+    #[cfg(feature = "http1")]
+    pub(super) fn new_header_timeout() -> Error {
+        Error::new_user(User::HeaderTimeout)
+    }
+
     #[cfg(any(feature = "http1", feature = "http2"))]
     #[cfg(feature = "client")]
     pub(super) fn new_user_unsupported_version() -> Error {
@@ -441,6 +449,8 @@ impl Error {
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "server")]
             Kind::User(User::UnexpectedHeader) => "user sent unexpected header",
+            #[cfg(feature = "http1")]
+            Kind::User(User::HeaderTimeout) => "read header from client timeout",
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "client")]
             Kind::User(User::UnsupportedVersion) => "request has unsupported HTTP version",

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -111,7 +111,7 @@ where
     }
 
     #[cfg(feature = "server")]
-    pub(crate) fn set_http1_header_parse_timeout(&mut self, val: Duration) {
+    pub(crate) fn set_http1_header_read_timeout(&mut self, val: Duration) {
         debug!("setting initial h1 header read timeout timer");
 
         self.state.h1_header_read_timeout = Some(val);

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -8,6 +8,7 @@ use http::header::{HeaderValue, CONNECTION};
 use http::{HeaderMap, Method, Version};
 use httparse::ParserConfig;
 use tokio::io::{AsyncRead, AsyncWrite};
+#[cfg(all(feature = "server", feature = "runtime"))]
 use tokio::time::Sleep;
 use tracing::{debug, error, trace};
 
@@ -49,7 +50,9 @@ where
                 keep_alive: KA::Busy,
                 method: None,
                 h1_parser_config: ParserConfig::default(),
+                #[cfg(all(feature = "server", feature = "runtime"))]
                 h1_header_read_timeout: None,
+                #[cfg(all(feature = "server", feature = "runtime"))]
                 h1_header_read_timeout_fut: None,
                 preserve_header_case: false,
                 title_case_headers: false,
@@ -110,7 +113,7 @@ where
         self.state.h09_responses = true;
     }
 
-    #[cfg(feature = "server")]
+    #[cfg(all(feature = "server", feature = "runtime"))]
     pub(crate) fn set_http1_header_read_timeout(&mut self, val: Duration) {
         self.state.h1_header_read_timeout = Some(val);
     }
@@ -187,7 +190,9 @@ where
                 cached_headers: &mut self.state.cached_headers,
                 req_method: &mut self.state.method,
                 h1_parser_config: self.state.h1_parser_config.clone(),
+                #[cfg(all(feature = "server", feature = "runtime"))]
                 h1_header_read_timeout: self.state.h1_header_read_timeout,
+                #[cfg(all(feature = "server", feature = "runtime"))]
                 h1_header_read_timeout_fut: &mut self.state.h1_header_read_timeout_fut,
                 preserve_header_case: self.state.preserve_header_case,
                 h09_responses: self.state.h09_responses,
@@ -809,7 +814,9 @@ struct State {
     /// a body or not.
     method: Option<Method>,
     h1_parser_config: ParserConfig,
+    #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout: Option<Duration>,
+    #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout_fut: Option<Pin<Box<Sleep>>>,
     preserve_header_case: bool,
     title_case_headers: bool,

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -112,10 +112,7 @@ where
 
     #[cfg(feature = "server")]
     pub(crate) fn set_http1_header_read_timeout(&mut self, val: Duration) {
-        debug!("setting initial h1 header read timeout timer");
-
         self.state.h1_header_read_timeout = Some(val);
-        self.state.h1_header_read_timeout_fut = Some(Box::pin(tokio::time::sleep(val)));
     }
 
     #[cfg(feature = "server")]

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -54,6 +54,8 @@ where
                 h1_header_read_timeout: None,
                 #[cfg(all(feature = "server", feature = "runtime"))]
                 h1_header_read_timeout_fut: None,
+                #[cfg(all(feature = "server", feature = "runtime"))]
+                h1_header_read_timeout_running: false,
                 preserve_header_case: false,
                 title_case_headers: false,
                 h09_responses: false,
@@ -194,6 +196,8 @@ where
                 h1_header_read_timeout: self.state.h1_header_read_timeout,
                 #[cfg(all(feature = "server", feature = "runtime"))]
                 h1_header_read_timeout_fut: &mut self.state.h1_header_read_timeout_fut,
+                #[cfg(all(feature = "server", feature = "runtime"))]
+                h1_header_read_timeout_running: &mut self.state.h1_header_read_timeout_running,
                 preserve_header_case: self.state.preserve_header_case,
                 h09_responses: self.state.h09_responses,
                 #[cfg(feature = "ffi")]
@@ -818,6 +822,8 @@ struct State {
     h1_header_read_timeout: Option<Duration>,
     #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout_fut: Option<Pin<Box<Sleep>>>,
+    #[cfg(all(feature = "server", feature = "runtime"))]
+    h1_header_read_timeout_running: bool,
     preserve_header_case: bool,
     title_case_headers: bool,
     h09_responses: bool,

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -49,9 +49,7 @@ where
                 keep_alive: KA::Busy,
                 method: None,
                 h1_parser_config: ParserConfig::default(),
-                #[cfg(feature = "server")]
                 h1_header_read_timeout: None,
-                #[cfg(feature = "server")]
                 h1_header_read_timeout_fut: None,
                 preserve_header_case: false,
                 title_case_headers: false,
@@ -189,9 +187,7 @@ where
                 cached_headers: &mut self.state.cached_headers,
                 req_method: &mut self.state.method,
                 h1_parser_config: self.state.h1_parser_config.clone(),
-                #[cfg(feature = "server")]
                 h1_header_read_timeout: self.state.h1_header_read_timeout,
-                #[cfg(feature = "server")]
                 h1_header_read_timeout_fut: &mut self.state.h1_header_read_timeout_fut,
                 preserve_header_case: self.state.preserve_header_case,
                 h09_responses: self.state.h09_responses,
@@ -813,9 +809,7 @@ struct State {
     /// a body or not.
     method: Option<Method>,
     h1_parser_config: ParserConfig,
-    #[cfg(feature = "server")]
     h1_header_read_timeout: Option<Duration>,
-    #[cfg(feature = "server")]
     h1_header_read_timeout_fut: Option<Pin<Box<Sleep>>>,
     preserve_header_case: bool,
     title_case_headers: bool,

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -182,7 +182,9 @@ where
                     cached_headers: parse_ctx.cached_headers,
                     req_method: parse_ctx.req_method,
                     h1_parser_config: parse_ctx.h1_parser_config.clone(),
+                    #[cfg(all(feature = "server", feature = "runtime"))]
                     h1_header_read_timeout: parse_ctx.h1_header_read_timeout,
+                    #[cfg(all(feature = "server", feature = "runtime"))]
                     h1_header_read_timeout_fut: parse_ctx.h1_header_read_timeout_fut,
                     preserve_header_case: parse_ctx.preserve_header_case,
                     h09_responses: parse_ctx.h09_responses,
@@ -195,7 +197,10 @@ where
                 Some(msg) => {
                     debug!("parsed {} headers", msg.head.headers.len());
 
-                    *parse_ctx.h1_header_read_timeout_fut = None;
+                    #[cfg(all(feature = "server", feature = "runtime"))]
+                    {
+                        *parse_ctx.h1_header_read_timeout_fut = None;
+                    }
                     return Poll::Ready(Ok(msg));
                 }
                 None => {
@@ -205,6 +210,7 @@ where
                         return Poll::Ready(Err(crate::Error::new_too_large()));
                     }
 
+                    #[cfg(all(feature = "server", feature = "runtime"))]
                     if let Some(h1_header_read_timeout_fut) = parse_ctx.h1_header_read_timeout_fut {
                         if Pin::new( h1_header_read_timeout_fut).poll(cx).is_ready() {
                             *parse_ctx.h1_header_read_timeout_fut = None;

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -1,6 +1,10 @@
+use std::pin::Pin;
+use std::time::Duration;
+
 use bytes::BytesMut;
 use http::{HeaderMap, Method};
 use httparse::ParserConfig;
+use tokio::time::Sleep;
 
 use crate::body::DecodedLength;
 use crate::proto::{BodyLength, MessageHead};
@@ -72,6 +76,8 @@ pub(crate) struct ParseContext<'a> {
     cached_headers: &'a mut Option<HeaderMap>,
     req_method: &'a mut Option<Method>,
     h1_parser_config: ParserConfig,
+    h1_header_read_timeout: Option<Duration>,
+    h1_header_read_timeout_fut: &'a mut Option<Pin<Box<Sleep>>>,
     preserve_header_case: bool,
     h09_responses: bool,
     #[cfg(feature = "ffi")]

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use bytes::BytesMut;
 use http::{HeaderMap, Method};
 use httparse::ParserConfig;
+#[cfg(all(feature = "server", feature = "runtime"))]
 use tokio::time::Sleep;
 
 use crate::body::DecodedLength;
@@ -76,7 +77,9 @@ pub(crate) struct ParseContext<'a> {
     cached_headers: &'a mut Option<HeaderMap>,
     req_method: &'a mut Option<Method>,
     h1_parser_config: ParserConfig,
+    #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout: Option<Duration>,
+    #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout_fut: &'a mut Option<Pin<Box<Sleep>>>,
     preserve_header_case: bool,
     h09_responses: bool,

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -81,6 +81,8 @@ pub(crate) struct ParseContext<'a> {
     h1_header_read_timeout: Option<Duration>,
     #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout_fut: &'a mut Option<Pin<Box<Sleep>>>,
+    #[cfg(all(feature = "server", feature = "runtime"))]
+    h1_header_read_timeout_running: &'a mut bool,
     preserve_header_case: bool,
     h09_responses: bool,
     #[cfg(feature = "ffi")]

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -2560,6 +2560,7 @@ mod tests {
                     h1_parser_config: Default::default(),
                     h1_header_read_timeout: None,
                     h1_header_read_timeout_fut: &mut None,
+                    h1_header_read_timeout_running: &mut false,
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
@@ -2602,6 +2603,7 @@ mod tests {
                     h1_parser_config: Default::default(),
                     h1_header_read_timeout: None,
                     h1_header_read_timeout_fut: &mut None,
+                    h1_header_read_timeout_running: &mut false,
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -70,6 +70,7 @@ where
     let span = trace_span!("parse_headers");
     let _s = span.enter();
 
+    #[cfg(all(feature = "server", feature = "runtime"))]
     if let Some(h1_header_read_timeout) = ctx.h1_header_read_timeout {
         if ctx.h1_header_read_timeout_fut.is_none() {
             debug!("setting h1 header read timeout timer");

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -2531,6 +2531,8 @@ mod tests {
                     cached_headers: &mut headers,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
+                    h1_header_read_timeout: None,
+                    h1_header_read_timeout_fut: &mut None,
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
@@ -2571,6 +2573,8 @@ mod tests {
                     cached_headers: &mut headers,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
+                    h1_header_read_timeout: None,
+                    h1_header_read_timeout_fut: &mut None,
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -69,6 +69,14 @@ where
 
     let span = trace_span!("parse_headers");
     let _s = span.enter();
+
+    if let Some(h1_header_read_timeout) = ctx.h1_header_read_timeout {
+        if ctx.h1_header_read_timeout_fut.is_none() {
+            debug!("setting h1 header read timeout timer");
+            *ctx.h1_header_read_timeout_fut = Some(Box::pin(tokio::time::sleep(h1_header_read_timeout)));
+        }
+    }
+
     T::parse(bytes, ctx)
 }
 
@@ -1428,6 +1436,8 @@ mod tests {
                 cached_headers: &mut None,
                 req_method: &mut method,
                 h1_parser_config: Default::default(),
+                h1_header_read_timeout: None,
+                h1_header_read_timeout_fut: &mut None,
                 preserve_header_case: false,
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
@@ -1455,6 +1465,8 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
+            h1_header_read_timeout: None,
+            h1_header_read_timeout_fut: &mut None,
             preserve_header_case: false,
             h09_responses: false,
             #[cfg(feature = "ffi")]
@@ -1477,6 +1489,8 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut None,
             h1_parser_config: Default::default(),
+            h1_header_read_timeout: None,
+            h1_header_read_timeout_fut: &mut None,
             preserve_header_case: false,
             h09_responses: false,
             #[cfg(feature = "ffi")]
@@ -1497,6 +1511,8 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
+            h1_header_read_timeout: None,
+            h1_header_read_timeout_fut: &mut None,
             preserve_header_case: false,
             h09_responses: true,
             #[cfg(feature = "ffi")]
@@ -1519,6 +1535,8 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
+            h1_header_read_timeout: None,
+            h1_header_read_timeout_fut: &mut None,
             preserve_header_case: false,
             h09_responses: false,
             #[cfg(feature = "ffi")]
@@ -1545,6 +1563,8 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config,
+            h1_header_read_timeout: None,
+            h1_header_read_timeout_fut: &mut None,
             preserve_header_case: false,
             h09_responses: false,
             #[cfg(feature = "ffi")]
@@ -1568,6 +1588,8 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
+            h1_header_read_timeout: None,
+            h1_header_read_timeout_fut: &mut None,
             preserve_header_case: false,
             h09_responses: false,
             #[cfg(feature = "ffi")]
@@ -1586,6 +1608,8 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut None,
             h1_parser_config: Default::default(),
+            h1_header_read_timeout: None,
+            h1_header_read_timeout_fut: &mut None,
             preserve_header_case: true,
             h09_responses: false,
             #[cfg(feature = "ffi")]
@@ -1625,6 +1649,8 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
+                    h1_header_read_timeout: None,
+                    h1_header_read_timeout_fut: &mut None,
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
@@ -1645,6 +1671,8 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
+                    h1_header_read_timeout: None,
+                    h1_header_read_timeout_fut: &mut None,
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
@@ -1874,6 +1902,8 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut Some(Method::GET),
                     h1_parser_config: Default::default(),
+                    h1_header_read_timeout: None,
+                    h1_header_read_timeout_fut: &mut None,
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
@@ -1894,6 +1924,8 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut Some(m),
                     h1_parser_config: Default::default(),
+                    h1_header_read_timeout: None,
+                    h1_header_read_timeout_fut: &mut None,
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
@@ -1914,6 +1946,8 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut Some(Method::GET),
                     h1_parser_config: Default::default(),
+                    h1_header_read_timeout: None,
+                    h1_header_read_timeout_fut: &mut None,
                     preserve_header_case: false,
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
@@ -2411,6 +2445,8 @@ mod tests {
                 cached_headers: &mut None,
                 req_method: &mut Some(Method::GET),
                 h1_parser_config: Default::default(),
+                h1_header_read_timeout: None,
+                h1_header_read_timeout_fut: &mut None,
                 preserve_header_case: false,
                 h09_responses: false,
                 #[cfg(feature = "ffi")]

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -102,7 +102,7 @@ pub struct Http<E = Exec> {
     h1_keep_alive: bool,
     h1_title_case_headers: bool,
     h1_preserve_header_case: bool,
-    #[cfg(feature = "http1")]
+    #[cfg(all(feature = "http1", feature = "runtime"))]
     h1_header_read_timeout: Option<Duration>,
     h1_writev: Option<bool>,
     #[cfg(feature = "http2")]
@@ -581,7 +581,7 @@ impl<E> Http<E> {
             h1_keep_alive: self.h1_keep_alive,
             h1_title_case_headers: self.h1_title_case_headers,
             h1_preserve_header_case: self.h1_preserve_header_case,
-            #[cfg(feature = "http1")]
+            #[cfg(all(feature = "http1", feature = "runtime"))]
             h1_header_read_timeout: self.h1_header_read_timeout,
             h1_writev: self.h1_writev,
             #[cfg(feature = "http2")]

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -286,7 +286,7 @@ impl Http {
             h1_keep_alive: true,
             h1_title_case_headers: false,
             h1_preserve_header_case: false,
-            #[cfg(feature = "http1")]
+            #[cfg(all(feature = "http1", feature = "runtime"))]
             h1_header_read_timeout: None,
             h1_writev: None,
             #[cfg(feature = "http2")]
@@ -379,8 +379,8 @@ impl<E> Http<E> {
     /// transmit the entire header withing this time, the connection is closed.
     ///
     /// Default is None.
-    #[cfg(feature = "http1")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
+    #[cfg(all(feature = "http1", feature = "runtime"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "http1", feature = "runtime"))))]
     pub fn http1_header_read_timeout(&mut self, read_timeout: Duration) -> &mut Self {
         self.h1_header_read_timeout = Some(read_timeout);
         self

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -376,7 +376,7 @@ impl<E> Http<E> {
     }
 
     /// Set a timeout for reading client request headers. If a client does not 
-    /// transmit the entire header withing this time, the connection is closed.
+    /// transmit the entire header within this time, the connection is closed.
     ///
     /// Default is None.
     #[cfg(all(feature = "http1", feature = "runtime"))]

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -638,8 +638,8 @@ impl<E> Http<E> {
                 if self.h1_preserve_header_case {
                     conn.set_preserve_header_case();
                 }
-                if let Some(header_parse_timeout) = self.h1_header_read_timeout {
-                    conn.set_http1_header_parse_timeout(header_parse_timeout);
+                if let Some(header_read_timeout) = self.h1_header_read_timeout {
+                    conn.set_http1_header_read_timeout(header_read_timeout);
                 }
                 if let Some(writev) = self.h1_writev {
                     if writev {

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -645,6 +645,7 @@ impl<E> Http<E> {
                 if self.h1_preserve_header_case {
                     conn.set_preserve_header_case();
                 }
+                #[cfg(all(feature = "http1", feature = "runtime"))]
                 if let Some(header_read_timeout) = self.h1_header_read_timeout {
                     conn.set_http1_header_read_timeout(header_read_timeout);
                 }

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -310,7 +310,7 @@ impl<I, E> Builder<I, E> {
     }
 
     /// Set a timeout for reading client request headers. If a client does not 
-    /// transmit the entire header withing this time, the connection is closed.
+    /// transmit the entire header within this time, the connection is closed.
     ///
     /// Default is None.
     #[cfg(all(feature = "http1", feature = "runtime"))]

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 #[cfg(feature = "tcp")]
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
-#[cfg(feature = "tcp")]
+#[cfg(any(feature = "tcp", feature = "http1"))]
 use std::time::Duration;
 
 #[cfg(all(feature = "tcp", any(feature = "http1", feature = "http2")))]
@@ -281,6 +281,17 @@ impl<I, E> Builder<I, E> {
     #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
     pub fn http1_preserve_header_case(mut self, val: bool) -> Self {
         self.protocol.http1_preserve_header_case(val);
+        self
+    }
+
+    /// Set a timeout for reading client request headers. If a client does not 
+    /// transmit the entire header withing this time, the connection is closed.
+    ///
+    /// Default is None.
+    #[cfg(feature = "http1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
+    pub fn http1_header_read_timeout(mut self, read_timeout: Duration) -> Self {
+        self.protocol.http1_header_read_timeout(read_timeout);
         self
     }
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -313,8 +313,8 @@ impl<I, E> Builder<I, E> {
     /// transmit the entire header withing this time, the connection is closed.
     ///
     /// Default is None.
-    #[cfg(feature = "http1")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
+    #[cfg(all(feature = "http1", feature = "runtime"))]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "http1", feature = "runtime"))))]
     pub fn http1_header_read_timeout(mut self, read_timeout: Duration) -> Self {
         self.protocol.http1_header_read_timeout(read_timeout);
         self

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1262,7 +1262,41 @@ fn header_name_too_long() {
 }
 
 #[tokio::test]
-async fn header_read_timeout() {
+async fn header_read_timeout_no_write() {
+    let listener = tcp_bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    thread::spawn(move || {
+        let mut tcp = connect(&addr);
+        thread::sleep(Duration::from_secs(6));
+        tcp.write_all(
+            b"\
+            GET / HTTP/1.1\r\n\
+            Something: 1\r\n\
+            \r\n\
+        ",
+        )
+        .expect_err("write 1");
+    });
+
+    let (socket, _) = listener.accept().await.unwrap();
+    let conn = Http::new()
+        .http1_header_read_timeout(Duration::from_secs(5))
+        .serve_connection(
+            socket,
+            service_fn(|_| {
+                let res = Response::builder()
+                    .status(200)
+                    .body(hyper::Body::empty())
+                    .unwrap();
+                future::ready(Ok::<_, hyper::Error>(res))
+            }),
+        );
+    conn.without_shutdown().await.expect("header timeout");
+}
+
+#[tokio::test]
+async fn header_read_timeout_slow_writes() {
     let listener = tcp_bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = listener.local_addr().unwrap();
 
@@ -1282,6 +1316,55 @@ async fn header_read_timeout() {
         ",
         )
         .expect_err("write 2");
+    });
+
+    let (socket, _) = listener.accept().await.unwrap();
+    let conn = Http::new()
+        .http1_header_read_timeout(Duration::from_secs(5))
+        .serve_connection(
+            socket,
+            service_fn(|_| {
+                let res = Response::builder()
+                    .status(200)
+                    .body(hyper::Body::empty())
+                    .unwrap();
+                future::ready(Ok::<_, hyper::Error>(res))
+            }),
+        );
+    conn.without_shutdown().await.expect_err("header timeout");
+}
+
+#[tokio::test]
+async fn header_read_timeout_slow_writes_2nd_request() {
+    let listener = tcp_bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    thread::spawn(move || {
+        let mut tcp = connect(&addr);
+        tcp.write_all(
+            b"\
+            GET / HTTP/1.1\r\n\
+            Something: 1\r\n\
+            \r\n\
+        ",
+        )
+        .expect("write 1");
+        thread::sleep(Duration::from_secs(6));
+        tcp.write_all(
+            b"\
+            GET / HTTP/1.1\r\n\
+            Something: 1\r\n\
+            \r\n\
+        ",
+        )
+        .expect("write 2");
+        thread::sleep(Duration::from_secs(6));
+        tcp.write_all(
+            b"\
+            Works: 0\r\n\
+        ",
+        )
+        .expect_err("write 3");
     });
 
     let (socket, _) = listener.accept().await.unwrap();

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1262,6 +1262,45 @@ fn header_name_too_long() {
 }
 
 #[tokio::test]
+async fn header_read_timeout() {
+    let listener = tcp_bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    thread::spawn(move || {
+        let mut tcp = connect(&addr);
+        tcp.write_all(
+            b"\
+            GET / HTTP/1.1\r\n\
+            Something: 1\r\n\
+        ",
+        )
+        .expect("write 1");
+        thread::sleep(Duration::from_secs(6));
+        tcp.write_all(
+            b"\
+            Works: 0\r\n\
+        ",
+        )
+        .expect_err("write 2");
+    });
+
+    let (socket, _) = listener.accept().await.unwrap();
+    let conn = Http::new()
+        .http1_header_read_timeout(Duration::from_secs(5))
+        .serve_connection(
+            socket,
+            service_fn(|_| {
+                let res = Response::builder()
+                    .status(200)
+                    .body(hyper::Body::empty())
+                    .unwrap();
+                future::ready(Ok::<_, hyper::Error>(res))
+            }),
+        );
+    conn.without_shutdown().await.expect_err("header timeout");
+}
+
+#[tokio::test]
 async fn upgrades() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 


### PR DESCRIPTION
Implements a timeout for reading the request header. The timer starts either when the connection is established (first request) or when the first byte is read from the header (subsequent requests reusing the same connection). The entire header must be read before the specified timeout is elapsed.

This is the first step towards protecting from Slowloris types of attacks

Supersedes #2661 by fixing https://github.com/hyperium/hyper/pull/2661#discussion_r728809455

Partially fixes #2457

Closes #2661