### PR TITLE
refactor(lib): resolve unused import

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,6 +1,7 @@
 //! HTTP extensions.
 
 use bytes::Bytes;
+#[cfg(any(feature = "http1", feature = "ffi"))]
 use http::header::HeaderName;
 #[cfg(feature = "http1")]
 use http::header::{IntoHeaderName, ValueIter};


### PR DESCRIPTION
running default build command
```rust
cargo build
```
reports
```bash
warning: unused import: `http::header::HeaderName`
 --> src/ext.rs:4:5
  |
4 | use http::header::HeaderName;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```