### PR TITLE
fix(server): use case-insensitive comparison for Expect: 100-continue

### DIFF
--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -274,7 +274,7 @@ impl Http1Transaction for Server {
                     // According to https://datatracker.ietf.org/doc/html/rfc2616#section-14.20
                     // Comparison of expectation values is case-insensitive for unquoted tokens
                     // (including the 100-continue token)
-                    expect_continue = value.to_str().map(|s| s.eq_ignore_ascii_case("100-continue")).unwrap_or(false);
+                    expect_continue = value.as_bytes().eq_ignore_ascii_case(b"100-continue");
                 }
                 header::UPGRADE => {
                     // Upgrades are only allowed with HTTP/1.1

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -271,7 +271,10 @@ impl Http1Transaction for Server {
                     }
                 }
                 header::EXPECT => {
-                    expect_continue = value.as_bytes() == b"100-continue";
+                    // According to https://datatracker.ietf.org/doc/html/rfc2616#section-14.20
+                    // Comparison of expectation values is case-insensitive for unquoted tokens
+                    // (including the 100-continue token)
+                    expect_continue = value.to_str().map(|s| s.eq_ignore_ascii_case("100-continue")).unwrap_or(false);
                 }
                 header::UPGRADE => {
                     // Upgrades are only allowed with HTTP/1.1

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -832,6 +832,39 @@ fn expect_continue_sends_100() {
 }
 
 #[test]
+fn expect_continue_accepts_upper_cased_expectation() {
+    let server = serve();
+    let mut req = connect(server.addr());
+    server.reply();
+
+    req.write_all(
+        b"\
+        POST /foo HTTP/1.1\r\n\
+        Host: example.domain\r\n\
+        Expect: 100-Continue\r\n\
+        Content-Length: 5\r\n\
+        Connection: Close\r\n\
+        \r\n\
+    ",
+    )
+    .expect("write 1");
+
+    let msg = b"HTTP/1.1 100 Continue\r\n\r\n";
+    let mut buf = vec![0; msg.len()];
+    req.read_exact(&mut buf).expect("read 1");
+    assert_eq!(buf, msg);
+
+    let msg = b"hello";
+    req.write_all(msg).expect("write 2");
+
+    let mut body = String::new();
+    req.read_to_string(&mut body).expect("read 2");
+
+    let body = server.body();
+    assert_eq!(body, msg);
+}
+
+#[test]
 fn expect_continue_but_no_body_is_ignored() {
     let server = serve();
     let mut req = connect(server.addr());


### PR DESCRIPTION
According to rfc2616#section-14.20 the header value is case-
insensitive. Certain clients (including Java's std lib
https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/master/src/java.net.http/share/classes/jdk/internal/net/http/Exchange.java#L408)
send the expectation as `100-Continue` and this should be handled
by the server.

(This is an attempt to address https://github.com/hyperium/hyper/issues/2708)