### PR TITLE
Bump itoa version, don't use mem::uninit (0.13 backport)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ http-body = "0.3.1"
 httpdate = "0.3"
 httparse = "1.0"
 h2 = "0.2.2"
-itoa = "0.4.1"
+itoa = "1"
 tracing = { version = "0.1", default-features = false, features = ["log", "std"] }
 pin-project = "1.0"
 tower-service = "0.3"
@@ -56,7 +56,7 @@ tower-util = "0.3"
 url = "1.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dev-dependencies]
-pnet = "0.25.0"
+pnet = "0.29.0"
 
 [features]
 default = [

--- a/src/common/drain.rs
+++ b/src/common/drain.rs
@@ -35,6 +35,8 @@ pub struct Draining {
 }
 
 #[derive(Clone)]
+// drained_tx is never ready
+#[allow(dead_code)]
 pub struct Watch {
     drained_tx: mpsc::Sender<Never>,
     rx: watch::Receiver<Action>,

--- a/src/common/sync_wrapper.rs
+++ b/src/common/sync_wrapper.rs
@@ -1,11 +1,6 @@
 /*
  * This is a copy of the sync_wrapper crate.
  */
-//! A mutual exclusion primitive that relies on static type information only
-//!
-//! This library is inspired by [this discussion](https://internals.rust-lang.org/t/what-shall-sync-mean-across-an-await/12020/2).
-#![doc(html_logo_url = "https://developer.actyx.com/img/logo.svg")]
-#![doc(html_favicon_url = "https://developer.actyx.com/img/favicon.ico")]
 
 /// A mutual exclusion primitive that relies on static type information only
 ///


### PR DESCRIPTION
Marking this as a draft for now while I test some crates, patching their `hyper` version to be this one then seeing if a `cargo update` fixes them with strict init checks. The code is done, though.

See: #2914 