### PR TITLE
Refactor(capi): make early returns consistent in C examples

### DIFF
--- a/capi/examples/client.c
+++ b/capi/examples/client.c
@@ -96,9 +96,9 @@ static int connect_to(const char *host, const char *port) {
 
         if (connect(sfd, rp->ai_addr, rp->ai_addrlen) != -1) {
             break;
-        } else {
-            close(sfd);
         }
+
+        close(sfd);
     }
 
     freeaddrinfo(result);

--- a/capi/examples/client.c
+++ b/capi/examples/client.c
@@ -24,22 +24,21 @@ static size_t read_cb(void *userdata, hyper_context *ctx, uint8_t *buf, size_t b
     struct conn_data *conn = (struct conn_data *)userdata;
     ssize_t ret = read(conn->fd, buf, buf_len);
 
-    if (ret < 0) {
-        int err = errno;
-        if (err == EAGAIN) {
-            // would block, register interest
-            if (conn->read_waker != NULL) {
-                hyper_waker_free(conn->read_waker);
-            }
-            conn->read_waker = hyper_context_waker(ctx);
-            return HYPER_IO_PENDING;
-        } else {
-            // kaboom
-            return HYPER_IO_ERROR;
-        }
-    } else {
+    if (ret >= 0) {
         return ret;
     }
+
+    if (errno != EAGAIN) {
+        // kaboom
+        return HYPER_IO_ERROR;
+    }
+
+    // would block, register interest
+    if (conn->read_waker != NULL) {
+        hyper_waker_free(conn->read_waker);
+    }
+    conn->read_waker = hyper_context_waker(ctx);
+    return HYPER_IO_PENDING;
 }
 
 static size_t write_cb(void *userdata, hyper_context *ctx, const uint8_t *buf, size_t buf_len) {

--- a/capi/examples/client.c
+++ b/capi/examples/client.c
@@ -312,15 +312,16 @@ int main(int argc, char *argv[]) {
         if (sel_ret < 0) {
             printf("select() error\n");
             return 1;
-        } else {
-            if (FD_ISSET(conn->fd, &fds_read)) {
-                hyper_waker_wake(conn->read_waker);
-                conn->read_waker = NULL;
-            }
-            if (FD_ISSET(conn->fd, &fds_write)) {
-                hyper_waker_wake(conn->write_waker);
-                conn->write_waker = NULL;
-            }
+        }
+
+        if (FD_ISSET(conn->fd, &fds_read)) {
+            hyper_waker_wake(conn->read_waker);
+            conn->read_waker = NULL;
+        }
+
+        if (FD_ISSET(conn->fd, &fds_write)) {
+            hyper_waker_wake(conn->write_waker);
+            conn->write_waker = NULL;
         }
 
     }

--- a/capi/examples/client.c
+++ b/capi/examples/client.c
@@ -140,17 +140,17 @@ typedef enum {
 #define STR_ARG(XX) (uint8_t *)XX, strlen(XX)
 
 int main(int argc, char *argv[]) {
-        const char *host = argc > 1 ? argv[1] : "httpbin.org";
-        const char *port = argc > 2 ? argv[2] : "80";
-        const char *path = argc > 3 ? argv[3] : "/";
-        printf("connecting to port %s on %s...\n", port, host);
+    const char *host = argc > 1 ? argv[1] : "httpbin.org";
+    const char *port = argc > 2 ? argv[2] : "80";
+    const char *path = argc > 3 ? argv[3] : "/";
+    printf("connecting to port %s on %s...\n", port, host);
 
-        int fd = connect_to(host, port);
+    int fd = connect_to(host, port);
     if (fd < 0) {
         return 1;
     }
-        printf("connected to %s, now get %s\n", host, path);
 
+    printf("connected to %s, now get %s\n", host, path);
     if (fcntl(fd, F_SETFL, O_NONBLOCK) != 0) {
         printf("failed to set socket to non-blocking\n");
         return 1;
@@ -165,7 +165,6 @@ int main(int argc, char *argv[]) {
     conn->fd = fd;
     conn->read_waker = NULL;
     conn->write_waker = NULL;
-
 
     // Hookup the IO
     hyper_io *io = hyper_io_new();

--- a/capi/examples/upload.c
+++ b/capi/examples/upload.c
@@ -385,17 +385,17 @@ int main(int argc, char *argv[]) {
         if (sel_ret < 0) {
             printf("select() error\n");
             return 1;
-        } else {
-            if (FD_ISSET(conn->fd, &fds_read)) {
-                hyper_waker_wake(conn->read_waker);
-                conn->read_waker = NULL;
-            }
-            if (FD_ISSET(conn->fd, &fds_write)) {
-                hyper_waker_wake(conn->write_waker);
-                conn->write_waker = NULL;
-            }
         }
 
+        if (FD_ISSET(conn->fd, &fds_read)) {
+            hyper_waker_wake(conn->read_waker);
+            conn->read_waker = NULL;
+        }
+
+        if (FD_ISSET(conn->fd, &fds_write)) {
+            hyper_waker_wake(conn->write_waker);
+            conn->write_waker = NULL;
+        }
     }
 
 

--- a/capi/examples/upload.c
+++ b/capi/examples/upload.c
@@ -96,9 +96,9 @@ static int connect_to(const char *host, const char *port) {
 
         if (connect(sfd, rp->ai_addr, rp->ai_addrlen) != -1) {
             break;
-        } else {
-            close(sfd);
         }
+
+        close(sfd);
     }
 
     freeaddrinfo(result);

--- a/capi/examples/upload.c
+++ b/capi/examples/upload.c
@@ -124,17 +124,20 @@ static int poll_req_upload(void *userdata,
     struct upload_body* upload = userdata;
 
     ssize_t res = read(upload->fd, upload->buf, upload->len);
-    if (res < 0) {
-        printf("error reading upload file: %d", errno);
-        return HYPER_POLL_ERROR;
-    } else if (res == 0) {
-        // All done!
-        *chunk = NULL;
-        return HYPER_POLL_READY;
-    } else {
+    if (res > 0) {
         *chunk = hyper_buf_copy(upload->buf, res);
         return HYPER_POLL_READY;
     }
+
+    if (res == 0) {
+        // All done!
+        *chunk = NULL;
+        return HYPER_POLL_READY;
+    }
+
+    // Oh no!
+    printf("error reading upload file: %d", errno);
+    return HYPER_POLL_ERROR;
 }
 
 static int print_each_header(void *userdata,

--- a/capi/examples/upload.c
+++ b/capi/examples/upload.c
@@ -349,20 +349,20 @@ int main(int argc, char *argv[]) {
                     hyper_executor_push(exec, body_data);
 
                     break;
-                } else {
-                    assert(task_type == HYPER_TASK_EMPTY);
-                    hyper_task_free(task);
-                    hyper_body_free(resp_body);
-
-                    printf("\n -- Done! -- \n");
-
-                    // Cleaning up before exiting
-                    hyper_executor_free(exec);
-                    free_conn_data(conn);
-                    free(upload.buf);
-
-                    return 0;
                 }
+
+                assert(task_type == HYPER_TASK_EMPTY);
+                hyper_task_free(task);
+                hyper_body_free(resp_body);
+
+                printf("\n -- Done! -- \n");
+
+                // Cleaning up before exiting
+                hyper_executor_free(exec);
+                free_conn_data(conn);
+                free(upload.buf);
+
+                return 0;
             case EXAMPLE_NOT_SET:
                 // A background task for hyper completed...
                 hyper_task_free(task);

--- a/capi/examples/upload.c
+++ b/capi/examples/upload.c
@@ -24,22 +24,21 @@ static size_t read_cb(void *userdata, hyper_context *ctx, uint8_t *buf, size_t b
     struct conn_data *conn = (struct conn_data *)userdata;
     ssize_t ret = read(conn->fd, buf, buf_len);
 
-    if (ret < 0) {
-        int err = errno;
-        if (err == EAGAIN) {
-            // would block, register interest
-            if (conn->read_waker != NULL) {
-                hyper_waker_free(conn->read_waker);
-            }
-            conn->read_waker = hyper_context_waker(ctx);
-            return HYPER_IO_PENDING;
-        } else {
-            // kaboom
-            return HYPER_IO_ERROR;
-        }
-    } else {
+    if (ret >= 0) {
         return ret;
     }
+
+    if (errno != EAGAIN) {
+        // kaboom
+        return HYPER_IO_ERROR;
+    }
+
+    // would block, register interest
+    if (conn->read_waker != NULL) {
+        hyper_waker_free(conn->read_waker);
+    }
+    conn->read_waker = hyper_context_waker(ctx);
+    return HYPER_IO_PENDING;
 }
 
 static size_t write_cb(void *userdata, hyper_context *ctx, const uint8_t *buf, size_t buf_len) {


### PR DESCRIPTION
Hello there! I saw the blog posts regarding this project's campaign for 1.0. 🥳

I figured I could help out with the C examples by making the code style regarding early returns more consistent. I found that (prior to this PR) the examples tended to mix between coding styles. On a personal note, I much prefer reading code with early returns anyway since there are less indentations/nested braces to worry about. 😅

So with that said, this PR simply refactors instances of nested error-handling logic as early returns. The result is more "linear" code with less indentations. Hooray!

To help make the review easier, I have also separated the commits into the specific decisions I took while refactoring. Hope this helps out a little bit with the documentation for the C API. Thanks!