### PR TITLE
Issue 2678: Span PoC - direction/feedback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ httpdate = "1.0"
 httparse = "1.5.1"
 h2 = { version = "0.3.3", optional = true }
 itoa = "0.4.1"
-tracing = { version = "0.1", default-features = false, features = ["std"] }
 pin-project-lite = "0.2.4"
 tower-service = "0.3"
 tokio = { version = "1", features = ["sync"] }
@@ -42,7 +41,11 @@ want = "0.3"
 # Optional
 
 libc = { version = "0.2", optional = true }
+log = { version = "0.4.14", optional = true }
+serde_json = { version = "1.0", optional = true }
 socket2 = { version = "0.4", optional = true }
+tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
+tracing-subscriber = { version = "0.3", optional = true }
 
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
@@ -80,9 +83,10 @@ full = [
     "client",
     "http1",
     "http2",
+    "layers",
+    "runtime",
     "server",
     "stream",
-    "runtime",
 ]
 
 # HTTP versions
@@ -107,6 +111,9 @@ tcp = [
     "tokio/rt",
     "tokio/time",
 ]
+
+# Tracing layers
+layers = ["serde_json", "tracing", "tracing-subscriber"]
 
 # C-API support (currently unstable (no semver))
 ffi = ["libc"]
@@ -139,6 +146,21 @@ required-features = ["full"]
 name = "client_json"
 path = "examples/client_json.rs"
 required-features = ["full"]
+
+[[example]]
+name = "client_json_tracing"
+path = "examples/client_json_tracing.rs"
+required-features = ["full",
+    "tracing/max_level_info",
+    ]
+
+[[example]]
+name = "client_json_tracing_off"
+path = "examples/client_json_tracing_off.rs"
+required-features = ["tracing",
+    "tracing/max_level_off",
+    "log/max_level_off",
+    ]
 
 [[example]]
 name = "echo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,12 @@ opentelemetry-jaeger = { version = "0.15.0", features = ["reqwest_collector_clie
 serde_json = { version = "1.0", optional = true }
 socket2 = { version = "0.4", optional = true }
 reqwest = {version = "0.11", optional = true }
-tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
+tracing = { version = "0.1", default-features = false, features = ["std", "log"], optional = true }
 tracing-core = { version = "0.1", default-features = false, optional = true }
+tracing-log = { version = "0.1", default-features = false, optional = true }
 tracing-opentelemetry = { version = "0.16", optional = true }
-tracing-subscriber = { version = "0.3", features = ["std"], optional = true }
+tracing-subscriber = { version = "0.3", features = ["std", "env-filter"], optional = true }
+tracing-tree = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
@@ -119,14 +121,18 @@ tcp = [
 
 # Tracing layers
 layers = [
+    "log",
     "opentelemetry",
     "opentelemetry-jaeger",
     "serde_json",
     "reqwest",
     "tracing",
     "tracing-core",
+    "tracing-log",
     "tracing-opentelemetry",
-    "tracing-subscriber"]
+    "tracing-subscriber",
+    "tracing-tree",
+    ]
 
 # C-API support (currently unstable (no semver))
 ffi = ["libc"]
@@ -176,8 +182,8 @@ required-features = ["full",
     ]
 
 [[example]]
-name = "client_otel_tracing"
-path = "examples/client_otel_tracing.rs"
+name = "client_json_tracing_otel"
+path = "examples/client_json_tracing_otel.rs"
 required-features = ["full",
     "tracing/max_level_trace",
     ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,15 @@ want = "0.3"
 
 libc = { version = "0.2", optional = true }
 log = { version = "0.4.14", optional = true }
+opentelemetry = { version = "0.16.0", features = ["rt-tokio", "trace"], optional = true }
+opentelemetry-jaeger = { version = "0.15.0", features = ["reqwest_collector_client","rt-tokio"], optional = true }
 serde_json = { version = "1.0", optional = true }
 socket2 = { version = "0.4", optional = true }
+reqwest = {version = "0.11", optional = true }
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
-tracing-subscriber = { version = "0.3", optional = true }
+tracing-core = { version = "0.1", default-features = false, optional = true }
+tracing-opentelemetry = { version = "0.16", optional = true }
+tracing-subscriber = { version = "0.3", features = ["std"], optional = true }
 
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
@@ -113,7 +118,15 @@ tcp = [
 ]
 
 # Tracing layers
-layers = ["serde_json", "tracing", "tracing-subscriber"]
+layers = [
+    "opentelemetry",
+    "opentelemetry-jaeger",
+    "serde_json",
+    "reqwest",
+    "tracing",
+    "tracing-core",
+    "tracing-opentelemetry",
+    "tracing-subscriber"]
 
 # C-API support (currently unstable (no semver))
 ffi = ["libc"]
@@ -148,24 +161,38 @@ path = "examples/client_json.rs"
 required-features = ["full"]
 
 [[example]]
-name = "client_json_tracing"
-path = "examples/client_json_tracing.rs"
+name = "client_json_tracing_json"
+path = "examples/client_json_tracing_json.rs"
 required-features = ["full",
-    "tracing/max_level_info",
+    "tracing/max_level_trace",
     ]
 
 [[example]]
 name = "client_json_tracing_off"
 path = "examples/client_json_tracing_off.rs"
-required-features = ["tracing",
+required-features = ["full",
     "tracing/max_level_off",
     "log/max_level_off",
+    ]
+
+[[example]]
+name = "client_otel_tracing"
+path = "examples/client_otel_tracing.rs"
+required-features = ["full",
+    "tracing/max_level_trace",
     ]
 
 [[example]]
 name = "echo"
 path = "examples/echo.rs"
 required-features = ["full"]
+
+[[example]]
+name = "echo_tracing_otel"
+path = "examples/echo_tracing_otel.rs"
+required-features = ["full",
+    "tracing/max_level_trace",
+    ]
 
 [[example]]
 name = "gateway"

--- a/examples/client_json_tracing.rs
+++ b/examples/client_json_tracing.rs
@@ -1,0 +1,71 @@
+#![deny(warnings)]
+#![warn(rust_2018_idioms)]
+
+// Statically compile tracing events and spans - "compile out" tracing code.
+//
+// Usage:
+//
+// $ cargo run --features="full tracing/max_level_info" --example client_json_tracing
+// ...
+// Running `target/debug/examples/client_json_tracing_off`
+// Hyper tracing event:
+//   level=Level(Info)
+//   target="client_json_tracing"
+//   name="event examples/client_json_tracing.rs:24"
+//   field=status
+//   field=answer
+//   field=message
+// etc.
+
+use hyper::body::Buf;
+use hyper::Client;
+//use hyper::PrintLayer;
+use hyper::JsonLayer;
+use serde::Deserialize;
+use tracing::info;
+use tracing_subscriber::prelude::*;
+
+// A simple type alias so as to DRY.
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Set up `tracing-subscriber` to process tracing data.
+    tracing_subscriber::registry().with(JsonLayer).init();
+
+    // Log a `tracing` "event".
+    info!(status = true, answer = 42, message = "first event");
+
+    let url = "http://jsonplaceholder.typicode.com/users".parse().unwrap();
+    let users = fetch_json(url).await?;
+    // print users
+    println!("users: {:#?}", users);
+
+    // print the sum of ids
+    let sum = users.iter().fold(0, |acc, user| acc + user.id);
+    println!("sum of ids: {}", sum);
+    Ok(())
+}
+
+async fn fetch_json(url: hyper::Uri) -> Result<Vec<User>> {
+    let client = Client::new();
+
+    // Fetch the url...
+    let res = client.get(url).await?;
+
+    // asynchronously aggregate the chunks of the body
+    let body = hyper::body::aggregate(res).await?;
+
+    // try to parse as json with serde_json
+    let users = serde_json::from_reader(body.reader())?;
+
+    Ok(users)
+}
+
+#[derive(Deserialize, Debug)]
+struct User {
+    id: i32,
+    #[allow(unused)]
+    name: String,
+}

--- a/examples/client_json_tracing_json.rs
+++ b/examples/client_json_tracing_json.rs
@@ -1,0 +1,64 @@
+#![deny(warnings)]
+#![warn(rust_2018_idioms)]
+
+// Statically compile tracing events and spans - "compile out" tracing code.
+//
+// Usage:
+//
+// $ cargo run --features="full tracing/max_level_info" --example client_json_tracing
+// ...
+// Running `target/debug/examples/client_json_tracing`
+
+// etc.
+
+use hyper::body::Buf;
+use hyper::Client;
+use hyper::JsonLayer;
+use serde::Deserialize;
+use tracing::info;
+use tracing_subscriber::prelude::*;
+
+// A simple type alias so as to DRY.
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Set up `tracing-subscriber` to process tracing data.
+    tracing_subscriber::registry().with(JsonLayer).init();
+
+    // Log a `tracing` "event".
+    info!(status = true, answer = 42, message = "first event");
+
+    let url = "http://jsonplaceholder.typicode.com/users".parse().unwrap();
+    let users = fetch_json(url).await?;
+    // print users
+    println!("users: {:#?}", users);
+
+    // print the sum of ids
+    let sum = users.iter().fold(0, |acc, user| acc + user.id);
+    println!("sum of ids: {}", sum);
+    Ok(())
+}
+
+async fn fetch_json(url: hyper::Uri) -> Result<Vec<User>> {
+    let client = Client::new();
+
+    // Fetch the url...
+    let res = client.get(url).await?;
+
+    // asynchronously aggregate the chunks of the body
+    let body = hyper::body::aggregate(res).await?;
+
+    // try to parse as json with serde_json
+    let users = serde_json::from_reader(body.reader())?;
+
+    Ok(users)
+}
+
+#[derive(Deserialize, Debug)]
+struct User {
+    id: i32,
+    #[allow(unused)]
+    name: String,
+}

--- a/examples/client_json_tracing_off.rs
+++ b/examples/client_json_tracing_off.rs
@@ -1,0 +1,76 @@
+#![deny(warnings)]
+#![warn(rust_2018_idioms)]
+
+// Statically compile out all tracing and logging events and spans
+// - that is, "compile out" all tracing and logging code.
+//
+// Usage:
+//
+// $ cargo run --features="full tracing/max_level_off log/max_level_off" --example client_json_tracing_off
+// ...
+// Running `target/debug/examples/client_json_tracing_off`
+// users: [
+//     User {
+//         id: 1,
+//         name: "Leanne Graham",
+//     },
+//     User {
+//         id: 2,
+//         name: "Ervin Howell",
+// etc.
+
+use hyper::body::Buf;
+use hyper::Client;
+use hyper::PrintLayer;
+// use hyper::JsonLayer;
+use serde::Deserialize;
+use tracing::info;
+use tracing_subscriber::prelude::*;
+
+// A simple type alias so as to DRY.
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Set up `tracing-subscriber` to process tracing data.
+    // Note:
+    // We silence tracing via compile/build time features - see `Cargo.toml`.
+    // Hence, no change is required from the `client_json_tracing` example.
+    tracing_subscriber::registry().with(PrintLayer).init();
+
+    // "Log" a `tracing` "event".
+    info!(status = true, answer = 42, message = "first event");
+
+    let url = "http://jsonplaceholder.typicode.com/users".parse().unwrap();
+    let users = fetch_json(url).await?;
+    // print users
+    println!("users: {:#?}", users);
+
+    // print the sum of ids
+    let sum = users.iter().fold(0, |acc, user| acc + user.id);
+    println!("sum of ids: {}", sum);
+    Ok(())
+}
+
+async fn fetch_json(url: hyper::Uri) -> Result<Vec<User>> {
+    let client = Client::new();
+
+    // Fetch the url...
+    let res = client.get(url).await?;
+
+    // asynchronously aggregate the chunks of the body
+    let body = hyper::body::aggregate(res).await?;
+
+    // try to parse as json with serde_json
+    let users = serde_json::from_reader(body.reader())?;
+
+    Ok(users)
+}
+
+#[derive(Deserialize, Debug)]
+struct User {
+    id: i32,
+    #[allow(unused)]
+    name: String,
+}

--- a/examples/client_json_tracing_otel.rs
+++ b/examples/client_json_tracing_otel.rs
@@ -46,11 +46,12 @@ async fn main() -> Result<()> {
         Box::new(trace_context_propagator),
         Box::new(jaeger_propagator),
     ]);
+    // Third create Jaeger pipeline
     let tracer = opentelemetry_jaeger::new_pipeline()
         .with_service_name("client_json2")
         .install_batch(opentelemetry::runtime::Tokio)
         .unwrap();
-    // Initialize `tracing` using `opentelemetry-tracing` and configure logging
+    // Initialize `tracing` using `opentelemetry-tracing` and configure stdout logging
     tracing_subscriber::Registry::default()
         .with(tracing_subscriber::EnvFilter::new("TRACE"))
         .with(hyper::OtelLayer::new(tracer))
@@ -58,36 +59,11 @@ async fn main() -> Result<()> {
         //.with(tracing_tree::HierarchicalLayer::new(2))
         .init();
 
-    // // Setup Tracer Provider
-    // let provider = opentelemetry::sdk::trace::TracerProvider::builder()
-    //     // We can build a span processor and pass it into provider.
-    //     .with_span_processor(jaeger_processor)
-    //     .build();
-    // // Get new Tracer from TracerProvider
-    // let tracer = opentelemetry::trace::TracerProvider::tracer(&provider, "client_json", None);
-    // // Create a layer with the configured tracer
-    // let telemetry = hyper::OtelLayer::new(tracer);
-    // // Use the tracing subscriber `Registry`, or any other subscriber
-    // // that impls `LookupSpan`
-    // tracing_subscriber::registry()
-    //     .with(telemetry)
-    //     .try_init()
-    //     .expect("Default subscriber");
-
-    //let subscriber = tracing_subscriber::Registry::default().with(telemetry);
-
     // Trace executed (async) code
     // tracing::subscriber::with_default(subscriber, || async {
-        // Create a span and enter it, returning a guard....
+    // Create a span and enter it, returning a guard....
     let root_span = tracing::span!(tracing::Level::INFO, "root_span_echo").entered();
     root_span.in_scope(|| async {
-        // After setting up OpenTelemetry/Jaeger, redirect all `log`'s events to our subscriber/layer
-        // let logger = tracing_log::LogTracer::new();
-        // log::set_boxed_logger(Box::new(logger))?;
-
-        // We are now inside the span! Like `enter()`, the guard returned by
-        // `entered()` will exit the span when it is dropped...
-
         // Log a `tracing` "event".
         info!(status = true, answer = 42, message = "first event");
 

--- a/examples/client_json_tracing_otel.rs
+++ b/examples/client_json_tracing_otel.rs
@@ -1,0 +1,139 @@
+#![deny(warnings)]
+#![warn(rust_2018_idioms)]
+
+// Statically compile tracing events and spans - "compile out" tracing code.
+//
+// Usage:
+//
+// $ cargo run --features="full tracing/max_level_info" --example client_otel_tracing
+// ...
+// Running `target/debug/examples/client_otel_tracing_off`
+// Hyper tracing event:
+//   level=Level(Info)
+//   target="client_otel_tracing"
+//   name="event examples/client_otel_tracing.rs:24"
+//   field=status
+//   field=answer
+//   field=message
+// etc.
+
+use hyper::body::Buf;
+use hyper::Client;
+// use hyper::OtelLayer;
+use serde::Deserialize;
+use tracing::info;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::prelude::*;
+//use tracing_subscriber::Layer;
+//use tracing_subscriber::Registry;
+
+// A simple type alias so as to DRY.
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // // Set up `tracing-subscriber` to process tracing data.
+    // // Create a jaeger exporter pipeline for a `trace_demo` service.
+    // let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 6831));
+    // // Build a Jaeger batch span processor
+    // let jaeger_processor = opentelemetry::sdk::trace::BatchSpanProcessor::builder(
+    //     opentelemetry_jaeger::new_pipeline()
+    //         .with_service_name("mre-jaeger")
+    //         .with_agent_endpoint(addr)
+    //         .with_trace_config(opentelemetry::sdk::trace::config().with_resource(
+    //             opentelemetry::sdk::Resource::new(vec![
+    //                 opentelemetry::KeyValue::new("service.name", "client"),
+    //                 opentelemetry::KeyValue::new("service.namespace", "client-namespace"),
+    //             ]),
+    //         ))
+    //         .init_async_exporter(opentelemetry::runtime::Tokio)
+    //         .expect("Jaeger Tokio async exporter"),
+    //     opentelemetry::runtime::Tokio,
+    // )
+    // .build();
+    // Start an otel jaeger trace pipeline
+    opentelemetry::global::set_text_map_propagator(opentelemetry::sdk::propagation::TraceContextPropagator::new());
+    //global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
+    // Then create a composite propagator
+    // let composite_propagator =  opentelemetry::sdk::propagation::TextMapCompositePropagator::new(vec![
+    //     Box::new(baggage_propagator),
+    //     Box::new(trace_context_propagator),
+    // ]);
+    let tracer = opentelemetry_jaeger::new_pipeline()
+        .with_service_name("client_json2")
+        .install_batch(opentelemetry::runtime::Tokio)
+        .unwrap();
+    // Initialize `tracing` using `opentelemetry-tracing` and configure logging
+    tracing_subscriber::Registry::default()
+        //.with(tracing_subscriber::EnvFilter::new("TRACE"))
+        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_opentelemetry::layer().with_tracer(tracer))
+        .init();
+
+    // // Setup Tracer Provider
+    // let provider = opentelemetry::sdk::trace::TracerProvider::builder()
+    //     // We can build a span processor and pass it into provider.
+    //     .with_span_processor(jaeger_processor)
+    //     .build();
+    // // Get new Tracer from TracerProvider
+    // let tracer = opentelemetry::trace::TracerProvider::tracer(&provider, "client_json", None);
+    // // Create a layer with the configured tracer
+    // let telemetry = hyper::OtelLayer::new(tracer);
+    // // Use the tracing subscriber `Registry`, or any other subscriber
+    // // that impls `LookupSpan`
+    // tracing_subscriber::registry()
+    //     .with(telemetry)
+    //     .try_init()
+    //     .expect("Default subscriber");
+
+    //let subscriber = tracing_subscriber::Registry::default().with(telemetry);
+
+    // Trace executed (async) code
+    //tracing::subscriber::with_default(subscriber, || async {
+    // Create a span and enter it, returning a guard....
+    let root_span = tracing::span!(tracing::Level::INFO, "root_span_echo").entered();
+
+    // We are now inside the span! Like `enter()`, the guard returned by
+    // `entered()` will exit the span when it is dropped...
+
+    // Log a `tracing` "event".
+    info!(status = true, answer = 42, message = "first event");
+
+    let url = "http://jsonplaceholder.typicode.com/users".parse().unwrap();
+    let users = fetch_json(url).await.expect("Vector of user data");
+    // print users
+    println!("users: {:#?}", users);
+
+    // print the sum of ids
+    let sum = users.iter().fold(0, |acc, user| acc + user.id);
+    println!("sum of ids: {}", sum);
+
+    // ...but, it can also be exited explicitly, returning the `Span`
+    // struct:
+    let _root_span = root_span.exit();
+    opentelemetry::global::shutdown_tracer_provider();
+    //}).await;
+    Ok(())
+}
+
+async fn fetch_json(url: hyper::Uri) -> Result<Vec<User>> {
+    let client = Client::new();
+
+    // Fetch the url...
+    let res = client.get(url).await?;
+
+    // asynchronously aggregate the chunks of the body
+    let body = hyper::body::aggregate(res).await?;
+
+    // try to parse as json with serde_json
+    let users = serde_json::from_reader(body.reader())?;
+
+    Ok(users)
+}
+
+#[derive(Deserialize, Debug)]
+struct User {
+    id: i32,
+    #[allow(unused)]
+    name: String,
+}

--- a/examples/client_json_tracing_otel1.rs
+++ b/examples/client_json_tracing_otel1.rs
@@ -1,0 +1,119 @@
+#![deny(warnings)]
+#![warn(rust_2018_idioms)]
+
+// Statically compile tracing events and spans - "compile out" tracing code.
+//
+// Usage:
+//
+// $ cargo run --features="full tracing/max_level_info" --example client_otel_tracing
+// ...
+// Running `target/debug/examples/client_otel_tracing_off`
+// Hyper tracing event:
+//   level=Level(Info)
+//   target="client_otel_tracing"
+//   name="event examples/client_otel_tracing.rs:24"
+//   field=status
+//   field=answer
+//   field=message
+// etc.
+
+use hyper::body::Buf;
+use hyper::Client;
+// use hyper::OtelLayer;
+use serde::Deserialize;
+use tracing::info;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::prelude::*;
+//use tracing_subscriber::Layer;
+//use tracing_subscriber::Registry;
+
+// A simple type alias so as to DRY.
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Set up `tracing-subscriber` to process tracing data.
+    // Create a jaeger exporter pipeline for a `trace_demo` service.
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 6831));
+    // Build a Jaeger batch span processor
+    let jaeger_processor = opentelemetry::sdk::trace::BatchSpanProcessor::builder(
+        opentelemetry_jaeger::new_pipeline()
+            .with_service_name("mre-jaeger")
+            .with_agent_endpoint(addr)
+            .with_trace_config(opentelemetry::sdk::trace::config().with_resource(
+                opentelemetry::sdk::Resource::new(vec![
+                    opentelemetry::KeyValue::new("service.name", "client"),
+                    opentelemetry::KeyValue::new("service.namespace", "client-namespace"),
+                ]),
+            ))
+            .init_async_exporter(opentelemetry::runtime::Tokio)
+            .expect("Jaeger Tokio async exporter"),
+        opentelemetry::runtime::Tokio,
+    )
+    .build();
+    // Setup Tracer Provider
+    let provider = opentelemetry::sdk::trace::TracerProvider::builder()
+        // We can build a span processor and pass it into provider.
+        .with_span_processor(jaeger_processor)
+        .build();
+    // Get new Tracer from TracerProvider
+    let tracer = opentelemetry::trace::TracerProvider::tracer(&provider, "client_json", None);
+    // Create a layer with the configured tracer
+    let telemetry = hyper::OtelLayer::layer().with_tracer(tracer);
+    // Use the tracing subscriber `Registry`, or any other subscriber
+    // that impls `LookupSpan`
+    tracing_subscriber::registry()
+        .with(telemetry)
+        .try_init()
+        .expect("Default subscriber");
+
+    //let subscriber = tracing_subscriber::Registry::default().with(telemetry);
+
+    // Trace executed (async) code
+    //tracing::subscriber::with_default(subscriber, || async {
+    // Create a span and enter it, returning a guard....
+    let root_span = tracing::span!(tracing::Level::INFO, "root_span_echo").entered();
+
+    // We are now inside the span! Like `enter()`, the guard returned by
+    // `entered()` will exit the span when it is dropped...
+
+    // Log a `tracing` "event".
+    info!(status = true, answer = 42, message = "first event");
+
+    let url = "http://jsonplaceholder.typicode.com/users".parse().unwrap();
+    let users = fetch_json(url).await.expect("Vector of user data");
+    // print users
+    println!("users: {:#?}", users);
+
+    // print the sum of ids
+    let sum = users.iter().fold(0, |acc, user| acc + user.id);
+    println!("sum of ids: {}", sum);
+
+    // ...but, it can also be exited explicitly, returning the `Span`
+    // struct:
+    let _root_span = root_span.exit();
+    //}).await;
+    Ok(())
+}
+
+async fn fetch_json(url: hyper::Uri) -> Result<Vec<User>> {
+    let client = Client::new();
+
+    // Fetch the url...
+    let res = client.get(url).await?;
+
+    // asynchronously aggregate the chunks of the body
+    let body = hyper::body::aggregate(res).await?;
+
+    // try to parse as json with serde_json
+    let users = serde_json::from_reader(body.reader())?;
+
+    Ok(users)
+}
+
+#[derive(Deserialize, Debug)]
+struct User {
+    id: i32,
+    #[allow(unused)]
+    name: String,
+}

--- a/examples/client_json_tracing_print.rs
+++ b/examples/client_json_tracing_print.rs
@@ -19,8 +19,7 @@
 
 use hyper::body::Buf;
 use hyper::Client;
-//use hyper::PrintLayer;
-use hyper::JsonLayer;
+use hyper::PrintLayer;
 use serde::Deserialize;
 use tracing::info;
 use tracing_subscriber::prelude::*;
@@ -32,7 +31,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>
 #[tokio::main]
 async fn main() -> Result<()> {
     // Set up `tracing-subscriber` to process tracing data.
-    tracing_subscriber::registry().with(JsonLayer).init();
+    tracing_subscriber::registry().with(PrintLayer).init();
 
     // Log a `tracing` "event".
     info!(status = true, answer = 42, message = "first event");

--- a/examples/echo_tracing_otel.rs
+++ b/examples/echo_tracing_otel.rs
@@ -1,0 +1,115 @@
+#![deny(warnings)]
+
+use futures_util::TryStreamExt;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::OtelLayer;
+use hyper::{Body, Method, Request, Response, Server, StatusCode};
+use tracing::info;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::prelude::*;
+
+
+/// This is our service handler. It receives a Request, routes on its
+/// path, and returns a Future of a Response.
+async fn echo(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    match (req.method(), req.uri().path()) {
+        // Serve some instructions at /
+        (&Method::GET, "/") => Ok(Response::new(Body::from(
+            "Try POSTing data to /echo such as: `curl localhost:3000/echo -XPOST -d 'hello world'`",
+        ))),
+
+        // Simply echo the body back to the client.
+        (&Method::POST, "/echo") => Ok(Response::new(req.into_body())),
+
+        // Convert to uppercase before sending back to client using a stream.
+        (&Method::POST, "/echo/uppercase") => {
+            let chunk_stream = req.into_body().map_ok(|chunk| {
+                chunk
+                    .iter()
+                    .map(|byte| byte.to_ascii_uppercase())
+                    .collect::<Vec<u8>>()
+            });
+            Ok(Response::new(Body::wrap_stream(chunk_stream)))
+        }
+
+        // Reverse the entire body before sending back to the client.
+        //
+        // Since we don't know the end yet, we can't simply stream
+        // the chunks as they arrive as we did with the above uppercase endpoint.
+        // So here we do `.await` on the future, waiting on concatenating the full body,
+        // then afterwards the content can be reversed. Only then can we return a `Response`.
+        (&Method::POST, "/echo/reversed") => {
+            let whole_body = hyper::body::to_bytes(req.into_body()).await?;
+
+            let reversed_body = whole_body.iter().rev().cloned().collect::<Vec<u8>>();
+            Ok(Response::new(Body::from(reversed_body)))
+        }
+
+        // Return the 404 Not Found for other routes.
+        _ => {
+            let mut not_found = Response::default();
+            *not_found.status_mut() = StatusCode::NOT_FOUND;
+            Ok(not_found)
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Set up `tracing-subscriber` to process tracing data.
+    // Create a jaeger exporter pipeline for a `trace_demo` service.
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 6831));
+    // Build a Jaeger batch span processor
+    let jaeger_processor = opentelemetry::sdk::trace::BatchSpanProcessor::builder(
+        opentelemetry_jaeger::new_pipeline()
+            .with_service_name("mre-jaeger")
+            .with_agent_endpoint(addr)
+            .with_trace_config(opentelemetry::sdk::trace::config().with_resource(
+                opentelemetry::sdk::Resource::new(vec![
+                    opentelemetry::KeyValue::new("service.name", "echo"),
+                    opentelemetry::KeyValue::new("service.namespace", "echo-namespace"),
+                ]),
+            ))
+            .init_async_exporter(opentelemetry::runtime::Tokio)
+            .expect("Jaeger Tokio async exporter"),
+        opentelemetry::runtime::Tokio,
+    )
+    .build();
+
+    // Setup Tracer Provider
+    let provider = opentelemetry::sdk::trace::TracerProvider::builder()
+        .with_span_processor(jaeger_processor)
+        .build();
+
+        // Get new Tracer from TracerProvider
+    let tracer = opentelemetry::trace::TracerProvider::tracer(&provider, "my_app", None);
+
+    // Create a layer with the configured tracer
+    let telemetry = OtelLayer::new(tracer);
+
+    // Use tracing subscriber `Registry`, or any other subscriber that `impl LookupSpan`
+    tracing_subscriber::registry()
+        .with(telemetry)
+        .try_init()
+        .expect("Default subscriber");
+
+        // Create a span and enter it, returning a guard....
+        let root_span = tracing::span!(tracing::Level::INFO, "root_span_echo").entered();
+
+        // Generate a `tracing` "event".
+        info!(status = true, answer = 42, message = "first event");
+
+        let addr = ([127, 0, 0, 1], 3000).into();
+
+        let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(echo)) });
+
+        let server = Server::bind(&addr).serve(service);
+
+        println!("Listening on http://{}", addr);
+
+        server.await.expect("Server fault");
+
+        let _root_span = root_span.exit();
+
+    Ok(())
+}

--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -50,6 +50,7 @@ impl DecodedLength {
     /// Checks the `u64` is within the maximum allowed for content-length.
     #[cfg(any(feature = "http1", feature = "http2"))]
     pub(crate) fn checked_new(len: u64) -> Result<Self, crate::error::Parse> {
+        #[cfg(not(feature = "layers"))]
         use tracing::warn;
 
         if len <= MAX_LEN {

--- a/src/common/layers/json.rs
+++ b/src/common/layers/json.rs
@@ -1,0 +1,79 @@
+use std::collections::BTreeMap;
+
+/// A layer for the tracing framework to record structured event and span data.
+#[derive(Debug)]
+pub struct HyperLayer;
+
+impl<S> tracing_subscriber::Layer<S> for HyperLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        // Covert event data to JSON
+        let mut fields = BTreeMap::new();
+        let mut visitor = JsonVisitor(&mut fields);
+        event.record(&mut visitor);
+        for field in event.fields() {
+            println!("  field={}", field.name());
+        }
+        // Output JSON event data
+        let output = serde_json::json!({
+            "target": event.metadata().target(),
+            "name": event.metadata().name(),
+            "level": format!("{:?}", event.metadata().level()),
+            "fields": fields,
+        });
+        println!("{}", serde_json::to_string_pretty(&output).unwrap());
+    }
+}
+
+struct JsonVisitor<'a>(&'a mut BTreeMap<String, serde_json::Value>);
+
+impl<'a> tracing::field::Visit for JsonVisitor<'a> {
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        self.0
+            .insert(field.name().to_string(), serde_json::json!(value));
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.0
+            .insert(field.name().to_string(), serde_json::json!(value));
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.0
+            .insert(field.name().to_string(), serde_json::json!(value));
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.0
+            .insert(field.name().to_string(), serde_json::json!(value));
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.0
+            .insert(field.name().to_string(), serde_json::json!(value));
+    }
+
+    fn record_error(
+        &mut self,
+        field: &tracing::field::Field,
+        value: &(dyn std::error::Error + 'static),
+    ) {
+        self.0.insert(
+            field.name().to_string(),
+            serde_json::json!(value.to_string()),
+        );
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.0.insert(
+            field.name().to_string(),
+            serde_json::json!(format!("{:?}", value)),
+        );
+    }
+}

--- a/src/common/layers/mod.rs
+++ b/src/common/layers/mod.rs
@@ -1,3 +1,31 @@
+//! HTTP Tracing
+//!
+//! Hyper uses the [`tracing`] crate to provide structured, event-based
+//! diagnostic information..
+//!
+//! Span configuration should conform to the OpenTelemetry [Exceptions], [HTTP]
+//! and [General] semantic conventions.
+//!
+//! # Examples
+//!
+//! For complete working code, take a look at these examples:
+//!
+//! - [`client_json`]: Hyper client example with no tracing related code.
+//! - [`client_json_tracing_otel`]: Hyper client example with OpenTelemetry
+//!   and Jaeger tracing.
+//! - [`client_json_tracing_off`]: The previous example, now with `Cargo.toml`
+//!   settings to statically compile all tracing overhead out of the final
+//!   binary.  The final result should be smaller, and faster, than the
+//!   [`client_json`] example.
+//!
+//! [tracing]: https://docs.rs/tracing
+//! [Exceptions]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md
+//! [General]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md
+//! [HTTP]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md
+//! [client_json]: https://github.com/hyperium/hyper/blob/master/examples/client_json.rs
+//! [client_json_tracing_otel]: https://github.com/hyperium/hyper/blob/master/examples/client_json_tracing_otel.rs
+//! [client_json_tracing_off]: https://github.com/hyperium/hyper/blob/master/examples/client_json_tracing_off.rs
+pub mod values;
 pub mod json;
-// pub mod otel;
+pub mod otel;
 pub mod print;

--- a/src/common/layers/mod.rs
+++ b/src/common/layers/mod.rs
@@ -18,6 +18,13 @@
 //!   binary.  The final result should be smaller, and faster, than the
 //!   [`client_json`] example.
 //!
+//! ```bash
+//! podman run -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
+//! cargo run --features="full tracing/max_level_trace" --example client_json_tracing_otel
+//! firefox http://localhost:16686
+//! # See also stdout
+//! ```
+//!
 //! [tracing]: https://docs.rs/tracing
 //! [Exceptions]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md
 //! [General]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md

--- a/src/common/layers/mod.rs
+++ b/src/common/layers/mod.rs
@@ -1,3 +1,3 @@
 pub mod json;
-pub mod otel;
+// pub mod otel;
 pub mod print;

--- a/src/common/layers/mod.rs
+++ b/src/common/layers/mod.rs
@@ -1,0 +1,3 @@
+pub mod json;
+pub mod otel;
+pub mod print;

--- a/src/common/layers/otel.rs
+++ b/src/common/layers/otel.rs
@@ -1,0 +1,22 @@
+/// A layer for the tracing framework to record structured event and span data.
+#[derive(Debug)]
+pub struct HyperLayer;
+
+impl<S> tracing_subscriber::Layer<S> for HyperLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        println!("Hyper tracing event:");
+        println!("  level={:?}", event.metadata().level());
+        println!("  target={:?}", event.metadata().target());
+        println!("  name={:?}", event.metadata().name());
+        for field in event.fields() {
+            println!("  field={}", field.name());
+        }
+    }
+}

--- a/src/common/layers/otel.rs
+++ b/src/common/layers/otel.rs
@@ -1,22 +1,848 @@
 /// A layer for the tracing framework to record structured event and span data.
-#[derive(Debug)]
-pub struct HyperLayer;
+// use crate::common::layers::otel::otel::SpanRef;
+// use opentelemetry::trace::SpanRef;
 
-impl<S> tracing_subscriber::Layer<S> for HyperLayer
+use opentelemetry::trace::TracerProvider;
+use opentelemetry::trace::Tracer;
+
+use tracing_subscriber::registry::SpanRef;
+
+use opentelemetry::{
+    trace::{self as otel, noop, TraceContextExt},
+    Context as OtelContext, Key, KeyValue,
+};
+use std::any::TypeId;
+use std::fmt;
+use std::marker;
+use std::time::{Instant, SystemTime};
+use tracing_core::span::{self, Attributes, Id, Record};
+use tracing_core::{field, Event};
+use tracing_opentelemetry::PreSampledTracer;
+// #[cfg(feature = "tracing-log")]
+// use tracing_log::NormalizeEvent;
+use tracing_subscriber::layer::Context;
+//use tracing_subscriber::registry::LookupSpan;
+//use tracing_subscriber::Layer;
+
+const SPAN_NAME_FIELD: &str = "otel.name";
+const SPAN_KIND_FIELD: &str = "otel.kind";
+const SPAN_STATUS_CODE_FIELD: &str = "otel.status_code";
+const SPAN_STATUS_MESSAGE_FIELD: &str = "otel.status_message";
+
+/// An [OpenTelemetry] propagation layer for use in a project that uses
+/// [tracing].
+///
+/// [OpenTelemetry]: https://opentelemetry.io
+/// [tracing]: https://github.com/tokio-rs/tracing
+#[allow(missing_debug_implementations)]
+pub struct HyperLayer<S, T> {
+    tracer: T,
+    tracked_inactivity: bool,
+    get_context: WithContext,
+    _registry: marker::PhantomData<S>,
+}
+
+impl<S> Default for HyperLayer<S, noop::NoopTracer>
 where
-    S: tracing::Subscriber,
+    S: tracing_core::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
 {
-    fn on_event(
+    fn default() -> Self {
+        HyperLayer::new(noop::NoopTracer::new())
+    }
+}
+
+/// Construct a layer to track spans via [OpenTelemetry].
+///
+/// [OpenTelemetry]: https://opentelemetry.io
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use tracing_subscriber::layer::SubscriberExt;
+/// use tracing_subscriber::Registry;
+///
+/// // Use the tracing subscriber `Registry`, or any other subscriber
+/// // that impls `LookupSpan`
+/// let subscriber = Registry::default().with(tracing_opentelemetry::layer());
+/// # drop(subscriber);
+/// ```
+pub fn layer<S>() -> HyperLayer<S, noop::NoopTracer>
+where
+    S: tracing_core::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    HyperLayer::default()
+}
+
+// this function "remembers" the types of the subscriber so that we
+// can downcast to something aware of them without knowing those
+// types at the callsite.
+//
+// See https://github.com/tokio-rs/tracing/blob/4dad420ee1d4607bad79270c1520673fa6266a3d/tracing-error/src/layer.rs
+pub(crate) struct WithContext(
+    fn(
+        &tracing::Dispatch,
+        &span::Id,
+        f: &mut dyn FnMut(&mut otel::SpanBuilder, &dyn PreSampledTracer),
+    ),
+);
+
+impl WithContext {
+    // This function allows a function to be called in the context of the
+    // "remembered" subscriber.
+    pub(crate) fn with_context<'a>(
         &self,
-        event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
+        dispatch: &'a tracing::Dispatch,
+        id: &span::Id,
+        mut f: impl FnMut(&mut otel::SpanBuilder, &dyn PreSampledTracer),
     ) {
-        println!("Hyper tracing event:");
-        println!("  level={:?}", event.metadata().level());
-        println!("  target={:?}", event.metadata().target());
-        println!("  name={:?}", event.metadata().name());
-        for field in event.fields() {
-            println!("  field={}", field.name());
+        (self.0)(dispatch, id, &mut f)
+    }
+}
+
+fn str_to_span_kind(s: &str) -> Option<otel::SpanKind> {
+    match s {
+        s if s.eq_ignore_ascii_case("server") => Some(otel::SpanKind::Server),
+        s if s.eq_ignore_ascii_case("client") => Some(otel::SpanKind::Client),
+        s if s.eq_ignore_ascii_case("producer") => Some(otel::SpanKind::Producer),
+        s if s.eq_ignore_ascii_case("consumer") => Some(otel::SpanKind::Consumer),
+        s if s.eq_ignore_ascii_case("internal") => Some(otel::SpanKind::Internal),
+        _ => None,
+    }
+}
+
+fn str_to_status_code(s: &str) -> Option<otel::StatusCode> {
+    match s {
+        s if s.eq_ignore_ascii_case("unset") => Some(otel::StatusCode::Unset),
+        s if s.eq_ignore_ascii_case("ok") => Some(otel::StatusCode::Ok),
+        s if s.eq_ignore_ascii_case("error") => Some(otel::StatusCode::Error),
+        _ => None,
+    }
+}
+
+struct SpanEventVisitor<'a>(&'a mut otel::Event);
+
+impl<'a> field::Visit for SpanEventVisitor<'a> {
+    /// Record events on the underlying OpenTelemetry [`Span`] from `bool` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_bool(&mut self, field: &field::Field, value: bool) {
+        match field.name() {
+            "message" => self.0.name = value.to_string().into(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.0.attributes.push(KeyValue::new(name, value));
+            }
         }
+    }
+
+    /// Record events on the underlying OpenTelemetry [`Span`] from `f64` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_f64(&mut self, field: &field::Field, value: f64) {
+        match field.name() {
+            "message" => self.0.name = value.to_string().into(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.0.attributes.push(KeyValue::new(name, value));
+            }
+        }
+    }
+
+    /// Record events on the underlying OpenTelemetry [`Span`] from `i64` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_i64(&mut self, field: &field::Field, value: i64) {
+        match field.name() {
+            "message" => self.0.name = value.to_string().into(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.0.attributes.push(KeyValue::new(name, value));
+            }
+        }
+    }
+
+    /// Record events on the underlying OpenTelemetry [`Span`] from `&str` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_str(&mut self, field: &field::Field, value: &str) {
+        match field.name() {
+            "message" => self.0.name = value.to_string().into(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.0
+                    .attributes
+                    .push(KeyValue::new(name, value.to_string()));
+            }
+        }
+    }
+
+    /// Record events on the underlying OpenTelemetry [`Span`] from values that
+    /// implement Debug.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_debug(&mut self, field: &field::Field, value: &dyn fmt::Debug) {
+        match field.name() {
+            "message" => self.0.name = format!("{:?}", value).into(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.0
+                    .attributes
+                    .push(KeyValue::new(name, format!("{:?}", value)));
+            }
+        }
+    }
+}
+
+struct SpanAttributeVisitor<'a>(&'a mut otel::SpanBuilder);
+
+impl<'a> SpanAttributeVisitor<'a> {
+    fn record(&mut self, attribute: KeyValue) {
+        debug_assert!(self.0.attributes.is_some());
+        if let Some(v) = self.0.attributes.as_mut() {
+            v.push(attribute);
+        }
+    }
+}
+
+impl<'a> field::Visit for SpanAttributeVisitor<'a> {
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `bool` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_bool(&mut self, field: &field::Field, value: bool) {
+        self.record(KeyValue::new(field.name(), value));
+    }
+
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `f64` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_f64(&mut self, field: &field::Field, value: f64) {
+        self.record(KeyValue::new(field.name(), value));
+    }
+
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `i64` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_i64(&mut self, field: &field::Field, value: i64) {
+        self.record(KeyValue::new(field.name(), value));
+    }
+
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `&str` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_str(&mut self, field: &field::Field, value: &str) {
+        match field.name() {
+            SPAN_NAME_FIELD => self.0.name = value.to_string().into(),
+            SPAN_KIND_FIELD => self.0.span_kind = str_to_span_kind(value),
+            SPAN_STATUS_CODE_FIELD => self.0.status_code = str_to_status_code(value),
+            SPAN_STATUS_MESSAGE_FIELD => self.0.status_message = Some(value.to_owned().into()),
+            _ => self.record(KeyValue::new(field.name(), value.to_string())),
+        }
+    }
+
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from values that
+    /// implement Debug.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_debug(&mut self, field: &field::Field, value: &dyn fmt::Debug) {
+        match field.name() {
+            SPAN_NAME_FIELD => self.0.name = format!("{:?}", value).into(),
+            SPAN_KIND_FIELD => self.0.span_kind = str_to_span_kind(&format!("{:?}", value)),
+            SPAN_STATUS_CODE_FIELD => {
+                self.0.status_code = str_to_status_code(&format!("{:?}", value))
+            }
+            SPAN_STATUS_MESSAGE_FIELD => {
+                self.0.status_message = Some(format!("{:?}", value).into())
+            }
+            _ => self.record(Key::new(field.name()).string(format!("{:?}", value))),
+        }
+    }
+}
+
+// pub struct HyperSubscriber {}
+
+// impl<C> tracing_subscriber::Subscribe<C> for HyperSubscriber<C>
+// where
+//     C: tracing_core::Collect + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+// {
+
+// }
+
+impl<S, T> HyperLayer<S, T>
+where
+    S: tracing_core::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    T: otel::Tracer + PreSampledTracer + 'static,
+{
+    /// Set the [`Tracer`] that this layer will use to produce and track
+    /// OpenTelemetry [`Span`]s.
+    ///
+    /// [`Tracer`]: opentelemetry::trace::Tracer
+    /// [`Span`]: opentelemetry::trace::Span
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tracing_opentelemetry::HyperLayer;
+    /// use tracing_subscriber::layer::SubscriberExt;
+    /// use tracing_subscriber::Registry;
+    ///
+    /// // Create a jaeger exporter pipeline for a `trace_demo` service.
+    /// let tracer = opentelemetry_jaeger::new_pipeline()
+    ///     .with_service_name("trace_demo")
+    ///     .install_simple()
+    ///     .expect("Error initializing Jaeger exporter");
+    ///
+    /// // Create a layer with the configured tracer
+    /// let otel_layer = HyperLayer::new(tracer);
+    ///
+    /// // Use the tracing subscriber `Registry`, or any other subscriber
+    /// // that impls `LookupSpan`
+    /// let subscriber = Registry::default().with(otel_layer);
+    /// # drop(subscriber);
+    /// ```
+    pub fn new(tracer: T) -> Self {
+        HyperLayer {
+            tracer,
+            tracked_inactivity: true,
+            get_context: WithContext(Self::get_context),
+            _registry: marker::PhantomData,
+        }
+    }
+
+    /// Set the [`Tracer`] that this layer will use to produce and track
+    /// OpenTelemetry [`Span`]s.
+    ///
+    /// [`Tracer`]: opentelemetry::trace::Tracer
+    /// [`Span`]: opentelemetry::trace::Span
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tracing_subscriber::layer::SubscriberExt;
+    /// use tracing_subscriber::Registry;
+    ///
+    /// // Create a jaeger exporter pipeline for a `trace_demo` service.
+    /// let tracer = opentelemetry_jaeger::new_pipeline()
+    ///     .with_service_name("trace_demo")
+    ///     .install_simple()
+    ///     .expect("Error initializing Jaeger exporter");
+    ///
+    /// // Create a layer with the configured tracer
+    /// let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    ///
+    /// // Use the tracing subscriber `Registry`, or any other subscriber
+    /// // that impls `LookupSpan`
+    /// let subscriber = Registry::default().with(otel_layer);
+    /// # drop(subscriber);
+    /// ```
+    pub fn with_tracer<Tracer>(self, tracer: Tracer) -> HyperLayer<S, Tracer>
+    where
+        Tracer: otel::Tracer + PreSampledTracer + 'static,
+    {
+        HyperLayer {
+            tracer,
+            tracked_inactivity: self.tracked_inactivity,
+            get_context: WithContext(HyperLayer::<S, Tracer>::get_context),
+            _registry: self._registry,
+        }
+    }
+
+    /// Sets whether or not spans metadata should include the _busy time_
+    /// (total time for which it was entered), and _idle time_ (total time
+    /// the span existed but was not entered).
+    pub fn with_tracked_inactivity(self, tracked_inactivity: bool) -> Self {
+        Self {
+            tracked_inactivity,
+            ..self
+        }
+    }
+
+    /// Retrieve the parent OpenTelemetry [`Context`] from the current tracing
+    /// [`span`] through the [`Registry`]. This [`Context`] links spans to their
+    /// parent for proper hierarchical visualization.
+    ///
+    /// [`Context`]: opentelemetry::Context
+    /// [`span`]: tracing::Span
+    /// [`Registry`]: tracing_subscriber::Registry
+    fn parent_context(&self, attrs: &Attributes<'_>, ctx: &Context<'_, S>) -> OtelContext {
+        // If a span is specified, it _should_ exist in the underlying `Registry`.
+        if let Some(parent) = attrs.parent() {
+            let span = ctx.span(parent).expect("Span not found, this is a bug");
+            let mut extensions = span.extensions_mut();
+            extensions
+                .get_mut::<otel::SpanBuilder>()
+                .map(|builder| self.tracer.sampled_context(builder))
+                .unwrap_or_default()
+        // Else if the span is inferred from context, look up any available current span.
+        } else if attrs.is_contextual() {
+            ctx.lookup_current()
+                .and_then(|span| {
+                    let mut extensions = span.extensions_mut();
+                    extensions
+                        .get_mut::<otel::SpanBuilder>()
+                        .map(|builder| self.tracer.sampled_context(builder))
+                })
+                .unwrap_or_else(OtelContext::current)
+        // Explicit root spans should have no parent context.
+        } else {
+            OtelContext::new()
+        }
+    }
+
+    fn get_context(
+        dispatch: &tracing::Dispatch,
+        id: &span::Id,
+        f: &mut dyn FnMut(&mut otel::SpanBuilder, &dyn PreSampledTracer),
+    ) {
+        let subscriber = dispatch
+            .downcast_ref::<S>()
+            .expect("subscriber should downcast to expected type; this is a bug!");
+        let span = subscriber
+            .span(id)
+            .expect("registry should have a span for the current ID");
+        let layer = dispatch
+            .downcast_ref::<HyperLayer<S, T>>()
+            .expect("layer should downcast to expected type; this is a bug!");
+
+        let mut extensions = span.extensions_mut();
+        if let Some(builder) = extensions.get_mut::<otel::SpanBuilder>() {
+            f(builder, &layer.tracer);
+        }
+    }
+}
+
+impl<S, T> tracing_subscriber::Layer<S> for HyperLayer<S, T>
+where
+    S: tracing_core::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    T: otel::Tracer + PreSampledTracer + 'static,
+{
+    /// Creates an [OpenTelemetry `Span`] for the corresponding [tracing `Span`].
+    ///
+    /// [OpenTelemetry `Span`]: opentelemetry::trace::Span
+    /// [tracing `Span`]: tracing::Span
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        if self.tracked_inactivity && extensions.get_mut::<Timings>().is_none() {
+            extensions.insert(Timings::new());
+        }
+
+        let mut builder = self
+            .tracer
+            .span_builder(attrs.metadata().name())
+            .with_start_time(SystemTime::now())
+            .with_parent_context(self.parent_context(attrs, &ctx))
+            // Eagerly assign span id so children have stable parent id
+            .with_span_id(self.tracer.new_span_id());
+
+        // Record new trace id if there is no active parent span
+        if !builder.parent_context.has_active_span() {
+            builder.trace_id = Some(self.tracer.new_trace_id());
+        }
+
+        let builder_attrs = builder
+            .attributes
+            .get_or_insert(Vec::with_capacity(attrs.fields().len() + 3));
+
+        let meta = attrs.metadata();
+
+        if let Some(filename) = meta.file() {
+            builder_attrs.push(KeyValue::new("code.filepath", filename));
+        }
+
+        if let Some(module) = meta.module_path() {
+            builder_attrs.push(KeyValue::new("code.namespace", module));
+        }
+
+        if let Some(line) = meta.line() {
+            builder_attrs.push(KeyValue::new("code.lineno", line as i64));
+        }
+
+        attrs.record(&mut SpanAttributeVisitor(&mut builder));
+        extensions.insert(builder);
+    }
+
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        if !self.tracked_inactivity {
+            return;
+        }
+
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        if let Some(timings) = extensions.get_mut::<Timings>() {
+            let now = Instant::now();
+            timings.idle += (now - timings.last).as_nanos() as i64;
+            timings.last = now;
+        }
+    }
+
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        if !self.tracked_inactivity {
+            return;
+        }
+
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        if let Some(timings) = extensions.get_mut::<Timings>() {
+            let now = Instant::now();
+            timings.busy += (now - timings.last).as_nanos() as i64;
+            timings.last = now;
+        }
+    }
+
+    /// Record OpenTelemetry [`attributes`] for the given values.
+    ///
+    /// [`attributes`]: opentelemetry::trace::SpanBuilder::attributes
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+        if let Some(builder) = extensions.get_mut::<otel::SpanBuilder>() {
+            values.record(&mut SpanAttributeVisitor(builder));
+        }
+    }
+
+    fn on_follows_from(&self, id: &Id, follows: &Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+        let builder = extensions
+            .get_mut::<otel::SpanBuilder>()
+            .expect("Missing SpanBuilder span extensions");
+
+        let follows_span = ctx
+            .span(follows)
+            .expect("Span to follow not found, this is a bug");
+        let mut follows_extensions = follows_span.extensions_mut();
+        let follows_builder = follows_extensions
+            .get_mut::<otel::SpanBuilder>()
+            .expect("Missing SpanBuilder span extensions");
+
+        let follows_context = self
+            .tracer
+            .sampled_context(follows_builder)
+            .span()
+            .span_context()
+            .clone();
+        let follows_link = otel::Link::new(follows_context, Vec::new());
+        if let Some(ref mut links) = builder.links {
+            links.push(follows_link);
+        } else {
+            builder.links = Some(vec![follows_link]);
+        }
+    }
+
+    /// Records OpenTelemetry [`Event`] data on event.
+    ///
+    /// Note:
+    /// An [`ERROR`]-level event will also set the OpenTelemetry span status
+    /// code to [`Error`], signaling that an error has occurred.
+    ///
+    /// [`Event`]: opentelemetry::trace::Event
+    /// [`ERROR`]: tracing::Level::ERROR
+    /// [`Error`]: opentelemetry::trace::StatusCode::Error
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        // let mut spans: Vec<SpanRef<'_, S>> = vec![];
+        //for span in scope.from_root() {
+        let span: SpanRef<'_,S>;
+        if let Some(span) = ctx.lookup_current() {
+            // Performing read operations before getting a write lock to avoid a deadlock
+            // See https://github.com/tokio-rs/tracing/issues/763
+            let (meta, otel_event) = Self::process_event(event);
+            Self::process_span(span, meta, otel_event);
+        } else {
+            // Adopt orphan events that are not in the context of a span
+            if event.is_root() {
+                // the event should be a root.
+                let tracer = opentelemetry::global::tracer_provider();
+                let tracer = tracer.tracer("",Some(""));
+                let metadata = event.metadata();
+                let span = tracer.span_builder(metadata.name())
+                                .with_kind(opentelemetry::trace::SpanKind::Internal)
+                                .start(&tracer);
+                let ctx = opentelemetry::trace::Span::span_context(&span);
+                // let span = ctx.lookup_current();
+            } else {
+                // Setup adopter-span under the root for the orphan event
+                let mut scope = ctx
+                    .event_scope(event)
+                    .expect("A root span must be entered.");
+                let span = scope.nth(1).unwrap();
+            }
+            // let meta = parent.metadata();
+            // let fields = parent.fields();
+            // let values: &tracing::field::ValueSet<'_> = fields.into();
+            // let span = tracing::Span::child_of(parent, meta, values);
+            // let context = span.span_context();
+            // let spanref = context.lookup_current();
+            let (meta, otel_event) = Self::process_event(event);
+            Self::process_span(span, meta, otel_event);
+        }
+        // spans.push(span);
+    }
+
+    /// Exports an OpenTelemetry [`Span`] on close.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        let span = ctx.span(&id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+        if let Some(mut builder) = extensions.remove::<otel::SpanBuilder>() {
+            if self.tracked_inactivity {
+                // Append busy/idle timings when enabled.
+                if let Some(timings) = extensions.get_mut::<Timings>() {
+                    let busy_ns = KeyValue::new("busy_ns", timings.busy);
+                    let idle_ns = KeyValue::new("idle_ns", timings.idle);
+
+                    if let Some(ref mut attributes) = builder.attributes {
+                        attributes.push(busy_ns);
+                        attributes.push(idle_ns);
+                    } else {
+                        builder.attributes = Some(vec![busy_ns, idle_ns]);
+                    }
+                }
+            }
+
+            // Assign end time, build and start span, drop span to export
+            builder.with_end_time(SystemTime::now()).start(&self.tracer);
+        }
+    }
+
+    // SAFETY:
+    // This is safe because the `WithContext` function pointer is valid
+    // for the lifetime of `&self`.
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+        match id {
+            id if id == TypeId::of::<Self>() => Some(self as *const _ as *const ()),
+            id if id == TypeId::of::<WithContext>() => {
+                Some(&self.get_context as *const _ as *const ())
+            }
+            _ => None,
+        }
+    }
+}
+
+impl<S, T> HyperLayer<S, T>
+where
+    S: tracing_core::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+    T: otel::Tracer + PreSampledTracer + 'static,
+{
+    fn process_span(span: SpanRef<'_,S>, meta: &tracing::Metadata<'_>, otel_event: otel::Event) {
+        {
+            let mut extensions = span.extensions_mut();
+            if let Some(builder) = extensions.get_mut::<otel::SpanBuilder>() {
+                if builder.status_code.is_none() && *meta.level() == tracing_core::Level::ERROR {
+                    builder.status_code = Some(otel::StatusCode::Error);
+                }
+
+                if let Some(ref mut events) = builder.events {
+                    events.push(otel_event);
+                } else {
+                    builder.events = Some(vec![otel_event]);
+                }
+            }
+        }
+    }
+
+    fn process_event<'a>(event: &'a tracing_core::Event<'_>) -> (&'a tracing::Metadata<'a>, otel::Event) {
+        #[cfg(feature = "tracing-log")]
+        let normalized_meta = event.normalized_metadata();
+        #[cfg(feature = "tracing-log")]
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+        #[cfg(not(feature = "tracing-log"))]
+        let meta = event.metadata();
+        let mut otel_event = otel::Event::new(
+            String::new(),
+            SystemTime::now(),
+            vec![
+                Key::new("level").string(meta.level().to_string()),
+                Key::new("target").string(meta.target().to_string()),
+            ],
+            0,
+        );
+        event.record(&mut SpanEventVisitor(&mut otel_event));
+        (meta, otel_event)
+    }
+}
+
+struct Timings {
+    idle: i64,
+    busy: i64,
+    last: Instant,
+}
+
+impl Timings {
+    fn new() -> Self {
+        Self {
+            idle: 0,
+            busy: 0,
+            last: Instant::now(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::trace::{noop, SpanKind, TraceFlags};
+    use std::borrow::Cow;
+    use std::sync::{Arc, Mutex};
+    use std::time::SystemTime;
+    use tracing_subscriber::prelude::*;
+
+    #[derive(Debug, Clone)]
+    struct TestTracer(Arc<Mutex<Option<otel::SpanBuilder>>>);
+    impl otel::Tracer for TestTracer {
+        type Span = noop::NoopSpan;
+        fn invalid(&self) -> Self::Span {
+            noop::NoopSpan::new()
+        }
+        fn start_with_context<T>(&self, _name: T, _context: OtelContext) -> Self::Span
+        where
+            T: Into<Cow<'static, str>>,
+        {
+            self.invalid()
+        }
+        fn span_builder<T>(&self, name: T) -> otel::SpanBuilder
+        where
+            T: Into<Cow<'static, str>>,
+        {
+            otel::SpanBuilder::from_name(name)
+        }
+        fn build(&self, builder: otel::SpanBuilder) -> Self::Span {
+            *self.0.lock().unwrap() = Some(builder);
+            self.invalid()
+        }
+    }
+
+    impl PreSampledTracer for TestTracer {
+        fn sampled_context(&self, _builder: &mut otel::SpanBuilder) -> OtelContext {
+            OtelContext::new()
+        }
+        fn new_trace_id(&self) -> otel::TraceId {
+            otel::TraceId::invalid()
+        }
+        fn new_span_id(&self) -> otel::SpanId {
+            otel::SpanId::invalid()
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct TestSpan(otel::SpanContext);
+    impl otel::Span for TestSpan {
+        fn add_event_with_timestamp(&mut self, _: String, _: SystemTime, _: Vec<KeyValue>) {}
+        fn span_context(&self) -> &otel::SpanContext {
+            &self.0
+        }
+        fn is_recording(&self) -> bool {
+            false
+        }
+        fn set_attribute(&mut self, _attribute: KeyValue) {}
+        fn set_status(&mut self, _code: otel::StatusCode, _message: String) {}
+        fn update_name(&mut self, _new_name: String) {}
+        fn end_with_timestamp(&mut self, _timestamp: SystemTime) {}
+    }
+
+    #[test]
+    fn dynamic_span_names() {
+        let dynamic_name = "GET http://example.com".to_string();
+        let tracer = TestTracer(Arc::new(Mutex::new(None)));
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug_span!("static_name", otel.name = dynamic_name.as_str());
+        });
+
+        let recorded_name = tracer.0.lock().unwrap().as_ref().map(|b| b.name.clone());
+        assert_eq!(recorded_name, Some(dynamic_name.into()))
+    }
+
+    #[test]
+    fn span_kind() {
+        let tracer = TestTracer(Arc::new(Mutex::new(None)));
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug_span!("request", otel.kind = %SpanKind::Server);
+        });
+
+        let recorded_kind = tracer.0.lock().unwrap().as_ref().unwrap().span_kind.clone();
+        assert_eq!(recorded_kind, Some(otel::SpanKind::Server))
+    }
+
+    #[test]
+    fn span_status_code() {
+        let tracer = TestTracer(Arc::new(Mutex::new(None)));
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug_span!("request", otel.status_code = ?otel::StatusCode::Ok);
+        });
+        let recorded_status_code = tracer.0.lock().unwrap().as_ref().unwrap().status_code;
+        assert_eq!(recorded_status_code, Some(otel::StatusCode::Ok))
+    }
+
+    #[test]
+    fn span_status_message() {
+        let tracer = TestTracer(Arc::new(Mutex::new(None)));
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+
+        let message = "message";
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug_span!("request", otel.status_message = message);
+        });
+
+        let recorded_status_message = tracer
+            .0
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .status_message
+            .clone();
+
+        assert_eq!(recorded_status_message, Some(message.into()))
+    }
+
+    #[test]
+    fn trace_id_from_existing_context() {
+        let tracer = TestTracer(Arc::new(Mutex::new(None)));
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+        let trace_id = otel::TraceId::from_u128(42);
+        let existing_cx = OtelContext::current_with_span(TestSpan(otel::SpanContext::new(
+            trace_id,
+            otel::SpanId::from_u64(1),
+            TraceFlags::default(),
+            false,
+            Default::default(),
+        )));
+        let _g = existing_cx.attach();
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug_span!("request", otel.kind = %SpanKind::Server);
+        });
+
+        let recorded_trace_id = tracer
+            .0
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .parent_context
+            .span()
+            .span_context()
+            .trace_id();
+        assert_eq!(recorded_trace_id, trace_id)
     }
 }

--- a/src/common/layers/print.rs
+++ b/src/common/layers/print.rs
@@ -2,10 +2,21 @@
 #[derive(Debug)]
 pub struct HyperLayer;
 
+impl HyperLayer
+// where
+//     S: tracing::Subscriber,
+{
+    /// Create a new layer
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
 impl<S> tracing_subscriber::Layer<S> for HyperLayer
 where
     S: tracing::Subscriber,
 {
+
     fn on_event(
         &self,
         event: &tracing::Event<'_>,

--- a/src/common/layers/print.rs
+++ b/src/common/layers/print.rs
@@ -1,0 +1,57 @@
+/// A layer for the tracing framework to record structured event and span data.
+#[derive(Debug)]
+pub struct HyperLayer;
+
+impl<S> tracing_subscriber::Layer<S> for HyperLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        println!("Hyper tracing event:");
+        println!("  level={:?}", event.metadata().level());
+        println!("  target={:?}", event.metadata().target());
+        println!("  name={:?}", event.metadata().name());
+        let mut visitor = PrintVisitor;
+        event.record(&mut visitor);
+    }
+}
+
+struct PrintVisitor;
+
+impl tracing::field::Visit for PrintVisitor {
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        println!("  field={} value={}", field.name(), value)
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        println!("  field={} value={}", field.name(), value)
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        println!("  field={} value={}", field.name(), value)
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        println!("  field={} value={}", field.name(), value)
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        println!("  field={} value={}", field.name(), value)
+    }
+
+    fn record_error(
+        &mut self,
+        field: &tracing::field::Field,
+        value: &(dyn std::error::Error + 'static),
+    ) {
+        println!("  field={} value={}", field.name(), value)
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        println!("  field={} value={:?}", field.name(), value)
+    }
+}

--- a/src/common/layers/values/encode.rs
+++ b/src/common/layers/values/encode.rs
@@ -1,0 +1,16 @@
+// use tracing::field::Field;
+// use tracing::field::Visit;
+// use tracing::Value;
+
+// use crate::proto::h1::{ Encode, Http1Transaction,};
+
+// use crate::proto::h1::{
+//     Encode, Encoder, Http1Transaction, ParseContext, ParseResult, ParsedMessage,
+// };
+
+// impl<'_> std::fmt::Display for Encode<'_> {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         // Customize so only `x` and `y` are denoted.
+//         write!(f, "x: {}, y: {}", self.x, self.y)
+//     }
+// }

--- a/src/common/layers/values/mod.rs
+++ b/src/common/layers/values/mod.rs
@@ -1,0 +1,1 @@
+pub mod encode;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -25,6 +25,8 @@ mod never;
 pub(crate) mod sync_wrapper;
 pub(crate) mod task;
 pub(crate) mod watch;
+#[cfg(all(feature = "layers", any(feature = "http1", feature = "http2")))]
+pub mod layers;
 
 #[cfg(all(feature = "client", any(feature = "http1", feature = "http2")))]
 pub(crate) use self::lazy::{lazy, Started as Lazy};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,8 @@ pub mod ffi;
 
 #[cfg(feature = "layers")]
 pub use crate::common::layers::json::HyperLayer as JsonLayer;
-// #[cfg(feature = "layers")]
-// pub use crate::common::layers::otel::HyperLayer as OtelLayer;
+#[cfg(feature = "layers")]
+pub use crate::common::layers::otel::HyperLayer as OtelLayer;
 #[cfg(feature = "layers")]
 pub use crate::common::layers::print::HyperLayer as PrintLayer;
 #[cfg(feature = "layers")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,12 @@
 //! - `http1`: Enables HTTP/1 support.
 //! - `http2`: Enables HTTP/2 support.
 //! - `client`: Enables the HTTP `client`.
+//! - `layers`: Provides print, JSON and OpenTelemetry layers for `tracing` spans and events.
 //! - `server`: Enables the HTTP `server`.
 //! - `runtime`: Enables convenient integration with `tokio`, providing
 //!   connectors and acceptors for TCP, and a default executor.
-//! - `tcp`: Enables convenient implementations over TCP (using tokio).
 //! - `stream`: Provides `futures::Stream` capabilities.
+//! - `tcp`: Enables convenient implementations over TCP (using tokio).
 //!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 
@@ -86,11 +87,17 @@ pub mod upgrade;
 #[cfg(feature = "ffi")]
 pub mod ffi;
 
+#[cfg(feature = "layers")]
+pub use crate::common::layers::json::HyperLayer as JsonLayer;
+#[cfg(feature = "layers")]
+pub use crate::common::layers::otel::HyperLayer as OtelLayer;
+#[cfg(feature = "layers")]
+pub use crate::common::layers::print::HyperLayer as PrintLayer;
+
 cfg_proto! {
     mod headers;
     mod proto;
 }
-
 cfg_feature! {
     #![feature = "client"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,10 +89,12 @@ pub mod ffi;
 
 #[cfg(feature = "layers")]
 pub use crate::common::layers::json::HyperLayer as JsonLayer;
-#[cfg(feature = "layers")]
-pub use crate::common::layers::otel::HyperLayer as OtelLayer;
+// #[cfg(feature = "layers")]
+// pub use crate::common::layers::otel::HyperLayer as OtelLayer;
 #[cfg(feature = "layers")]
 pub use crate::common::layers::print::HyperLayer as PrintLayer;
+#[cfg(feature = "layers")]
+#[macro_use] extern crate tracing;
 
 cfg_proto! {
     mod headers;


### PR DESCRIPTION
Seeking feedback on the approach:

TLDR;

```bash
podman run -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
cargo run --features="full tracing/max_level_trace" --example client_json_tracing_otel
firefox http://localhost:16686
# See also stdout
```

- ~~Use of a feature flag `layers`, adding the flag to `full` and placing tracing logic behind that flag.~~ See issue #2698 
- Use OpenTelemetry semantic conventions as the starting point.
- The initial documentation is in `src/common/layers/mod.rs`
- [src/proto/h1/role.rs]:  `Server::encode` span (328-470) is the most complete and serves point of reference.  We start here because these are the functions the the subject of spans in the current code base:

  - The `cfg_attr` is a template I propose to use elsewhere: Acceptable?
  - The use of `tracing::Span::current().record(...)`: Acceptable?
  - The `cfg!(feature = ~~"layers"~~ TBD)` guard: Acceptable?
  - I suggest using the `tracing-error` crate, so I don't propose to do too much around the errors: Acceptable?
  - Function arguments that require a tracing `Value` trait are skipped. The proposed workaround until the Value trait is unsealed is to `impl Debug for ...` and `impl Display for ...` in `src/common/layers/values/*.rs`: Acceptable?
  - Move all `debug!(..)` and `trace!(..)` either into a span field, or if not appropriate, behind a `cfg!(feature = "layers")` guard, leave all other levels alone: Acceptable?
  
Once these four spans (`Client:encode`, `Client:parse`, `Server:encode`, `Server:parse`) are  stabilized and merged:

- Propose additional functions to add spans for, per @seanmonstar 's suggestion [finangle guide](https://twitter.github.io/finagle/guide/Tracing.html#standard-annotations)
- Once all spans are in place, rationalize the fields (and their updating) across/between spans
- Add `tracing-error`
 