### PR TITLE
feat(CI): add external type check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -260,3 +260,23 @@ jobs:
         with:
           command: rustdoc
           args: --features full,ffi -- --cfg docsrs --cfg hyper_unstable_ffi -D broken-intra-doc-links
+
+  doc:
+    name: Check exposed types
+    needs: [style, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: cargo check-external-types
+        uses: actions-rs/cargo@v1
+        with:
+          command: check-external-types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ libc = { version = "0.2", optional = true }
 socket2 = { version = "0.4", optional = true }
 
 [dev-dependencies]
+cargo-check-external-types = "0.1.2"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 matches = "0.1"
 num_cpus = "1.0"


### PR DESCRIPTION
Adding audit for issue #2925.

Uses the nightly build to uses rustdoc to create a diff with the exported types.