### PR TITLE
feat(server): add an option to disable adding the `DATE` header

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -59,6 +59,8 @@ where
                 h1_header_read_timeout_running: false,
                 preserve_header_case: false,
                 title_case_headers: false,
+                #[cfg(feature = "server")]
+                add_date: true,
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
                 on_informational: None,
@@ -109,6 +111,11 @@ where
 
     pub(crate) fn set_preserve_header_case(&mut self) {
         self.state.preserve_header_case = true;
+    }
+
+    #[cfg(feature = "server")]
+    pub(crate) fn disable_add_date(&mut self) {
+        self.state.add_date = false;
     }
 
     #[cfg(feature = "client")]
@@ -558,6 +565,8 @@ where
                 keep_alive: self.state.wants_keep_alive(),
                 req_method: &mut self.state.method,
                 title_case_headers: self.state.title_case_headers,
+                #[cfg(feature = "server")]
+                add_date: self.state.add_date,
             },
             buf,
         ) {
@@ -827,6 +836,8 @@ struct State {
     h1_header_read_timeout_running: bool,
     preserve_header_case: bool,
     title_case_headers: bool,
+    #[cfg(feature = "server")]
+    add_date: bool,
     h09_responses: bool,
     /// If set, called with each 1xx informational response received for
     /// the current request. MUST be unset after a non-1xx response is

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -99,6 +99,8 @@ pub(crate) struct Encode<'a, T> {
     keep_alive: bool,
     req_method: &'a mut Option<Method>,
     title_case_headers: bool,
+    #[cfg(feature = "server")]
+    add_date: bool,
 }
 
 /// Extra flags that a request "wants", like expect-continue or upgrades.

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -309,6 +309,22 @@ impl<I, E> Builder<I, E> {
         self
     }
 
+    /// Set whether to automatically add the `DATE` header to responses.
+    ///
+    /// If true, and a request does not include a `DATE` header, one will be
+    /// added automatically.
+    ///
+    /// It is a protocol violation not to include a `DATE` header unless the 
+    /// server does not have a clock capable of providing a reasonable 
+    /// approximation of the time.
+    ///
+    /// Currently, this setting is unimplemented for HTTP/2.
+    ///
+    /// Default is `true`. 
+    pub fn add_date(mut self, val: bool) -> Self {
+        self.protocol.add_date(val);
+        self
+    }
     /// Set a timeout for reading client request headers. If a client does not 
     /// transmit the entire header within this time, the connection is closed.
     ///


### PR DESCRIPTION
Add an option to disable the automatic addition of the `DATE` header for
situations when an accurate time is not available or the `DATE` header
is otherwise undesirable, for example communicating with a non-compliant
client.

According to RFC7231#7.1.1.2, 'An origin server MUST NOT send a Date
header field if it does not have a clock capable of providing a
reasonable approximation of the current instance in Coordinated
Universal Time.' Otherwise, sending the date is required.

Resolve the now closed issue hyperium#912.