### PR TITLE
fix(http2): received `Body::size_hint()` now return 0 if implicitly empty

### DIFF
--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -68,6 +68,16 @@ impl DecodedLength {
             }
         }
     }
+
+    /// Returns whether this represents an exact length.
+    ///
+    /// This includes 0, which of course is an exact known length.
+    ///
+    /// It would return false if "chunked" or otherwise size-unknown.
+    #[cfg(feature = "http2")]
+    pub(crate) fn is_exact(&self) -> bool {
+        self.0 <= MAX_LEN
+    }
 }
 
 impl fmt::Debug for DecodedLength {

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -484,12 +484,13 @@ where
                         }
                     }
 
-                    // automatically set Content-Length from body...
-                    if let Some(len) = body.size_hint().exact() {
-                        headers::set_content_length_if_missing(res.headers_mut(), len);
-                    }
 
                     if !body.is_end_stream() {
+                        // automatically set Content-Length from body...
+                        if let Some(len) = body.size_hint().exact() {
+                            headers::set_content_length_if_missing(res.headers_mut(), len);
+                        }
+
                         let body_tx = reply!(me, res, false);
                         H2StreamState::Body {
                             pipe: PipeToSendStream::new(body, body_tx),

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -361,6 +361,26 @@ mod response_body_lengths {
         assert_eq!(res.headers().get("content-length").unwrap(), "10");
         assert_eq!(res.body().size_hint().exact(), Some(10));
     }
+
+    #[tokio::test]
+    async fn http2_implicit_empty_size_hint() {
+        use http_body::Body;
+
+        let server = serve();
+        let addr_str = format!("http://{}", server.addr());
+        server.reply();
+
+        let client = Client::builder()
+            .http2_only(true)
+            .build_http::<hyper::Body>();
+        let uri = addr_str
+            .parse::<hyper::Uri>()
+            .expect("server addr should parse");
+
+        let res = client.get(uri).await.unwrap();
+        assert_eq!(res.headers().get("content-length"), None);
+        assert_eq!(res.body().size_hint().exact(), Some(0));
+    }
 }
 
 #[test]


### PR DESCRIPTION
An HTTP/2 stream may include a set of headers, and a flag signalling
END-STREAM, even if a `content-length` isn't included. hyper wouldn't
notice, and so the `Body` would report a size-hint of `0..MAX`. hyper
now notices that the stream is ended, and couldn't possibly include any
bytes for the body, and thus will give a size-hint of `0` exactly.

Closes #2712 