### PR TITLE
Add fuzzing harness to fuzz a single request parse

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+
+[package]
+name = "hyper-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+tokio = "1.14.0"
+async-io = "1.6.0"
+
+[dependencies.hyper]
+path = ".."
+features = ["full"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_request"
+path = "fuzz_targets/fuzz_request.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_request.rs
+++ b/fuzz/fuzz_targets/fuzz_request.rs
@@ -1,0 +1,63 @@
+#![feature(never_type)]
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use std::pin::Pin;
+
+use std::task::{Context, Poll};
+
+use hyper::{Body, Request, Response};
+
+struct WriteVoidReadData(std::io::Cursor<Vec<u8>>);
+
+impl tokio::io::AsyncRead for WriteVoidReadData {
+    fn poll_read(
+        mut self: core::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        tokio::io::AsyncRead::poll_read(Pin::new(&mut self.0), cx, buf)
+    }
+}
+
+impl tokio::io::AsyncWrite for WriteVoidReadData {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Poll::Ready(Ok(buf.len()))
+    }
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+struct VoidService;
+
+impl hyper::service::Service<Request<Body>> for VoidService {
+    type Response = Response<hyper::body::Body>;
+    type Error = !;
+    type Future = core::future::Ready<Result<Self::Response, !>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: Request<Body>) -> Self::Future {
+        core::future::ready(Ok(Response::new(hyper::body::Body::empty())))
+    }
+}
+
+fuzz_target!(|data: Vec<u8>| {
+    let s = hyper::server::conn::Http::new();
+    let svc = s.serve_connection(WriteVoidReadData(std::io::Cursor::new(data)), VoidService);
+    drop(async_io::block_on(svc));
+});


### PR DESCRIPTION
This *might* be somewhat redundant seeing as both `h2` and `httparse` are fuzzed independently, but it's probably worth fuzzing the code here.