### PR TITLE
feat(body): add `Body::wrap_body`

### DIFF
--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -56,6 +56,19 @@ pub(crate) fn take_full_data<T: HttpBody + 'static>(body: &mut T) -> Option<T::D
     }
 }
 
+pub(crate) fn try_downcast<T, K>(k: K) -> Result<T, K>
+where
+    T: 'static,
+    K: Send + 'static,
+{
+    let mut k = Some(k);
+    if let Some(k) = <dyn std::any::Any>::downcast_mut::<Option<T>>(&mut k) {
+        Ok(k.take().unwrap())
+    } else {
+        Err(k.unwrap())
+    }
+}
+
 fn _assert_send_sync() {
     fn _assert_send<T: Send>() {}
     fn _assert_sync<T: Sync>() {}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -18,10 +18,6 @@ pub(crate) mod io;
 #[cfg(all(feature = "client", any(feature = "http1", feature = "http2")))]
 mod lazy;
 mod never;
-#[cfg(any(
-    feature = "stream",
-    all(feature = "client", any(feature = "http1", feature = "http2"))
-))]
 pub(crate) mod sync_wrapper;
 pub(crate) mod task;
 pub(crate) mod watch;

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,7 +48,6 @@ pub(super) enum Kind {
     #[cfg(all(feature = "http1", feature = "server", feature = "runtime"))]
     HeaderTimeout,
     /// Error while reading a body from connection.
-    #[cfg(any(feature = "http1", feature = "http2", feature = "stream"))]
     Body,
     /// Error while writing a body to connection.
     #[cfg(any(feature = "http1", feature = "http2"))]
@@ -92,7 +91,6 @@ pub(super) enum Header {
 #[derive(Debug)]
 pub(super) enum User {
     /// Error calling user's HttpBody::poll_data().
-    #[cfg(any(feature = "http1", feature = "http2"))]
     Body,
     /// The user aborted writing of the outgoing body.
     BodyWriteAborted,
@@ -367,7 +365,6 @@ impl Error {
         Error::new_user(User::Service).with(cause)
     }
 
-    #[cfg(any(feature = "http1", feature = "http2"))]
     pub(super) fn new_user_body<E: Into<Cause>>(cause: E) -> Error {
         Error::new_user(User::Body).with(cause)
     }
@@ -440,7 +437,6 @@ impl Error {
             Kind::Accept => "error accepting connection",
             #[cfg(all(feature = "http1", feature = "server", feature = "runtime"))]
             Kind::HeaderTimeout => "read header from client timeout",
-            #[cfg(any(feature = "http1", feature = "http2", feature = "stream"))]
             Kind::Body => "error reading a body from connection",
             #[cfg(any(feature = "http1", feature = "http2"))]
             Kind::BodyWrite => "error writing a body to connection",
@@ -451,7 +447,6 @@ impl Error {
             #[cfg(any(feature = "http1", feature = "http2"))]
             Kind::Io => "connection error",
 
-            #[cfg(any(feature = "http1", feature = "http2"))]
             Kind::User(User::Body) => "error from user's HttpBody stream",
             Kind::User(User::BodyWriteAborted) => "user body write aborted",
             #[cfg(any(feature = "http1", feature = "http2"))]


### PR DESCRIPTION
This adds `Body::wrap_body` which creates a `Body` from any `impl http_body::Body`. This is required in axum for https://github.com/tokio-rs/axum/pull/1154.

Note that I made the PR against `0.14.x` because the `Body` struct is undergoing some big changes on `master`. If you want me to make this PR against `master` instead and backport this to `0.14.x` then just let me know 😊