### PR TITLE
fix(examples): don't send authority in tower

### DIFF
--- a/examples/tower_client.rs
+++ b/examples/tower_client.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let body = Body::empty();
 
-    let req = Request::get(uri).body(body)?;
+    let req = Request::get(uri.path_and_query().unwrap().to_string()).body(body)?;
     let res = svc.call(req).await?;
 
     println!("RESPONSE={:?}", res);


### PR DESCRIPTION
Sending the authority in the request of this example might be confusing
for new users, since this kind of requests are for proxy not for regular
clients.

