### PR TITLE
docs(client, body): fix doctests failing when certain features are disabled

### DIFF
--- a/src/body/to_bytes.rs
+++ b/src/body/to_bytes.rs
@@ -17,6 +17,7 @@ use super::HttpBody;
 /// # Example
 ///
 /// ```
+/// # #[cfg(all(feature = "client", any(feature = "http1", feature = "http2")))]
 /// # async fn doc() -> hyper::Result<()> {
 /// use hyper::{body::HttpBody};
 ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -27,10 +27,10 @@
 //! [full client example](https://github.com/hyperium/hyper/blob/master/examples/client.rs).
 //!
 //! ```
+//! # #[cfg(all(feature = "tcp", feature = "client", any(feature = "http1", feature = "http2")))]
+//! # async fn fetch_httpbin() -> hyper::Result<()> {
 //! use hyper::{body::HttpBody as _, Client, Uri};
 //!
-//! # #[cfg(feature = "tcp")]
-//! # async fn fetch_httpbin() -> hyper::Result<()> {
 //! let client = Client::new();
 //!
 //! // Make a GET /ip to 'http://httpbin.org'


### PR DESCRIPTION
The first commit fixes #2687, the second one fixes a very similar issue regarding a client doctest.