### PR TITLE
chore(dependencies): update to itoa 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ http-body = "0.4"
 httpdate = "1.0"
 httparse = "1.5.1"
 h2 = { version = "0.3.9", optional = true }
-itoa = "0.4.1"
+itoa = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 pin-project-lite = "0.2.4"
 tower-service = "0.3"

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -580,7 +580,7 @@ impl Server {
     #[inline]
     fn encode_headers<W>(
         msg: Encode<'_, StatusCode>,
-        mut dst: &mut Vec<u8>,
+        dst: &mut Vec<u8>,
         mut is_last: bool,
         orig_len: usize,
         mut wrote_len: bool,
@@ -837,7 +837,7 @@ impl Server {
                             "content-length: ",
                             header::CONTENT_LENGTH,
                         );
-                        let _ = ::itoa::write(&mut dst, len);
+                        extend(dst, ::itoa::Buffer::new().format(len).as_bytes());
                         extend(dst, b"\r\n");
                         Encoder::length(len)
                     }


### PR DESCRIPTION
serde_json already uses this and I've already submitted a PR for http. This will let new builds of hyper only have a single version of itoa again.