### PR TITLE
feat(server): remove addrstream struct

### DIFF
--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -81,9 +81,6 @@ cfg_feature! {
     pub(super) use self::upgrades::UpgradeableConnection;
 }
 
-#[cfg(feature = "tcp")]
-pub use super::tcp::{AddrIncoming, AddrStream};
-
 /// A lower-level configuration of the HTTP protocol.
 ///
 /// This structure is used to configure options for an HTTP server connection.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -92,7 +92,7 @@
 //! use hyper::{Body, Request, Response, Server};
 //! use hyper::service::{make_service_fn, service_fn};
 //! # #[cfg(feature = "runtime")]
-//! use hyper::server::conn::AddrStream;
+//! use tokio::net::TcpStream;
 //!
 //! #[derive(Clone)]
 //! struct AppContext {
@@ -115,14 +115,14 @@
 //!     };
 //!
 //!     // A `MakeService` that produces a `Service` to handle each connection.
-//!     let make_service = make_service_fn(move |conn: &AddrStream| {
+//!     let make_service = make_service_fn(move |conn: &TcpStream| {
 //!         // We have to clone the context to share it with each invocation of
 //!         // `make_service`. If your data doesn't implement `Clone` consider using
 //!         // an `std::sync::Arc`.
 //!         let context = context.clone();
 //!
 //!         // You can grab the address of the incoming connection like so.
-//!         let addr = conn.remote_addr();
+//!         let addr = conn.peer_addr().unwrap();
 //!
 //!         // Create a `Service` for responding to the request.
 //!         let service = service_fn(move |req| {

--- a/src/service/make.rs
+++ b/src/service/make.rs
@@ -108,13 +108,13 @@ where
 /// # async fn run() {
 /// use std::convert::Infallible;
 /// use hyper::{Body, Request, Response, Server};
-/// use hyper::server::conn::AddrStream;
+/// use tokio::net::TcpStream;
 /// use hyper::service::{make_service_fn, service_fn};
 ///
 /// let addr = ([127, 0, 0, 1], 3000).into();
 ///
-/// let make_svc = make_service_fn(|socket: &AddrStream| {
-///     let remote_addr = socket.remote_addr();
+/// let make_svc = make_service_fn(|socket: &TcpStream| {
+///     let remote_addr = socket.peer_addr().unwrap();
 ///     async move {
 ///         Ok::<_, Infallible>(service_fn(move |_: Request<Body>| async move {
 ///             Ok::<_, Infallible>(


### PR DESCRIPTION
Remove `AddrStream` type, it provides no benefit over `tokio::net::TcpStream`.

Closes issue #2850

This is my first contribution to this project, so I may have missed something. I am happy to take any feedback. Thanks!

### Notes
- I'm not quite sure if my changes to `AddrIncoming.poll_next_` method are correct, or if that method is actually used anywhere.
- `AddrStream` is used in documentation related to `make_service`, but as I understand it, `make_service` will be removed anyway in a different PR. Ref issue #2854