### PR TITLE
make as public

### DIFF
--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -38,7 +38,7 @@
 pub use tower_service::Service;
 
 mod http;
-mod make;
+pub mod make;
 #[cfg(all(any(feature = "http1", feature = "http2"), feature = "client"))]
 mod oneshot;
 mod util;


### PR DESCRIPTION
So, the idea here is to be able to use MakeServiceRef and MakeServiceFn outside of the api scope.
:)
