### PR TITLE
refactor(client) use Box<str> in ..::dns::Name

### DIFF
--- a/src/client/connect/dns.rs
+++ b/src/client/connect/dns.rs
@@ -38,7 +38,7 @@ pub(super) use self::sealed::Resolve;
 /// A domain name to resolve into IP addresses.
 #[derive(Clone, Hash, Eq, PartialEq)]
 pub struct Name {
-    host: String,
+    host: Box<str>,
 }
 
 /// A resolver using blocking `getaddrinfo` calls in a threadpool.
@@ -58,7 +58,7 @@ pub struct GaiFuture {
 }
 
 impl Name {
-    pub(super) fn new(host: String) -> Name {
+    pub(super) fn new(host: Box<str>) -> Name {
         Name { host }
     }
 
@@ -85,7 +85,7 @@ impl FromStr for Name {
 
     fn from_str(host: &str) -> Result<Self, Self::Err> {
         // Possibly add validation later
-        Ok(Name::new(host.to_owned()))
+        Ok(Name::new(host.into()))
     }
 }
 


### PR DESCRIPTION
Use Box<str> in hyper::client::connect::dns::Name, so
its size is 16 bytes, not 24 bytes.  As Name never
change its contents, read-only Box<str> is perfectly OK.

