### PR TITLE
feat(rt): add Timer trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,6 @@ server = []
 runtime = [
     "tokio/net",
     "tokio/rt",
-    "tokio/time",
 ]
 
 # C-API support (currently unstable (no semver))

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -1,0 +1,3 @@
+
+mod tokiort;
+pub use tokiort::TokioTimer;

--- a/benches/support/tokiort.rs
+++ b/benches/support/tokiort.rs
@@ -1,0 +1,66 @@
+#![allow(dead_code)]
+//! Various runtimes for hyper
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use futures_util::Future;
+use hyper::rt::{Sleep, Timer};
+
+/// An Executor that uses the tokio runtime.
+pub struct TokioExecutor;
+
+/// A Timer that uses the tokio runtime.
+
+#[derive(Clone, Debug)]
+pub struct TokioTimer;
+
+impl Timer for TokioTimer {
+    fn sleep(&self, duration: Duration) -> Box<dyn Sleep + Unpin> {
+        let s = tokio::time::sleep(duration);
+        let hs = TokioSleep { inner: Box::pin(s) };
+        return Box::new(hs);
+    }
+
+    fn sleep_until(&self, deadline: Instant) -> Box<dyn Sleep + Unpin> {
+        return Box::new(TokioSleep {
+            inner: Box::pin(tokio::time::sleep_until(deadline.into())),
+        });
+    }
+}
+
+struct TokioTimeout<T> {
+    inner: Pin<Box<tokio::time::Timeout<T>>>,
+}
+
+impl<T> Future for TokioTimeout<T>
+where
+    T: Future,
+{
+    type Output = Result<T::Output, tokio::time::error::Elapsed>;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(context)
+    }
+}
+
+// Use TokioSleep to get tokio::time::Sleep to implement Unpin.
+// see https://docs.rs/tokio/latest/tokio/time/struct.Sleep.html
+pub(crate) struct TokioSleep {
+    pub(crate) inner: Pin<Box<tokio::time::Sleep>>,
+}
+
+impl Future for TokioSleep {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(cx)
+    }
+}
+
+// Use HasSleep to get tokio::time::Sleep to implement Unpin.
+// see https://docs.rs/tokio/latest/tokio/time/struct.Sleep.html
+
+impl Sleep for TokioSleep {}

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -10,14 +10,14 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::Recv;
 use crate::body::Body;
+use super::super::dispatch;
 use crate::common::{
     exec::{BoxSendFuture, Exec},
     task, Future, Pin, Poll,
 };
-use crate::upgrade::Upgraded;
 use crate::proto;
-use crate::rt::Executor;
-use super::super::dispatch;
+use crate::rt::{Executor};
+use crate::upgrade::Upgraded;
 
 type Dispatcher<T, B> =
     proto::dispatch::Dispatcher<proto::dispatch::Client<B>, B, T, proto::h1::ClientTransaction>;
@@ -120,7 +120,10 @@ where
     ///   before calling this method.
     /// - Since absolute-form `Uri`s are not required, if received, they will
     ///   be serialized as-is.
-    pub fn send_request(&mut self, req: Request<B>) -> impl Future<Output = crate::Result<Response<Recv>>> {
+    pub fn send_request(
+        &mut self,
+        req: Request<B>,
+    ) -> impl Future<Output = crate::Result<Response<Recv>>> {
         let sent = self.dispatch.send(req);
 
         async move {
@@ -130,7 +133,7 @@ where
                     Ok(Err(err)) => Err(err),
                     // this is definite bug if it happens, but it shouldn't happen!
                     Err(_canceled) => panic!("dispatch dropped without returning error"),
-                }
+                },
                 Err(_req) => {
                     tracing::debug!("connection was not ready");
 
@@ -476,4 +479,3 @@ impl Builder {
         }
     }
 }
-

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -15,6 +15,8 @@ pub(crate) mod exec;
 pub(crate) mod io;
 mod never;
 pub(crate) mod task;
+#[cfg(any(feature = "http1", feature = "http2", feature = "server"))]
+pub(crate) mod time;
 pub(crate) mod watch;
 
 #[cfg(any(feature = "http1", feature = "http2", feature = "runtime"))]
@@ -26,3 +28,10 @@ cfg_proto! {
     pub(crate) use std::marker::Unpin;
 }
 pub(crate) use std::{future::Future, pin::Pin};
+
+pub(crate) fn into_pin<T: ?Sized>(boxed: Box<T>) -> Pin<Box<T>> {
+    // It's not possible to move or replace the insides of a `Pin<Box<T>>`
+    // when `T: !Unpin`, so it's safe to pin it directly without any
+    // additional requirements.
+    unsafe { Pin::new_unchecked(boxed) }
+}

--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -1,0 +1,87 @@
+use std::{fmt, sync::Arc};
+#[cfg(all(feature = "server", feature = "runtime"))]
+use std::{
+    pin::Pin,
+    time::{Duration, Instant},
+};
+
+#[cfg(all(feature = "server", feature = "runtime"))]
+use crate::rt::Sleep;
+use crate::rt::Timer;
+
+/// A user-provided timer to time background tasks.
+#[derive(Clone)]
+pub(crate) enum Time {
+    Timer(Arc<dyn Timer + Send + Sync>),
+    Empty,
+}
+
+impl fmt::Debug for Time {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Time").finish()
+    }
+}
+
+/*
+pub(crate) fn timeout<F>(tim: Tim, future: F, duration: Duration) -> HyperTimeout<F> {
+    HyperTimeout { sleep: tim.sleep(duration), future: future }
+}
+
+pin_project_lite::pin_project! {
+    pub(crate) struct HyperTimeout<F> {
+        sleep: Box<dyn Sleep>,
+        #[pin]
+        future: F
+    }
+}
+
+pub(crate) struct Timeout;
+
+impl<F> Future for HyperTimeout<F> where F: Future {
+
+    type Output = Result<F::Output, Timeout>;
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output>{
+        let mut this = self.project();
+        if let Poll::Ready(v) = this.future.poll(ctx) {
+            return Poll::Ready(Ok(v));
+        }
+
+        if let Poll::Ready(_) = Pin::new(&mut this.sleep).poll(ctx) {
+            return Poll::Ready(Err(Timeout));
+        }
+
+        return Poll::Pending;
+    }
+}
+*/
+
+#[cfg(all(feature = "server", feature = "runtime"))]
+impl Time {
+    pub(crate) fn sleep(&self, duration: Duration) -> Box<dyn Sleep + Unpin> {
+        match *self {
+            Time::Empty => {
+                panic!("You must supply a timer.")
+            }
+            Time::Timer(ref t) => t.sleep(duration),
+        }
+    }
+
+    pub(crate) fn sleep_until(&self, deadline: Instant) -> Box<dyn Sleep + Unpin> {
+        match *self {
+            Time::Empty => {
+                panic!("You must supply a timer.")
+            }
+            Time::Timer(ref t) => t.sleep_until(deadline),
+        }
+    }
+
+    pub(crate) fn reset(&self, sleep: &mut Pin<Box<dyn Sleep>>, new_deadline: Instant) {
+        match *self {
+            Time::Empty => {
+                panic!("You must supply a timer.")
+            }
+            Time::Timer(ref t) => t.reset(sleep, new_deadline),
+        }
+    }
+}

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -58,10 +58,10 @@ cfg_client! {
 impl<D, Bs, I, T> Dispatcher<D, Bs, I, T>
 where
     D: Dispatch<
-        PollItem = MessageHead<T::Outgoing>,
-        PollBody = Bs,
-        RecvItem = MessageHead<T::Incoming>,
-    > + Unpin,
+            PollItem = MessageHead<T::Outgoing>,
+            PollBody = Bs,
+            RecvItem = MessageHead<T::Incoming>,
+        > + Unpin,
     D::PollError: Into<Box<dyn StdError + Send + Sync>>,
     I: AsyncRead + AsyncWrite + Unpin,
     T: Http1Transaction + Unpin,
@@ -256,7 +256,10 @@ where
                 if wants.contains(Wants::UPGRADE) {
                     let upgrade = self.conn.on_upgrade();
                     debug_assert!(!upgrade.is_none(), "empty upgrade");
-                    debug_assert!(head.extensions.get::<OnUpgrade>().is_none(), "OnUpgrade already set");
+                    debug_assert!(
+                        head.extensions.get::<OnUpgrade>().is_none(),
+                        "OnUpgrade already set"
+                    );
                     head.extensions.insert(upgrade);
                 }
                 self.dispatch.recv_msg(Ok((head, body)))?;
@@ -396,10 +399,10 @@ where
 impl<D, Bs, I, T> Future for Dispatcher<D, Bs, I, T>
 where
     D: Dispatch<
-        PollItem = MessageHead<T::Outgoing>,
-        PollBody = Bs,
-        RecvItem = MessageHead<T::Incoming>,
-    > + Unpin,
+            PollItem = MessageHead<T::Outgoing>,
+            PollBody = Bs,
+            RecvItem = MessageHead<T::Incoming>,
+        > + Unpin,
     D::PollError: Into<Box<dyn StdError + Send + Sync>>,
     I: AsyncRead + AsyncWrite + Unpin,
     T: Http1Transaction + Unpin,

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -4,11 +4,13 @@ use std::{pin::Pin, time::Duration};
 use bytes::BytesMut;
 use http::{HeaderMap, Method};
 use httparse::ParserConfig;
-#[cfg(all(feature = "server", feature = "runtime"))]
-use tokio::time::Sleep;
 
 use crate::body::DecodedLength;
+#[cfg(all(feature = "server", feature = "runtime"))]
+use crate::common::time::Time;
 use crate::proto::{BodyLength, MessageHead};
+#[cfg(all(feature = "server", feature = "runtime"))]
+use crate::rt::Sleep;
 
 pub(crate) use self::conn::Conn;
 pub(crate) use self::decode::Decoder;
@@ -79,9 +81,11 @@ pub(crate) struct ParseContext<'a> {
     #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout: Option<Duration>,
     #[cfg(all(feature = "server", feature = "runtime"))]
-    h1_header_read_timeout_fut: &'a mut Option<Pin<Box<Sleep>>>,
+    h1_header_read_timeout_fut: &'a mut Option<Pin<Box<dyn Sleep>>>,
     #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout_running: &'a mut bool,
+    #[cfg(all(feature = "server", feature = "runtime"))]
+    timer: Time,
     preserve_header_case: bool,
     #[cfg(feature = "ffi")]
     preserve_header_order: bool,

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -5,8 +5,31 @@
 //! If the `runtime` feature is disabled, the types in this module can be used
 //! to plug in other runtimes.
 
+use std::{
+    future::Future,
+    pin::Pin,
+    time::{Duration, Instant},
+};
+
 /// An executor of futures.
 pub trait Executor<Fut> {
     /// Place the future into the executor to be run.
     fn execute(&self, fut: Fut);
 }
+
+/// A timer which provides timer-like functions.
+pub trait Timer {
+    /// Return a future that resolves in `duration` time.
+    fn sleep(&self, duration: Duration) -> Box<dyn Sleep + Unpin>;
+
+    /// Return a future that resolves at `deadline`.
+    fn sleep_until(&self, deadline: Instant) -> Box<dyn Sleep + Unpin>;
+
+    /// Reset a future to resolve at `new_deadline` instead.
+    fn reset(&self, sleep: &mut Pin<Box<dyn Sleep>>, new_deadline: Instant) {
+        *sleep = crate::common::into_pin(self.sleep_until(new_deadline));
+    }
+}
+
+/// A future returned by a `Timer`.
+pub trait Sleep: Send + Sync + Unpin + Future<Output = ()> {}

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -46,6 +46,7 @@
     not(all(feature = "http1", feature = "http2"))
 ))]
 use std::marker::PhantomData;
+use std::sync::Arc;
 #[cfg(all(any(feature = "http1", feature = "http2"), feature = "runtime"))]
 use std::time::Duration;
 
@@ -55,6 +56,7 @@ use crate::common::io::Rewind;
 use crate::error::{Kind, Parse};
 #[cfg(feature = "http1")]
 use crate::upgrade::Upgraded;
+use crate::{common::time::Time, rt::Timer};
 
 cfg_feature! {
     #![any(feature = "http1", feature = "http2")]
@@ -86,6 +88,7 @@ cfg_feature! {
 #[cfg_attr(docsrs, doc(cfg(any(feature = "http1", feature = "http2"))))]
 pub struct Http<E = Exec> {
     pub(crate) exec: E,
+    pub(crate) timer: Time,
     h1_half_close: bool,
     h1_keep_alive: bool,
     h1_title_case_headers: bool,
@@ -169,7 +172,7 @@ pin_project! {
 #[cfg(all(feature = "http1", feature = "http2"))]
 #[derive(Clone, Debug)]
 enum Fallback<E> {
-    ToHttp2(proto::h2::server::Config, E),
+    ToHttp2(proto::h2::server::Config, E, Time),
     Http1Only,
 }
 
@@ -225,6 +228,7 @@ impl Http {
     pub fn new() -> Http {
         Http {
             exec: Exec::Default,
+            timer: Time::Empty,
             h1_half_close: false,
             h1_keep_alive: true,
             h1_title_case_headers: false,
@@ -554,6 +558,30 @@ impl<E> Http<E> {
     pub fn with_executor<E2>(self, exec: E2) -> Http<E2> {
         Http {
             exec,
+            timer: self.timer,
+            h1_half_close: self.h1_half_close,
+            h1_keep_alive: self.h1_keep_alive,
+            h1_title_case_headers: self.h1_title_case_headers,
+            h1_preserve_header_case: self.h1_preserve_header_case,
+            #[cfg(all(feature = "http1", feature = "runtime"))]
+            h1_header_read_timeout: self.h1_header_read_timeout,
+            h1_writev: self.h1_writev,
+            #[cfg(feature = "http2")]
+            h2_builder: self.h2_builder,
+            mode: self.mode,
+            max_buf_size: self.max_buf_size,
+            pipeline_flush: self.pipeline_flush,
+        }
+    }
+
+    /// Set the timer used in background tasks.
+    pub fn with_timer<M>(self, timer: M) -> Http<E>
+    where
+        M: Timer + Send + Sync + 'static,
+    {
+        Http {
+            exec: self.exec,
+            timer: Time::Timer(Arc::new(timer)),
             h1_half_close: self.h1_half_close,
             h1_keep_alive: self.h1_keep_alive,
             h1_title_case_headers: self.h1_title_case_headers,
@@ -610,6 +638,10 @@ impl<E> Http<E> {
         macro_rules! h1 {
             () => {{
                 let mut conn = proto::Conn::new(io);
+                #[cfg(feature = "runtime")]
+                {
+                    conn.set_timer(self.timer.clone());
+                }
                 if !self.h1_keep_alive {
                     conn.disable_keep_alive();
                 }
@@ -654,8 +686,13 @@ impl<E> Http<E> {
             #[cfg(feature = "http2")]
             ConnectionMode::H2Only => {
                 let rewind_io = Rewind::new(io);
-                let h2 =
-                    proto::h2::Server::new(rewind_io, service, &self.h2_builder, self.exec.clone());
+                let h2 = proto::h2::Server::new(
+                    rewind_io,
+                    service,
+                    &self.h2_builder,
+                    self.exec.clone(),
+                    self.timer.clone(),
+                );
                 ProtoServer::H2 { h2 }
             }
         };
@@ -664,7 +701,11 @@ impl<E> Http<E> {
             conn: Some(proto),
             #[cfg(all(feature = "http1", feature = "http2"))]
             fallback: if self.mode == ConnectionMode::Fallback {
-                Fallback::ToHttp2(self.h2_builder.clone(), self.exec.clone())
+                Fallback::ToHttp2(
+                    self.h2_builder.clone(),
+                    self.exec.clone(),
+                    self.timer.clone(),
+                )
             } else {
                 Fallback::Http1Only
             },
@@ -808,7 +849,12 @@ where
         let mut conn = Some(self);
         futures_util::future::poll_fn(move |cx| {
             ready!(conn.as_mut().unwrap().poll_without_shutdown(cx))?;
-            Poll::Ready(conn.take().unwrap().try_into_parts().ok_or_else(crate::Error::new_without_shutdown_not_h1))
+            Poll::Ready(
+                conn.take()
+                    .unwrap()
+                    .try_into_parts()
+                    .ok_or_else(crate::Error::new_without_shutdown_not_h1),
+            )
         })
     }
 
@@ -825,11 +871,17 @@ where
         };
         let mut rewind_io = Rewind::new(io);
         rewind_io.rewind(read_buf);
-        let (builder, exec) = match self.fallback {
-            Fallback::ToHttp2(ref builder, ref exec) => (builder, exec),
+        let (builder, exec, timer) = match self.fallback {
+            Fallback::ToHttp2(ref builder, ref exec, ref timer) => (builder, exec, timer),
             Fallback::Http1Only => unreachable!("upgrade_h2 with Fallback::Http1Only"),
         };
-        let h2 = proto::h2::Server::new(rewind_io, dispatch.into_service(), builder, exec.clone());
+        let h2 = proto::h2::Server::new(
+            rewind_io,
+            dispatch.into_service(),
+            builder,
+            exec.clone(),
+            timer.clone(),
+        );
 
         debug_assert!(self.conn.is_none());
         self.conn = Some(ProtoServer::H2 { h2 });

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -21,6 +21,9 @@ pub use futures_util::{
 pub use hyper::{HeaderMap, StatusCode};
 pub use std::net::SocketAddr;
 
+mod tokiort;
+pub use tokiort::TokioTimer;
+
 #[allow(unused_macros)]
 macro_rules! t {
     (

--- a/tests/support/tokiort.rs
+++ b/tests/support/tokiort.rs
@@ -1,0 +1,1 @@
+../../benches/support/tokiort.rs


### PR DESCRIPTION
This adds a `hyper::rt::Timer` trait, and it is used in connection
builders to configure a custom timer source for timeouts.

Closes #2846 
Closes #2847 
Closes #2848 

Continues #2904 
