### PR TITLE
Remove unsafe from proto::h2

### DIFF
--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -341,7 +341,7 @@ where
                                 let (pending, on_upgrade) = crate::upgrade::pending();
                                 let io = H2Upgraded {
                                     ping,
-                                    send_stream: unsafe { UpgradedSendStream::new(send_stream) },
+                                    send_stream: UpgradedSendStream::new(send_stream),
                                     recv_stream,
                                     buf: Bytes::new(),
                                 };

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -433,7 +433,7 @@ impl<F, B, E> H2Stream<F, B>
 where
     F: Future<Output = Result<Response<B>, E>>,
     B: HttpBody,
-    B::Data: 'static,
+    B::Data: Send + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
     E: Into<Box<dyn StdError + Send + Sync>>,
 {
@@ -489,7 +489,7 @@ where
                                 H2Upgraded {
                                     ping: connect_parts.ping,
                                     recv_stream: connect_parts.recv_stream,
-                                    send_stream: unsafe { UpgradedSendStream::new(send_stream) },
+                                    send_stream: UpgradedSendStream::new(send_stream),
                                     buf: Bytes::new(),
                                 },
                                 Bytes::new(),
@@ -527,7 +527,7 @@ impl<F, B, E> Future for H2Stream<F, B>
 where
     F: Future<Output = Result<Response<B>, E>>,
     B: HttpBody,
-    B::Data: 'static,
+    B::Data: Send + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
     E: Into<Box<dyn StdError + Send + Sync>>,
 {


### PR DESCRIPTION
Back in #2523, @nox introduced the notion of an UpgradedSendStream, to support the CONNECT method of HTTP/2. This used `unsafe {}` to support `http_body::Body`, where `Body::Data` did not implement `Send`, since the `Data` type wouldn't be sent across the stream once upgraded.

Unfortunately, according to this [thread], I think this may be undefined behavior, because this relies on us requiring the transmute to execute.

This patch fixes the potential UB by adding the unncessary `Send` constraints. It appears that all the internal users of
`UpgradeSendStream` already work with `http_body::Body` types that have `Send`-able `Data` constraints. We can add this constraint without breaking any external APIs, which lets us remove the `unsafe {}` blocks.

I filed https://github.com/rust-lang/unsafe-code-guidelines/issues/337 for formal guidance on this pattern.

Fixes #2829

[thread]: https://users.rust-lang.org/t/is-a-reference-to-impossible-value-considered-ub/31383
