### PR TITLE
Only build cdylib when the FFI cfg is active

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ include = [
   #"build.rs",
 ]
 
-[lib]
-crate-type = ["lib", "staticlib", "cdylib"]
-
 [dependencies]
 bytes = "1"
 futures-core = { version = "0.3", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,11 @@
 #![cfg_attr(test, deny(warnings))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(hyper_unstable_ffi, crate_type = "cdylib")]
+#![cfg_attr(
+    hyper_unstable_ffi,
+    allow(unknown_lints, deprecated_cfg_attr_crate_type_name)
+)]
 
 //! # hyper
 //!


### PR DESCRIPTION
Hi, 

as part of the [initiative to improve compile times](https://blog.rust-lang.org/inside-rust/2022/02/22/compiler-team-ambitions-2022.html#faster-builds-initiatives--%EF%B8%8F) we've been looking at rustc benchmarks over a number of crates in the ecosystem.

We've noticed `hyper` was preventing pipelining opportunities, both for:
- its own dependencies: compilation only starts when dependencies are done with codegen, not just when their metadata is available, e.g. for `tokio` or `h2`, depending on the chosen features. 
- its dependent crates: it seems crates depending on `hyper` also wait for codegen instead of its metadata, as we can see e.g. here in [`warp-0.3.2`](https://lqd.github.io/rustc-benchmarking-data/results/round-13-cargo-timing-opt-j8/cargo-timing-warp-0.3.2-opt-j8.html). 
 
In this cargo timing example, `hyper` could start building 6.6s earlier with `h2`'s metadata, and `warp` could start building as soon as `hyper`'s metadata is available, around 6s earlier (from different measurements, `hyper`'s metadata is not visible in the link above). 

Adding both of these together, there could be a sizable opportunity to improve compile times in the whole `hyper` ecosystem, in addition to `hyper` contributors working on the crate itself.

I've discussed this with @nox and they've directed me at https://github.com/hyperium/hyper/issues/2685 as the cause, with this [cargo issue as a blocker](https://github.com/rust-lang/cargo/issues/10356). Until that is fixed however, I wanted to discuss this hack as an alternative, to re-enable pipelining (without creating a whole different FFI-binding crate) and improve compile times in the meantime. 

The idea is to use `#![crate_type]` to build the cdylib only when the FFI cfg is active, in the source rather than via cargo. This works, I believe, on stable and on your MSRV of 1.46 (but I'm not sure I was able to fully test this, and hope CI will help). It has however been recently deprecated, and that deprecation will land on stable in the 1.59 release tomorrow. I don't think it'll go away before the cargo issue is fixed though, so it still seems pretty safe. (Also: I've had to allow the lint to build with deny warnings, and unknown lints to support 1.46+ which don't yet know about that new lint. Another note: maybe the `ffi` feature should be checked in addition to the `hyper_unstable_ffi` cfg ?).

I believe there's another cargo feature which could maybe help, to specify dependency crate types in the cargo manifest; all in all, it seems issues in cargo will be fixed and this is mostly a temporary measure to help things until those principled fixes are available.

Just to give you an idea of the impact this has, I've benchmarked building `hyper` (with the `client,http1,http2` features) from `-j2` to `-j12`: debug builds improve by 7-8%, and release builds by 18-29% (26% mean). This does translate to downstream crates. 

I can provide precise numbers and cargo timing graphs if needed.

(Opening as draft for discussion whether something like this could work for you ? and to test it out on CI)