### PR TITLE
feat(upgrade): allow http upgrades with any body type

### DIFF
--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -258,7 +258,7 @@ mod sealed {
         fn on_upgrade(self) -> OnUpgrade;
     }
 
-    impl CanUpgrade for http::Request<crate::Body> {
+    impl<B> CanUpgrade for http::Request<B> {
         fn on_upgrade(mut self) -> OnUpgrade {
             self.extensions_mut()
                 .remove::<OnUpgrade>()
@@ -266,7 +266,7 @@ mod sealed {
         }
     }
 
-    impl CanUpgrade for &'_ mut http::Request<crate::Body> {
+    impl<B> CanUpgrade for &'_ mut http::Request<B> {
         fn on_upgrade(self) -> OnUpgrade {
             self.extensions_mut()
                 .remove::<OnUpgrade>()
@@ -274,7 +274,7 @@ mod sealed {
         }
     }
 
-    impl CanUpgrade for http::Response<crate::Body> {
+    impl<B> CanUpgrade for http::Response<B> {
         fn on_upgrade(mut self) -> OnUpgrade {
             self.extensions_mut()
                 .remove::<OnUpgrade>()
@@ -282,7 +282,7 @@ mod sealed {
         }
     }
 
-    impl CanUpgrade for &'_ mut http::Response<crate::Body> {
+    impl<B> CanUpgrade for &'_ mut http::Response<B> {
         fn on_upgrade(self) -> OnUpgrade {
             self.extensions_mut()
                 .remove::<OnUpgrade>()


### PR DESCRIPTION
Allow using `Request<T>`/`Response<T>` for any given T with `upgrade::on` instead of just restricting it to `hyper::Body`.

#2086 mentioned moving the upgrades API off of the Body type with part of the motivation being:
>This also makes it more annoying for users who may wish adjust their `http::Request<Body>` into some `http::Request<Doodad>`.

But the current API is still restricted to just the `hyper::Body` body type which seems more strict than it needs to be.