### PR TITLE
Avoid panics in uses of `Instant`

### DIFF
--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -458,7 +458,9 @@ impl<T: Poolable> PoolInner<T> {
                     trace!("idle interval evicting closed for {:?}", key);
                     return false;
                 }
-                if now - entry.idle_at > dur {
+
+                // Avoid `Instant::sub` to avoid issues like rust-lang/rust#86470.
+                if now.saturating_duration_since(entry.idle_at) > dur {
                     trace!("idle interval evicting expired for {:?}", key);
                     return false;
                 }
@@ -721,7 +723,8 @@ impl Expiration {
 
     fn expires(&self, instant: Instant) -> bool {
         match self.0 {
-            Some(timeout) => instant.elapsed() > timeout,
+            // Avoid `Instant::elapsed` to avoid issues like rust-lang/rust#86470.
+            Some(timeout) => Instant::now().saturating_duration_since(instant) > timeout,
             None => false,
         }
     }


### PR DESCRIPTION
We have reports of runtime panics (linkerd/linkerd2#7748) that sound a
lot like rust-lang/rust#86470. We don't have any evidence that these
panics originate in hyper, but #2385 reports a similar issue.

Even though this is almost definitely a bug in Rust, it seems most
prudent to actively avoid the uses of `Instant` that are prone to this
bug.

This change replaces uses of `Instant::elapsed` and `Instant::sub` with
calls to `Instant::saturating_duration_since` to prevent this class of
panic.

