### PR TITLE
feat(connect): network interface binding with bind_local_device

### DIFF
--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -581,7 +581,11 @@ fn bind_local_address(
     local_addr_ipv6: &Option<Ipv6Addr>,
 ) -> io::Result<()> {
     match (*dst_addr, local_addr_ipv4, local_addr_ipv6) {
-        (SocketAddr::V4(_), Some(addr), _) => {
+        (SocketAddr::V4(_), Some(addr), None) => {
+            socket.bind(&SocketAddr::new(addr.clone().into(), 0).into())?;
+        }
+        (SocketAddr::V4(_), None, Some(addr)) => {
+            // Connection from IPv6 local to IPv4 remote
             socket.bind(&SocketAddr::new(addr.clone().into(), 0).into())?;
         }
         (SocketAddr::V6(_), _, Some(addr)) => {


### PR DESCRIPTION
This PR adds interface/device binding just like in curl:
```bash
$ curl --interface wlan0 'https://api.ipify.org'
1.2.3.4
```

It's needed, because sometimes binding to local IP just doesn't work (for example raspberry pi wlan0).
Also, when DHCP IP changes, the program would have to update local IPv4 and IPv6.
Solution to that is binding to an interface name, which does not change.

Also, I've added a small fix for IPv6 which was found a few months ago - it was annoying to debug on an IPv6 machine.
Unfortunatelly, [536b3a8](https://github.com/hyperium/hyper/commit/536b3a87aa84d0577d2223b2ad64bc22571ec2a9) wasn't tested.