### PR TITLE
feat(client): add option to HttpConnector to enable or disable

### DIFF
--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -86,7 +86,7 @@ use ::http::Extensions;
 cfg_feature! {
     #![feature = "tcp"]
 
-    pub use self::http::{HttpConnector, HttpInfo};
+    pub use self::http::{HttpConnector, HttpInfo, HttpConnection};
 
     pub mod dns;
     mod http;

--- a/src/client/tests.rs
+++ b/src/client/tests.rs
@@ -1,9 +1,9 @@
 use std::io;
 
 use futures_util::future;
-use tokio::net::TcpStream;
 
 use super::Client;
+use super::connect::HttpConnection;
 
 #[tokio::test]
 async fn client_connect_uri_argument() {
@@ -13,7 +13,7 @@ async fn client_connect_uri_argument() {
         assert_eq!(dst.port(), None);
         assert_eq!(dst.path(), "/", "path should be removed");
 
-        future::err::<TcpStream, _>(io::Error::new(io::ErrorKind::Other, "expect me"))
+        future::err::<HttpConnection, _>(io::Error::new(io::ErrorKind::Other, "expect me"))
     });
 
     let client = Client::builder().build::<_, crate::Body>(connector);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1120,11 +1120,10 @@ mod dispatch_impl {
     use futures_util::stream::StreamExt;
     use http::Uri;
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-    use tokio::net::TcpStream;
 
     use super::support;
     use hyper::body::HttpBody;
-    use hyper::client::connect::{Connected, Connection, HttpConnector};
+    use hyper::client::connect::{Connected, Connection, HttpConnection, HttpConnector};
     use hyper::Client;
 
     #[test]
@@ -2090,7 +2089,7 @@ mod dispatch_impl {
     }
 
     struct DebugStream {
-        tcp: TcpStream,
+        tcp: HttpConnection,
         on_drop: mpsc::Sender<()>,
         is_alpn_h2: bool,
         is_proxy: bool,


### PR DESCRIPTION
This adds `http_info` configuration option in `http::Config`. It can be used to enable or disable `HttpInfo`. 

`HttpInfo` is set through methods defined on `TcpStream` (`peer_addr()` and `local_addr()`). Configuration options have to be made available to `TcpStream` in order to enforce `http_info`. `HttpConnection` is added to achieve this.
 
Fixes #2833

Ps: Rust and oss newbie so apologies if I missed some obvious issue 😅