### PR TITLE
feat: make body::Sender and Body::channel private

### DIFF
--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -20,7 +20,8 @@ pub use http_body::Body as HttpBody;
 pub use http_body::SizeHint;
 
 pub use self::aggregate::aggregate;
-pub use self::body::{Recv, Sender};
+pub use self::body::Recv;
+pub(crate) use self::body::Sender;
 pub(crate) use self::length::DecodedLength;
 pub use self::to_bytes::to_bytes;
 


### PR DESCRIPTION
Make `body::Sender` and `Body::channel` (currently named `Recv::channel`) private, and update the tests that relied on these types. As far as I can see there were only two affected tests, as well as the `end_to_end` benchmark which is currently disabled (#2930). 

I ended up using `#[allow(unused)]` a few places in `body` after making the aforementioned types private, please let me know if you'd like me to take a different approach.

This closes #2962 
