### PR TITLE
feat(error): add `Error::message`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -396,6 +396,11 @@ impl Error {
         }
     }
 
+    /// The error's standalone message, without the message from the source.
+    pub fn message(&self) -> impl fmt::Display + '_ {
+        self.description()
+    }
+
     fn description(&self) -> &str {
         match self.inner.kind {
             Kind::Parse(Parse::Method) => "invalid HTTP method parsed",


### PR DESCRIPTION
This is an alternate solution to https://github.com/hyperium/hyper/issues/2732 that doesn't change `hyper::Error`'s `Display` impl (like https://github.com/hyperium/hyper/pull/2542 does).

It adds `Error::message` which returns the message that is unique to the error, without the message from the source. That way users can create a newtype around `hyper::Error` and use this in the `Display` impl to work around https://github.com/hyperium/hyper/issues/2732.

Fixes https://github.com/hyperium/hyper/issues/2732