### PR TITLE
Remove stream cargo feature

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Test
         # Can't enable tcp feature since Miri does not support the tokio runtime
-        run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test --features http1,http2,client,server,stream,nightly
+        run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test --features http1,http2,client,server,nightly
 
   features:
     name: features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ futures-core = { version = "0.3", default-features = false }
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 http = "0.2"
-http-body = "0.4"
+http-body = { git = "https://github.com/hyperium/http-body", branch = "master" }
+http-body-util = { git = "https://github.com/hyperium/http-body", branch = "master" }
 httpdate = "1.0"
 httparse = "1.6"
 h2 = { version = "0.3.9", optional = true }
@@ -80,7 +81,6 @@ full = [
     "http1",
     "http2",
     "server",
-    "stream",
     "runtime",
 ]
 
@@ -91,9 +91,6 @@ http2 = ["h2"]
 # Client/Server
 client = []
 server = []
-
-# `impl Stream` for things
-stream = []
 
 # Tokio support
 runtime = [

--- a/benches/body.rs
+++ b/benches/body.rs
@@ -6,7 +6,7 @@ extern crate test;
 use bytes::Buf;
 use futures_util::stream;
 use futures_util::StreamExt;
-use hyper::body::Body;
+use http_body_util::StreamBody;
 
 macro_rules! bench_stream {
     ($bencher:ident, bytes: $bytes:expr, count: $count:expr, $total_ident:ident, $body_pat:pat, $block:expr) => {{
@@ -20,9 +20,10 @@ macro_rules! bench_stream {
 
         $bencher.iter(|| {
             rt.block_on(async {
-                let $body_pat = Body::wrap_stream(
+                let $body_pat = StreamBody::new(
                     stream::iter(__s.iter()).map(|&s| Ok::<_, std::convert::Infallible>(s)),
                 );
+
                 $block;
             });
         });

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -9,10 +9,11 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use futures_util::{stream, StreamExt};
+use http_body_util::StreamBody;
 use tokio::sync::oneshot;
 
 use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Response, Server};
+use hyper::{Response, Server};
 
 macro_rules! bench_server {
     ($b:ident, $header:expr, $body:expr) => {{
@@ -101,7 +102,7 @@ fn throughput_fixedsize_large_payload(b: &mut test::Bencher) {
 fn throughput_fixedsize_many_chunks(b: &mut test::Bencher) {
     bench_server!(b, ("content-length", "1000000"), || {
         static S: &[&[u8]] = &[&[b'x'; 1_000] as &[u8]; 1_000] as _;
-        Body::wrap_stream(stream::iter(S.iter()).map(|&s| Ok::<_, String>(s)))
+        StreamBody::new(stream::iter(S.iter()).map(|&s| Ok::<_, String>(s)))
     })
 }
 
@@ -123,7 +124,7 @@ fn throughput_chunked_large_payload(b: &mut test::Bencher) {
 fn throughput_chunked_many_chunks(b: &mut test::Bencher) {
     bench_server!(b, ("transfer-encoding", "chunked"), || {
         static S: &[&[u8]] = &[&[b'x'; 1_000] as &[u8]; 1_000] as _;
-        Body::wrap_stream(stream::iter(S.iter()).map(|&s| Ok::<_, String>(s)))
+        StreamBody::new(stream::iter(S.iter()).map(|&s| Ok::<_, String>(s)))
     })
 }
 

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,6 +1,5 @@
 #![deny(warnings)]
 
-use futures_util::TryStreamExt;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 
@@ -16,16 +15,17 @@ async fn echo(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
         // Simply echo the body back to the client.
         (&Method::POST, "/echo") => Ok(Response::new(req.into_body())),
 
+        // TODO: Fix this, broken in PR #2896
         // Convert to uppercase before sending back to client using a stream.
-        (&Method::POST, "/echo/uppercase") => {
-            let chunk_stream = req.into_body().map_ok(|chunk| {
-                chunk
-                    .iter()
-                    .map(|byte| byte.to_ascii_uppercase())
-                    .collect::<Vec<u8>>()
-            });
-            Ok(Response::new(Body::wrap_stream(chunk_stream)))
-        }
+        // (&Method::POST, "/echo/uppercase") => {
+        // let chunk_stream = req.into_body().map_ok(|chunk| {
+        //     chunk
+        //         .iter()
+        //         .map(|byte| byte.to_ascii_uppercase())
+        //         .collect::<Vec<u8>>()
+        // });
+        // Ok(Response::new(Body::wrap_stream(chunk_stream)))
+        // }
 
         // Reverse the entire body before sending back to the client.
         //

--- a/examples/send_file.rs
+++ b/examples/send_file.rs
@@ -1,9 +1,5 @@
 #![deny(warnings)]
 
-use tokio::fs::File;
-
-use tokio_util::codec::{BytesCodec, FramedRead};
-
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Result, Server, StatusCode};
 
@@ -48,11 +44,8 @@ fn not_found() -> Response<Body> {
 }
 
 async fn simple_file_send(filename: &str) -> Result<Response<Body>> {
-    // Serve a file by asynchronously reading it by chunks using tokio-util crate.
-
-    if let Ok(file) = File::open(filename).await {
-        let stream = FramedRead::new(file, BytesCodec::new());
-        let body = Body::wrap_stream(stream);
+    if let Ok(contents) = tokio::fs::read(filename).await {
+        let body = contents.into();
         return Ok(Response::new(body));
     }
 

--- a/examples/web_api.rs
+++ b/examples/web_api.rs
@@ -1,7 +1,6 @@
 #![deny(warnings)]
 
 use bytes::Buf;
-use futures_util::{stream, StreamExt};
 use hyper::client::HttpConnector;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{header, Body, Client, Method, Request, Response, Server, StatusCode};
@@ -24,18 +23,10 @@ async fn client_request_response(client: &Client<HttpConnector>) -> Result<Respo
         .unwrap();
 
     let web_res = client.request(req).await?;
-    // Compare the JSON we sent (before) with what we received (after):
-    let before = stream::once(async {
-        Ok(format!(
-            "<b>POST request body</b>: {}<br><b>Response</b>: ",
-            POST_DATA,
-        )
-        .into())
-    });
-    let after = web_res.into_body();
-    let body = Body::wrap_stream(before.chain(after));
 
-    Ok(Response::new(body))
+    let res_body = web_res.into_body();
+
+    Ok(Response::new(res_body))
 }
 
 async fn api_post_response(req: Request<Body>) -> Result<Response<Body>> {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -18,10 +18,7 @@ pub(crate) mod io;
 #[cfg(all(feature = "client", any(feature = "http1", feature = "http2")))]
 mod lazy;
 mod never;
-#[cfg(any(
-    feature = "stream",
-    all(feature = "client", any(feature = "http1", feature = "http2"))
-))]
+#[cfg(all(feature = "client", any(feature = "http1", feature = "http2")))]
 pub(crate) mod sync_wrapper;
 pub(crate) mod task;
 pub(crate) mod watch;

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,7 +48,7 @@ pub(super) enum Kind {
     #[cfg(all(feature = "http1", feature = "server", feature = "runtime"))]
     HeaderTimeout,
     /// Error while reading a body from connection.
-    #[cfg(any(feature = "http1", feature = "http2", feature = "stream"))]
+    #[cfg(any(feature = "http1", feature = "http2"))]
     Body,
     /// Error while writing a body to connection.
     #[cfg(any(feature = "http1", feature = "http2"))]
@@ -294,7 +294,7 @@ impl Error {
         Error::new(Kind::ChannelClosed)
     }
 
-    #[cfg(any(feature = "http1", feature = "http2", feature = "stream"))]
+    #[cfg(any(feature = "http1", feature = "http2"))]
     pub(super) fn new_body<E: Into<Cause>>(cause: E) -> Error {
         Error::new(Kind::Body).with(cause)
     }
@@ -440,7 +440,7 @@ impl Error {
             Kind::Accept => "error accepting connection",
             #[cfg(all(feature = "http1", feature = "server", feature = "runtime"))]
             Kind::HeaderTimeout => "read header from client timeout",
-            #[cfg(any(feature = "http1", feature = "http2", feature = "stream"))]
+            #[cfg(any(feature = "http1", feature = "http2"))]
             Kind::Body => "error reading a body from connection",
             #[cfg(any(feature = "http1", feature = "http2"))]
             Kind::BodyWrite => "error writing a body to connection",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,6 @@
 //! - `runtime`: Enables convenient integration with `tokio`, providing
 //!   connectors and acceptors for TCP, and a default executor.
 //! - `tcp`: Enables convenient implementations over TCP (using tokio).
-//! - `stream`: Provides `futures::Stream` capabilities.
 //!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 

--- a/src/server/accept.rs
+++ b/src/server/accept.rs
@@ -6,11 +6,6 @@
 //!   connections.
 //! - Utilities like `poll_fn` to ease creating a custom `Accept`.
 
-#[cfg(feature = "stream")]
-use futures_core::Stream;
-#[cfg(feature = "stream")]
-use pin_project_lite::pin_project;
-
 use crate::common::{
     task::{self, Poll},
     Pin,
@@ -73,39 +68,4 @@ where
     }
 
     PollFn(func)
-}
-
-/// Adapt a `Stream` of incoming connections into an `Accept`.
-///
-/// # Optional
-///
-/// This function requires enabling the `stream` feature in your
-/// `Cargo.toml`.
-#[cfg(feature = "stream")]
-pub fn from_stream<S, IO, E>(stream: S) -> impl Accept<Conn = IO, Error = E>
-where
-    S: Stream<Item = Result<IO, E>>,
-{
-    pin_project! {
-        struct FromStream<S> {
-            #[pin]
-            stream: S,
-        }
-    }
-
-    impl<S, IO, E> Accept for FromStream<S>
-    where
-        S: Stream<Item = Result<IO, E>>,
-    {
-        type Conn = IO;
-        type Error = E;
-        fn poll_accept(
-            self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
-        ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
-            self.project().stream.poll_next(cx)
-        }
-    }
-
-    FromStream { stream }
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -457,92 +457,95 @@ test! {
             body: &b"hello"[..],
 }
 
-test! {
-    name: client_get_req_body_sized,
+// TODO: Fix this, broken in PR #2896
+// test! {
+//     name: client_get_req_body_sized,
 
-    server:
-        expected: "\
-            GET / HTTP/1.1\r\n\
-            content-length: 5\r\n\
-            host: {addr}\r\n\
-            \r\n\
-            hello\
-            ",
-        reply: REPLY_OK,
+//     server:
+//         expected: "\
+//             GET / HTTP/1.1\r\n\
+//             content-length: 5\r\n\
+//             host: {addr}\r\n\
+//             \r\n\
+//             hello\
+//             ",
+//         reply: REPLY_OK,
 
-    client:
-        request: {
-            method: GET,
-            url: "http://{addr}/",
-            headers: {
-                "Content-Length" => "5",
-            },
-            body: (Body::wrap_stream(Body::from("hello"))),
-        },
-        response:
-            status: OK,
-            headers: {},
-            body: None,
-}
+//     client:
+//         request: {
+//             method: GET,
+//             url: "http://{addr}/",
+//             headers: {
+//                 "Content-Length" => "5",
+//             },
+//             body: (Body::wrap_stream(Body::from("hello"))),
+//         },
+//         response:
+//             status: OK,
+//             headers: {},
+//             body: None,
+// }
 
-test! {
-    name: client_get_req_body_unknown,
+// TODO: Fix this, broken in PR #2896
+// test! {
+//     name: client_get_req_body_unknown,
 
-    server:
-        expected: "\
-            GET / HTTP/1.1\r\n\
-            host: {addr}\r\n\
-            \r\n\
-            ",
-        reply: REPLY_OK,
+//     server:
+//         expected: "\
+//             GET / HTTP/1.1\r\n\
+//             host: {addr}\r\n\
+//             \r\n\
+//             ",
+//         reply: REPLY_OK,
 
-    client:
-        request: {
-            method: GET,
-            url: "http://{addr}/",
-            // wrap_steam means we don't know the content-length,
-            // but we're wrapping a non-empty stream.
-            //
-            // But since the headers cannot tell us, and the method typically
-            // doesn't have a body, the body must be ignored.
-            body: (Body::wrap_stream(Body::from("hello"))),
-        },
-        response:
-            status: OK,
-            headers: {},
-            body: None,
-}
+//     client:
+//         request: {
+//             method: GET,
+//             url: "http://{addr}/",
+//             // wrap_steam means we don't know the content-length,
+//             // but we're wrapping a non-empty stream.
+//             //
+//             // But since the headers cannot tell us, and the method typically
+//             // doesn't have a body, the body must be ignored.
+//             body: (Body::from("hello")),
+//         },
+//         response:
+//             status: OK,
+//             headers: {},
+//             body: None,
+// }
 
-test! {
-    name: client_get_req_body_unknown_http10,
+// TODO: Fix this, broken in PR #2896
+// test! {
+//     name: client_get_req_body_unknown_http10,
 
-    server:
-        expected: "\
-            GET / HTTP/1.0\r\n\
-            host: {addr}\r\n\
-            \r\n\
-            ",
-        reply: "HTTP/1.0 200 OK\r\ncontent-length: 0\r\n\r\n",
+//     server:
+//         expected: "\
+//             GET / HTTP/1.0\r\n\
+//             host: {addr}\r\n\
+//             \r\n\
+//             ",
+//         reply: "HTTP/1.0 200 OK\r\ncontent-length: 0\r\n\r\n",
 
-    client:
-        request: {
-            method: GET,
-            url: "http://{addr}/",
-            headers: {
-                "transfer-encoding" => "chunked",
-            },
-            version: HTTP_10,
-            // wrap_steam means we don't know the content-length,
-            // but we're wrapping a non-empty stream.
-            //
-            // But since the headers cannot tell us, the body must be ignored.
-            body: (Body::wrap_stream(Body::from("hello"))),
-        },
-        response:
-            status: OK,
-            headers: {},
-            body: None,
-}
+//     client:
+//         request: {
+//             method: GET,
+//             url: "http://{addr}/",
+//             headers: {
+//                 "transfer-encoding" => "chunked",
+//             },
+//             version: HTTP_10,
+//             // wrap_steam means we don't know the content-length,
+//             // but we're wrapping a non-empty stream.
+//             //
+//             // But since the headers cannot tell us, the body must be ignored.
+//             body: (Body::from("hello")),
+//         },
+//         response:
+//             status: OK,
+//             headers: {},
+//             body: None,
+// }
 
 test! {
     name: client_post_sized,
@@ -602,32 +605,33 @@ test! {
             body: None,
 }
 
-test! {
-    name: client_post_unknown,
+// TODO: Fix this, broken in PR #2896
+// test! {
+//     name: client_post_unknown,
 
-    server:
-        expected: "\
-            POST /chunks HTTP/1.1\r\n\
-            host: {addr}\r\n\
-            transfer-encoding: chunked\r\n\
-            \r\n\
-            B\r\n\
-            foo bar baz\r\n\
-            0\r\n\r\n\
-            ",
-        reply: REPLY_OK,
+//     server:
+//         expected: "\
+//             POST /chunks HTTP/1.1\r\n\
+//             host: {addr}\r\n\
+//             transfer-encoding: chunked\r\n\
+//             \r\n\
+//             B\r\n\
+//             foo bar baz\r\n\
+//             0\r\n\r\n\
+//             ",
+//         reply: REPLY_OK,
 
-    client:
-        request: {
-            method: POST,
-            url: "http://{addr}/chunks",
-            body: (Body::wrap_stream(Body::from("foo bar baz"))),
-        },
-        response:
-            status: OK,
-            headers: {},
-            body: None,
-}
+//     client:
+//         request: {
+//             method: POST,
+//             url: "http://{addr}/chunks",
+//             body: (Body::from("foo bar baz")),
+//         },
+//         response:
+//             status: OK,
+//             headers: {},
+//             body: None,
+// }
 
 test! {
     name: client_post_empty,
@@ -1661,78 +1665,79 @@ mod dispatch_impl {
         assert_eq!(connects.load(Ordering::Relaxed), 2);
     }
 
-    #[test]
-    fn client_keep_alive_when_response_before_request_body_ends() {
-        let _ = pretty_env_logger::try_init();
-        let server = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = server.local_addr().unwrap();
-        let rt = support::runtime();
+    // TODO: Fix this, broken in PR #2896
+    // #[test]
+    // fn client_keep_alive_when_response_before_request_body_ends() {
+    //     let _ = pretty_env_logger::try_init();
+    //     let server = TcpListener::bind("127.0.0.1:0").unwrap();
+    //     let addr = server.local_addr().unwrap();
+    //     let rt = support::runtime();
 
-        let connector = DebugConnector::new();
-        let connects = connector.connects.clone();
+    //     let connector = DebugConnector::new();
+    //     let connects = connector.connects.clone();
 
-        let client = Client::builder().build(connector);
+    //     let client = Client::builder().build(connector);
 
-        let (tx1, rx1) = oneshot::channel();
-        let (tx2, rx2) = oneshot::channel();
-        let (tx3, rx3) = oneshot::channel();
-        thread::spawn(move || {
-            let mut sock = server.accept().unwrap().0;
-            sock.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
-            sock.set_write_timeout(Some(Duration::from_secs(5)))
-                .unwrap();
-            let mut buf = [0; 4096];
-            sock.read(&mut buf).expect("read 1");
-            sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
-                .expect("write 1");
-            // after writing the response, THEN stream the body
-            let _ = tx1.send(());
+    //     let (tx1, rx1) = oneshot::channel();
+    //     let (tx2, rx2) = oneshot::channel();
+    //     let (tx3, rx3) = oneshot::channel();
+    //     thread::spawn(move || {
+    //         let mut sock = server.accept().unwrap().0;
+    //         sock.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    //         sock.set_write_timeout(Some(Duration::from_secs(5)))
+    //             .unwrap();
+    //         let mut buf = [0; 4096];
+    //         sock.read(&mut buf).expect("read 1");
+    //         sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+    //             .expect("write 1");
+    //         // after writing the response, THEN stream the body
+    //         let _ = tx1.send(());
 
-            sock.read(&mut buf).expect("read 2");
-            let _ = tx2.send(());
+    //         sock.read(&mut buf).expect("read 2");
+    //         let _ = tx2.send(());
 
-            let n2 = sock.read(&mut buf).expect("read 3");
-            assert_ne!(n2, 0);
-            let second_get = "GET /b HTTP/1.1\r\n";
-            assert_eq!(s(&buf[..second_get.len()]), second_get);
-            sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
-                .expect("write 2");
-            let _ = tx3.send(());
-        });
+    //         let n2 = sock.read(&mut buf).expect("read 3");
+    //         assert_ne!(n2, 0);
+    //         let second_get = "GET /b HTTP/1.1\r\n";
+    //         assert_eq!(s(&buf[..second_get.len()]), second_get);
+    //         sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+    //             .expect("write 2");
+    //         let _ = tx3.send(());
+    //     });
 
-        assert_eq!(connects.load(Ordering::Relaxed), 0);
+    //     assert_eq!(connects.load(Ordering::Relaxed), 0);
 
-        let delayed_body = rx1
-            .then(|_| tokio::time::sleep(Duration::from_millis(200)))
-            .map(|_| Ok::<_, ()>("hello a"))
-            .map_err(|_| -> hyper::Error { panic!("rx1") })
-            .into_stream();
+    //     let delayed_body = rx1
+    //         .then(|_| tokio::time::sleep(Duration::from_millis(200)))
+    //         .map(|_| Ok::<_, ()>("hello a"))
+    //         .map_err(|_| -> hyper::Error { panic!("rx1") })
+    //         .into_stream();
 
-        let rx = rx2.expect("thread panicked");
-        let req = Request::builder()
-            .method("POST")
-            .uri(&*format!("http://{}/a", addr))
-            .body(Body::wrap_stream(delayed_body))
-            .unwrap();
-        let client2 = client.clone();
+    //     let rx = rx2.expect("thread panicked");
+    //     let req = Request::builder()
+    //         .method("POST")
+    //         .uri(&*format!("http://{}/a", addr))
+    //         .body(Body::wrap_stream(delayed_body))
+    //         .unwrap();
+    //     let client2 = client.clone();
 
-        // req 1
-        let fut = future::join(client.request(req), rx)
-            .then(|_| tokio::time::sleep(Duration::from_millis(200)))
-            // req 2
-            .then(move |()| {
-                let rx = rx3.expect("thread panicked");
-                let req = Request::builder()
-                    .uri(&*format!("http://{}/b", addr))
-                    .body(Body::empty())
-                    .unwrap();
-                future::join(client2.request(req), rx).map(|r| r.0)
-            });
+    //     // req 1
+    //     let fut = future::join(client.request(req), rx)
+    //         .then(|_| tokio::time::sleep(Duration::from_millis(200)))
+    //         // req 2
+    //         .then(move |()| {
+    //             let rx = rx3.expect("thread panicked");
+    //             let req = Request::builder()
+    //                 .uri(&*format!("http://{}/b", addr))
+    //                 .body(Body::empty())
+    //                 .unwrap();
+    //             future::join(client2.request(req), rx).map(|r| r.0)
+    //         });
 
-        rt.block_on(fut).unwrap();
+    //     rt.block_on(fut).unwrap();
 
-        assert_eq!(connects.load(Ordering::Relaxed), 1);
-    }
+    //     assert_eq!(connects.load(Ordering::Relaxed), 1);
+    // }
 
     #[tokio::test]
     async fn client_keep_alive_eager_when_chunked() {
@@ -2160,11 +2165,11 @@ mod conn {
     use bytes::Buf;
     use futures_channel::oneshot;
     use futures_util::future::{self, poll_fn, FutureExt, TryFutureExt};
-    use futures_util::StreamExt;
     use hyper::upgrade::OnUpgrade;
     use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _, ReadBuf};
     use tokio::net::{TcpListener as TkTcpListener, TcpStream};
 
+    use hyper::body::HttpBody;
     use hyper::client::conn;
     use hyper::{self, Body, Method, Request, Response, StatusCode};
 
@@ -2208,7 +2213,7 @@ mod conn {
                 .unwrap();
             let mut res = client.send_request(req).await.expect("send_request");
             assert_eq!(res.status(), hyper::StatusCode::OK);
-            assert!(res.body_mut().next().await.is_none());
+            assert!(res.body_mut().data().await.is_none());
         };
 
         future::join(server, client).await;
@@ -2265,7 +2270,7 @@ mod conn {
                 res.headers().get("line-folded-header").unwrap(),
                 "hello   world"
             );
-            assert!(res.body_mut().next().await.is_none());
+            assert!(res.body_mut().data().await.is_none());
         };
 
         future::join(server, client).await;
@@ -2321,7 +2326,7 @@ mod conn {
                 res.headers().get(http::header::CONTENT_LENGTH).unwrap(),
                 "0"
             );
-            assert!(res.body_mut().next().await.is_none());
+            assert!(res.body_mut().data().await.is_none());
         };
 
         future::join(server, client).await;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -17,8 +17,6 @@ use std::time::Duration;
 use bytes::Bytes;
 use futures_channel::oneshot;
 use futures_util::future::{self, Either, FutureExt, TryFutureExt};
-#[cfg(feature = "stream")]
-use futures_util::stream::StreamExt as _;
 use h2::client::SendRequest;
 use h2::{RecvStream, SendStream};
 use http::header::{HeaderName, HeaderValue};
@@ -1844,6 +1842,7 @@ async fn h2_connect() {
 #[tokio::test]
 async fn h2_connect_multiplex() {
     use futures_util::stream::FuturesUnordered;
+    use futures_util::StreamExt;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     let _ = pretty_env_logger::try_init();
@@ -2192,30 +2191,31 @@ async fn max_buf_size() {
         .expect_err("should TooLarge error");
 }
 
-#[cfg(feature = "stream")]
-#[test]
-fn streaming_body() {
-    let _ = pretty_env_logger::try_init();
+// TODO: Broken in PR #2896. Fix this if we don't have other tests to verify that the
+// HTTP/1 server dispatcher properly handles a streaming body
+// #[test]
+// fn streaming_body() {
+//     let _ = pretty_env_logger::try_init();
 
-    // disable keep-alive so we can use read_to_end
-    let server = serve_opts().keep_alive(false).serve();
+//     // disable keep-alive so we can use read_to_end
+//     let server = serve_opts().keep_alive(false).serve();
 
-    static S: &[&[u8]] = &[&[b'x'; 1_000] as &[u8]; 1_00] as _;
-    let b = futures_util::stream::iter(S.iter()).map(|&s| Ok::<_, hyper::Error>(s));
-    let b = hyper::Body::wrap_stream(b);
-    server.reply().body_stream(b);
+//     static S: &[&[u8]] = &[&[b'x'; 1_000] as &[u8]; 1_00] as _;
+//     let b = futures_util::stream::iter(S.iter()).map(|&s| Ok::<_, hyper::Error>(s));
+//     let b = hyper::Body::wrap_stream(b);
+//     server.reply().body_stream(b);
 
-    let mut tcp = connect(server.addr());
-    tcp.write_all(b"GET / HTTP/1.1\r\n\r\n").unwrap();
-    let mut buf = Vec::new();
-    tcp.read_to_end(&mut buf).expect("read 1");
+//     let mut tcp = connect(server.addr());
+//     tcp.write_all(b"GET / HTTP/1.1\r\n\r\n").unwrap();
+//     let mut buf = Vec::new();
+//     tcp.read_to_end(&mut buf).expect("read 1");
 
-    assert!(
-        buf.starts_with(b"HTTP/1.1 200 OK\r\n"),
-        "response is 200 OK"
-    );
-    assert_eq!(buf.len(), 100_789, "full streamed body read");
-}
+//     assert!(
+//         buf.starts_with(b"HTTP/1.1 200 OK\r\n"),
+//         "response is 200 OK"
+//     );
+//     assert_eq!(buf.len(), 100_789, "full streamed body read");
+// }
 
 #[test]
 fn http1_response_with_http2_version() {
@@ -2300,42 +2300,42 @@ async fn http2_service_error_sends_reset_reason() {
     assert_eq!(h2_err.reason(), Some(h2::Reason::INADEQUATE_SECURITY));
 }
 
-#[cfg(feature = "stream")]
-#[test]
-fn http2_body_user_error_sends_reset_reason() {
-    use std::error::Error;
-    let server = serve();
-    let addr_str = format!("http://{}", server.addr());
+// TODO: Fix this, broken in PR #2896
+// #[test]
+// fn http2_body_user_error_sends_reset_reason() {
+//     use std::error::Error;
+//     let server = serve();
+//     let addr_str = format!("http://{}", server.addr());
 
-    let b = futures_util::stream::once(future::err::<String, _>(h2::Error::from(
-        h2::Reason::INADEQUATE_SECURITY,
-    )));
-    let b = hyper::Body::wrap_stream(b);
+//     let b = futures_util::stream::once(future::err::<String, _>(h2::Error::from(
+//         h2::Reason::INADEQUATE_SECURITY,
+//     )));
+//     let b = hyper::Body::wrap_stream(b);
 
-    server.reply().body_stream(b);
+//     server.reply().body_stream(b);
 
-    let rt = support::runtime();
+//     let rt = support::runtime();
 
-    let err: hyper::Error = rt
-        .block_on(async move {
-            let client = Client::builder()
-                .http2_only(true)
-                .build_http::<hyper::Body>();
-            let uri = addr_str.parse().expect("server addr should parse");
+//     let err: hyper::Error = rt
+//         .block_on(async move {
+//             let client = Client::builder()
+//                 .http2_only(true)
+//                 .build_http::<hyper::Body>();
+//             let uri = addr_str.parse().expect("server addr should parse");
 
-            let mut res = client.get(uri).await?;
+//             let mut res = client.get(uri).await?;
 
-            while let Some(chunk) = res.body_mut().next().await {
-                chunk?;
-            }
-            Ok(())
-        })
-        .unwrap_err();
+//             while let Some(chunk) = res.body_mut().next().await {
+//                 chunk?;
+//             }
+//             Ok(())
+//         })
+//         .unwrap_err();
 
-    let h2_err = err.source().unwrap().downcast_ref::<h2::Error>().unwrap();
+//     let h2_err = err.source().unwrap().downcast_ref::<h2::Error>().unwrap();
 
-    assert_eq!(h2_err.reason(), Some(h2::Reason::INADEQUATE_SECURITY));
-}
+//     assert_eq!(h2_err.reason(), Some(h2::Reason::INADEQUATE_SECURITY));
+// }
 
 struct Http2ReadyErrorSvc;
 


### PR DESCRIPTION
Removes the `stream` cargo feature and any usage of `Stream`, including `Body::wrap_stream`, `impl Stream for Body` and `accept::from_stream`.

A few tests were broken, and some examples. Quite extensive changes were needed to fix some of them, which I wasn't able to do in this PR. As discussed on Discord I left TODO comments on the remaining broken tests, tagged with the PR number (#2896).

This PR partially fixes issue #2855.