### PR TITLE
chore(lib): bump MSRV to 1.56

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.49 # keep in sync with MSRV.md dev doc
+          - 1.56 # keep in sync with MSRV.md dev doc
 
         os:
           - ubuntu-latest

--- a/docs/MSRV.md
+++ b/docs/MSRV.md
@@ -6,4 +6,4 @@ hyper. It is possible that an older compiler can work, but that is not
 guaranteed. We try to increase the MSRV responsibly, only when a significant
 new feature is needed.
 
-The current MSRV is: **1.49**.
+The current MSRV is: **1.56**.


### PR DESCRIPTION
`indexmap` now requires 1.56...