### PR TITLE
Add local_addr information from TcpStream to the HttpInfo struct

### DIFF
--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -66,6 +66,7 @@ pub struct HttpConnector<R = GaiResolver> {
 #[derive(Clone, Debug)]
 pub struct HttpInfo {
     remote_addr: SocketAddr,
+    local_addr: SocketAddr,
 }
 
 #[derive(Clone)]
@@ -360,8 +361,8 @@ where
 impl Connection for TcpStream {
     fn connected(&self) -> Connected {
         let connected = Connected::new();
-        if let Ok(remote_addr) = self.peer_addr() {
-            connected.extra(HttpInfo { remote_addr })
+        if let (Ok(remote_addr), Ok(local_addr)) = (self.peer_addr(), self.local_addr()) {
+            connected.extra(HttpInfo { remote_addr, local_addr })
         } else {
             connected
         }
@@ -372,6 +373,11 @@ impl HttpInfo {
     /// Get the remote address of the transport used.
     pub fn remote_addr(&self) -> SocketAddr {
         self.remote_addr
+    }
+
+    /// Get the local address of the transport used.
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
     }
 }
 


### PR DESCRIPTION
The `HttpConnection` struct now adds `local_addr` information from `TcpStream` to the `HttpInfo` struct

This resolves the issue #2767

