### PR TITLE
run some tests with Miri

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,7 @@ jobs:
       - style
       - test
       - msrv
+      - miri
       - features
       - ffi
       - ffi-header
@@ -123,6 +124,27 @@ jobs:
         with:
           command: check
           args: --features full
+
+  miri:
+    name: Test with Miri
+    needs: [style]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: miri
+          override: true
+
+      - name: Test
+        # Can't enable tcp feature since Miri does not support the tokio runtime
+        run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test --features http1,http2,client,server,stream,nightly
 
   features:
     name: features

--- a/src/body/to_bytes.rs
+++ b/src/body/to_bytes.rs
@@ -17,7 +17,7 @@ use super::HttpBody;
 /// # Example
 ///
 /// ```
-/// # #[cfg(all(feature = "client", any(feature = "http1", feature = "http2")))]
+/// # #[cfg(all(feature = "client", feature = "tcp", any(feature = "http1", feature = "http2")))]
 /// # async fn doc() -> hyper::Result<()> {
 /// use hyper::{body::HttpBody};
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_debug_implementations)]
 #![cfg_attr(test, deny(rust_2018_idioms))]
 #![cfg_attr(all(test, feature = "full"), deny(unreachable_pub))]
-#![cfg_attr(test, deny(warnings))]
+#![cfg_attr(all(test, feature = "full"), deny(warnings))]
 #![cfg_attr(all(test, feature = "nightly"), feature(test))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -727,8 +727,11 @@ mod tests {
                 cached_headers: &mut None,
                 req_method: &mut None,
                 h1_parser_config: Default::default(),
+                #[cfg(feature = "runtime")]
                 h1_header_read_timeout: None,
+                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_fut: &mut None,
+                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_running: &mut false,
                 preserve_header_case: false,
                 h09_responses: false,

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1474,8 +1474,11 @@ mod tests {
                 cached_headers: &mut None,
                 req_method: &mut method,
                 h1_parser_config: Default::default(),
+                #[cfg(feature = "runtime")]
                 h1_header_read_timeout: None,
+                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_fut: &mut None,
+                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_running: &mut false,
                 preserve_header_case: false,
                 h09_responses: false,
@@ -1504,8 +1507,11 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
             preserve_header_case: false,
             h09_responses: false,
@@ -1529,8 +1535,11 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut None,
             h1_parser_config: Default::default(),
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
             preserve_header_case: false,
             h09_responses: false,
@@ -1552,8 +1561,11 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
             preserve_header_case: false,
             h09_responses: true,
@@ -1577,8 +1589,11 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
             preserve_header_case: false,
             h09_responses: false,
@@ -1606,8 +1621,11 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
             preserve_header_case: false,
             h09_responses: false,
@@ -1632,8 +1650,11 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
             preserve_header_case: false,
             h09_responses: false,
@@ -1653,8 +1674,11 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut None,
             h1_parser_config: Default::default(),
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
+            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
             preserve_header_case: true,
             h09_responses: false,
@@ -1695,8 +1719,11 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
                     preserve_header_case: false,
                     h09_responses: false,
@@ -1718,8 +1745,11 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
                     preserve_header_case: false,
                     h09_responses: false,
@@ -1950,8 +1980,11 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut Some(Method::GET),
                     h1_parser_config: Default::default(),
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
                     preserve_header_case: false,
                     h09_responses: false,
@@ -1973,8 +2006,11 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut Some(m),
                     h1_parser_config: Default::default(),
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
                     preserve_header_case: false,
                     h09_responses: false,
@@ -1996,8 +2032,11 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut Some(Method::GET),
                     h1_parser_config: Default::default(),
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
                     preserve_header_case: false,
                     h09_responses: false,
@@ -2496,8 +2535,11 @@ mod tests {
                 cached_headers: &mut None,
                 req_method: &mut Some(Method::GET),
                 h1_parser_config: Default::default(),
+                #[cfg(feature = "runtime")]
                 h1_header_read_timeout: None,
+                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_fut: &mut None,
+                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_running: &mut false,
                 preserve_header_case: false,
                 h09_responses: false,
@@ -2583,8 +2625,11 @@ mod tests {
                     cached_headers: &mut headers,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
                     preserve_header_case: false,
                     h09_responses: false,
@@ -2626,8 +2671,11 @@ mod tests {
                     cached_headers: &mut headers,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
+                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
                     preserve_header_case: false,
                     h09_responses: false,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -91,6 +91,7 @@
 //! use std::net::SocketAddr;
 //! use hyper::{Body, Request, Response, Server};
 //! use hyper::service::{make_service_fn, service_fn};
+//! # #[cfg(feature = "runtime")]
 //! use hyper::server::conn::AddrStream;
 //!
 //! #[derive(Clone)]


### PR DESCRIPTION
We have to limit the set of features we test:  `--feature full` does not work since it fires up the tokio runtime, which calls `epoll_create1` and that is not supported by Miri.

Fixes https://github.com/hyperium/hyper/issues/2794