### PR TITLE
fix(ffi): Change hyper_headers_foreach to iterate in recieved order

### DIFF
--- a/capi/include/hyper.h
+++ b/capi/include/hyper.h
@@ -612,18 +612,6 @@ void hyper_headers_foreach(const struct hyper_headers *headers,
                            void *userdata);
 
 /*
- Iterates the headers in the order the were recieved, passing each name and value pair to the callback.
-
- The `userdata` pointer is also passed to the callback.
-
- The callback should return `HYPER_ITER_CONTINUE` to keep iterating, or
- `HYPER_ITER_BREAK` to stop.
- */
-void hyper_headers_foreach_ordered(const struct hyper_headers *headers,
-                                   hyper_headers_foreach_callback func,
-                                   void *userdata);
-
-/*
  Sets the header with the provided name to the provided value.
 
  This overwrites any previous value set for the header.

--- a/capi/include/hyper.h
+++ b/capi/include/hyper.h
@@ -356,6 +356,22 @@ void hyper_clientconn_free(struct hyper_clientconn *conn);
 struct hyper_clientconn_options *hyper_clientconn_options_new(void);
 
 /*
+ Set the whether or not header case is preserved.
+
+ Pass `0` to allow lowercase normalization (default), `1` to retain original case.
+ */
+void hyper_clientconn_options_set_preserve_header_case(struct hyper_clientconn_options *opts,
+                                                       int enabled);
+
+/*
+ Set the whether or not header order is preserved.
+
+ Pass `0` to allow reordering (default), `1` to retain original ordering.
+ */
+void hyper_clientconn_options_set_preserve_header_order(struct hyper_clientconn_options *opts,
+                                                        int enabled);
+
+/*
  Free a `hyper_clientconn_options *`.
  */
 void hyper_clientconn_options_free(struct hyper_clientconn_options *opts);
@@ -594,6 +610,18 @@ struct hyper_body *hyper_response_body(struct hyper_response *resp);
 void hyper_headers_foreach(const struct hyper_headers *headers,
                            hyper_headers_foreach_callback func,
                            void *userdata);
+
+/*
+ Iterates the headers in the order the were recieved, passing each name and value pair to the callback.
+
+ The `userdata` pointer is also passed to the callback.
+
+ The callback should return `HYPER_ITER_CONTINUE` to keep iterating, or
+ `HYPER_ITER_BREAK` to stop.
+ */
+void hyper_headers_foreach_ordered(const struct hyper_headers *headers,
+                                   hyper_headers_foreach_callback func,
+                                   void *userdata);
 
 /*
  Sets the header with the provided name to the provided value.

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -560,6 +560,7 @@ impl Builder {
             h1_parser_config: Default::default(),
             h1_title_case_headers: false,
             h1_preserve_header_case: false,
+            #[cfg(feature = "ffi")]
             h1_preserve_header_order: false,
             h1_max_buf_size: None,
             #[cfg(feature = "ffi")]
@@ -966,9 +967,11 @@ impl Builder {
                     if opts.h1_title_case_headers {
                         conn.set_title_case_headers();
                     }
+                    #[cfg(feature = "ffi")]
                     if opts.h1_preserve_header_case {
                         conn.set_preserve_header_case();
                     }
+                    #[cfg(feature = "ffi")]
                     if opts.h1_preserve_header_order {
                         conn.set_preserve_header_order();
                     }

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -156,6 +156,8 @@ pub struct Builder {
     h1_writev: Option<bool>,
     h1_title_case_headers: bool,
     h1_preserve_header_case: bool,
+    #[cfg(feature = "ffi")]
+    h1_preserve_header_order: bool,
     h1_read_buf_exact_size: Option<usize>,
     h1_max_buf_size: Option<usize>,
     #[cfg(feature = "ffi")]
@@ -558,6 +560,7 @@ impl Builder {
             h1_parser_config: Default::default(),
             h1_title_case_headers: false,
             h1_preserve_header_case: false,
+            h1_preserve_header_order: false,
             h1_max_buf_size: None,
             #[cfg(feature = "ffi")]
             h1_headers_raw: false,
@@ -701,6 +704,21 @@ impl Builder {
     /// Default is false.
     pub fn http1_preserve_header_case(&mut self, enabled: bool) -> &mut Builder {
         self.h1_preserve_header_case = enabled;
+        self
+    }
+
+    /// Set whether to support preserving original header order.
+    ///
+    /// Currently, this will record the order in which headers are received, and store this
+    /// ordering in a private extension on the `Response`. It will also look for and use
+    /// such an extension in any provided `Request`.
+    ///
+    /// Note that this setting does not affect HTTP/2.
+    ///
+    /// Default is false.
+    #[cfg(feature = "ffi")]
+    pub fn http1_preserve_header_order(&mut self, enabled: bool) -> &mut Builder {
+        self.h1_preserve_header_order = enabled;
         self
     }
 
@@ -950,6 +968,9 @@ impl Builder {
                     }
                     if opts.h1_preserve_header_case {
                         conn.set_preserve_header_case();
+                    }
+                    if opts.h1_preserve_header_order {
+                        conn.set_preserve_header_order();
                     }
                     if opts.h09_responses {
                         conn.set_h09_responses();

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -5,6 +5,7 @@ use http::header::HeaderName;
 #[cfg(feature = "http1")]
 use http::header::{IntoHeaderName, ValueIter};
 use http::HeaderMap;
+#[cfg(feature = "ffi")]
 use std::collections::HashMap;
 #[cfg(feature = "http2")]
 use std::fmt;
@@ -123,6 +124,7 @@ impl HeaderCaseMap {
     }
 }
 
+#[cfg(feature = "ffi")]
 #[derive(Clone, Debug)]
 /// Hashmap<Headername, numheaders with that name>
 pub(crate) struct OriginalHeaderOrder {

--- a/src/ffi/client.rs
+++ b/src/ffi/client.rs
@@ -95,12 +95,33 @@ ffi_fn! {
     fn hyper_clientconn_options_new() -> *mut hyper_clientconn_options {
         let mut builder = conn::Builder::new();
         builder.http1_preserve_header_case(true);
+        builder.http1_preserve_header_order(true);
 
         Box::into_raw(Box::new(hyper_clientconn_options {
             builder,
             exec: WeakExec::new(),
         }))
     } ?= std::ptr::null_mut()
+}
+
+ffi_fn! {
+    /// Set the whether or not header case is preserved.
+    ///
+    /// Pass `0` to allow lowercase normalization (default), `1` to retain original case.
+    fn hyper_clientconn_options_set_preserve_header_case(opts: *mut hyper_clientconn_options, enabled: c_int) {
+        let opts = non_null! { &mut *opts ?= () };
+        opts.builder.http1_preserve_header_case(enabled != 0);
+    }
+}
+
+ffi_fn! {
+    /// Set the whether or not header order is preserved.
+    ///
+    /// Pass `0` to allow reordering (default), `1` to retain original ordering.
+    fn hyper_clientconn_options_set_preserve_header_order(opts: *mut hyper_clientconn_options, enabled: c_int) {
+        let opts = non_null! { &mut *opts ?= () };
+        opts.builder.http1_preserve_header_order(enabled != 0);
+    }
 }
 
 ffi_fn! {

--- a/src/ffi/client.rs
+++ b/src/ffi/client.rs
@@ -94,8 +94,6 @@ ffi_fn! {
     /// Creates a new set of HTTP clientconn options to be used in a handshake.
     fn hyper_clientconn_options_new() -> *mut hyper_clientconn_options {
         let mut builder = conn::Builder::new();
-        builder.http1_preserve_header_case(true);
-        builder.http1_preserve_header_order(true);
 
         Box::into_raw(Box::new(hyper_clientconn_options {
             builder,

--- a/src/ffi/client.rs
+++ b/src/ffi/client.rs
@@ -93,7 +93,7 @@ unsafe impl AsTaskType for hyper_clientconn {
 ffi_fn! {
     /// Creates a new set of HTTP clientconn options to be used in a handshake.
     fn hyper_clientconn_options_new() -> *mut hyper_clientconn_options {
-        let mut builder = conn::Builder::new();
+        let builder = conn::Builder::new();
 
         Box::into_raw(Box::new(hyper_clientconn_options {
             builder,

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -58,6 +58,8 @@ where
                 #[cfg(all(feature = "server", feature = "runtime"))]
                 h1_header_read_timeout_running: false,
                 preserve_header_case: false,
+                #[cfg(feature = "ffi")]
+                preserve_header_order: false,
                 title_case_headers: false,
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
@@ -109,6 +111,11 @@ where
 
     pub(crate) fn set_preserve_header_case(&mut self) {
         self.state.preserve_header_case = true;
+    }
+
+    #[cfg(feature = "ffi")]
+    pub(crate) fn set_preserve_header_order(&mut self) {
+        self.state.preserve_header_order = true;
     }
 
     #[cfg(feature = "client")]
@@ -200,6 +207,8 @@ where
                 #[cfg(all(feature = "server", feature = "runtime"))]
                 h1_header_read_timeout_running: &mut self.state.h1_header_read_timeout_running,
                 preserve_header_case: self.state.preserve_header_case,
+                #[cfg(feature = "ffi")]
+                preserve_header_order: self.state.preserve_header_order,
                 h09_responses: self.state.h09_responses,
                 #[cfg(feature = "ffi")]
                 on_informational: &mut self.state.on_informational,
@@ -824,6 +833,8 @@ struct State {
     #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout_running: bool,
     preserve_header_case: bool,
+    #[cfg(feature = "ffi")]
+    preserve_header_order: bool,
     title_case_headers: bool,
     h09_responses: bool,
     /// If set, called with each 1xx informational response received for

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -1,17 +1,17 @@
 use std::cmp;
 use std::fmt;
+#[cfg(all(feature = "server", feature = "runtime"))]
+use std::future::Future;
 use std::io::{self, IoSlice};
 use std::marker::Unpin;
 use std::mem::MaybeUninit;
 #[cfg(all(feature = "server", feature = "runtime"))]
-use std::future::Future;
-#[cfg(all(feature = "server", feature = "runtime"))]
 use std::time::Duration;
 
-#[cfg(all(feature = "server", feature = "runtime"))]
-use tokio::time::Instant;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+#[cfg(all(feature = "server", feature = "runtime"))]
+use tokio::time::Instant;
 use tracing::{debug, trace};
 
 use super::{Http1Transaction, ParseContext, ParsedMessage};
@@ -194,6 +194,8 @@ where
                     #[cfg(all(feature = "server", feature = "runtime"))]
                     h1_header_read_timeout_running: parse_ctx.h1_header_read_timeout_running,
                     preserve_header_case: parse_ctx.preserve_header_case,
+                    #[cfg(feature = "ffi")]
+                    preserve_header_order: parse_ctx.preserve_header_order,
                     h09_responses: parse_ctx.h09_responses,
                     #[cfg(feature = "ffi")]
                     on_informational: parse_ctx.on_informational,
@@ -208,9 +210,13 @@ where
                     {
                         *parse_ctx.h1_header_read_timeout_running = false;
 
-                        if let Some(h1_header_read_timeout_fut) = parse_ctx.h1_header_read_timeout_fut {
+                        if let Some(h1_header_read_timeout_fut) =
+                            parse_ctx.h1_header_read_timeout_fut
+                        {
                             // Reset the timer in order to avoid woken up when the timeout finishes
-                            h1_header_read_timeout_fut.as_mut().reset(Instant::now() + Duration::from_secs(30 * 24 * 60 * 60));
+                            h1_header_read_timeout_fut
+                                .as_mut()
+                                .reset(Instant::now() + Duration::from_secs(30 * 24 * 60 * 60));
                         }
                     }
                     return Poll::Ready(Ok(msg));
@@ -224,12 +230,14 @@ where
 
                     #[cfg(all(feature = "server", feature = "runtime"))]
                     if *parse_ctx.h1_header_read_timeout_running {
-                        if let Some(h1_header_read_timeout_fut) = parse_ctx.h1_header_read_timeout_fut {
-                            if Pin::new( h1_header_read_timeout_fut).poll(cx).is_ready() {
+                        if let Some(h1_header_read_timeout_fut) =
+                            parse_ctx.h1_header_read_timeout_fut
+                        {
+                            if Pin::new(h1_header_read_timeout_fut).poll(cx).is_ready() {
                                 *parse_ctx.h1_header_read_timeout_running = false;
 
                                 tracing::warn!("read header from client timeout");
-                                return Poll::Ready(Err(crate::Error::new_header_timeout()))
+                                return Poll::Ready(Err(crate::Error::new_header_timeout()));
                             }
                         }
                     }
@@ -731,6 +739,8 @@ mod tests {
                 h1_header_read_timeout_fut: &mut None,
                 h1_header_read_timeout_running: &mut false,
                 preserve_header_case: false,
+                #[cfg(feature = "ffi")]
+                preserve_header_order: false,
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
                 on_informational: &mut None,
@@ -894,9 +904,7 @@ mod tests {
     async fn write_buf_flatten() {
         let _ = pretty_env_logger::try_init();
 
-        let mock = Mock::new()
-            .write(b"hello world, it's hyper!")
-            .build();
+        let mock = Mock::new().write(b"hello world, it's hyper!").build();
 
         let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(mock);
         buffered.write_buf.set_strategy(WriteStrategy::Flatten);

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use self::conn::Conn;
 pub(crate) use self::decode::Decoder;
 pub(crate) use self::dispatch::Dispatcher;
 pub(crate) use self::encode::{EncodedBuf, Encoder};
- //TODO: move out of h1::io
+//TODO: move out of h1::io
 pub(crate) use self::io::MINIMUM_MAX_BUFFER_SIZE;
 
 mod conn;
@@ -23,7 +23,6 @@ pub(crate) mod dispatch;
 mod encode;
 mod io;
 mod role;
-
 
 cfg_client! {
     pub(crate) type ClientTransaction = role::Client;
@@ -84,6 +83,8 @@ pub(crate) struct ParseContext<'a> {
     #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout_running: &'a mut bool,
     preserve_header_case: bool,
+    #[cfg(feature = "ffi")]
+    preserve_header_order: bool,
     h09_responses: bool,
     #[cfg(feature = "ffi")]
     on_informational: &'a mut Option<crate::ffi::OnInformational>,

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -16,7 +16,9 @@ use crate::body::DecodedLength;
 #[cfg(feature = "server")]
 use crate::common::date;
 use crate::error::Parse;
-use crate::ext::{HeaderCaseMap, OriginalHeaderOrder};
+use crate::ext::HeaderCaseMap;
+#[cfg(feature = "ffi")]
+use crate::ext::OriginalHeaderOrder;
 use crate::headers;
 use crate::proto::h1::{
     Encode, Encoder, Http1Transaction, ParseContext, ParseResult, ParsedMessage,
@@ -316,6 +318,7 @@ impl Http1Transaction for Server {
             extensions.insert(header_case_map);
         }
 
+        #[cfg(feature = "ffi")]
         if let Some(header_order) = header_order {
             extensions.insert(header_order);
         }
@@ -1043,6 +1046,7 @@ impl Http1Transaction for Client {
                 extensions.insert(header_case_map);
             }
 
+            #[cfg(feature = "ffi")]
             if let Some(header_order) = header_order {
                 extensions.insert(header_order);
             }


### PR DESCRIPTION
Libcurl expects that headers are iterated in the same order that they
are recieved. Previously this caused curl tests 580 and 581 to fail.

SUMMARY OF CHANGES: Add a new data structure to HeaderCaseMap that
represents the order in which headers originally appear in a HTTP
message. This datastructure is `Vec<(Headername, multimap-index)>`.
This vector is ordered by the order which headers were recieved.
This new datastucture is used in hyper_headers_foreach to iterate
through headers in the correct order.

CLOSES ISSUE: #2780
BEAKING CHANGE: HeaderCaseMap::append now requires that names passed
into it impl Into<HeaderName> + Clone. Currently all types that impl
IntoHeaderName (in hyper and http) also impl these traits already.

