### PR TITLE
refactor(error): improve error message when user body ends early

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -686,10 +686,8 @@ where
                             Writing::KeepAlive
                         }
                     }
-                    Err(_not_eof) => {
-                        res = Err(crate::Error::new_user_body(
-                            crate::Error::new_body_write_aborted(),
-                        ));
+                    Err(not_eof) => {
+                        res = Err(crate::Error::new_body_write_aborted().with(not_eof));
                         Writing::Closed
                     }
                 }

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -22,7 +22,7 @@ pub(crate) struct EncodedBuf<B> {
 }
 
 #[derive(Debug)]
-pub(crate) struct NotEof;
+pub(crate) struct NotEof(u64);
 
 #[derive(Debug, PartialEq, Clone)]
 enum Kind {
@@ -98,7 +98,7 @@ impl Encoder {
             })),
             #[cfg(feature = "server")]
             Kind::CloseDelimited => Ok(None),
-            Kind::Length(_) => Err(NotEof),
+            Kind::Length(n) => Err(NotEof(n)),
         }
     }
 
@@ -350,6 +350,14 @@ impl<B: Buf> From<Chain<Chain<ChunkSize, B>, StaticBuf>> for EncodedBuf<B> {
         }
     }
 }
+
+impl fmt::Display for NotEof {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "early end, expected {} more bytes", self.0)
+    }
+}
+
+impl std::error::Error for NotEof {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
When a request or response includes a `content-length` header, but then the `impl HttpBody` ends before all the data has been written, the returned error message has been improved from:

```
error from user's HttpBody stream: body write aborted
```

to:

```
user body write aborted: early end, expected 49 more bytes
```