### PR TITLE
feat(client, server): remove runtime cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ serde_json = "1.0"
 tokio = { version = "1", features = [
     "fs",
     "macros",
+    "net",
     "io-std",
     "io-util",
     "rt",
@@ -81,7 +82,6 @@ full = [
     "http1",
     "http2",
     "server",
-    "runtime",
 ]
 
 # HTTP versions
@@ -91,12 +91,6 @@ http2 = ["h2"]
 # Client/Server
 client = []
 server = []
-
-# Tokio support
-runtime = [
-    "tokio/net",
-    "tokio/rt",
-]
 
 # C-API support (currently unstable (no semver))
 ffi = ["libc"]

--- a/benches/support/tokiort.rs
+++ b/benches/support/tokiort.rs
@@ -9,8 +9,19 @@ use std::{
 use futures_util::Future;
 use hyper::rt::{Sleep, Timer};
 
+#[derive(Clone)]
 /// An Executor that uses the tokio runtime.
 pub struct TokioExecutor;
+
+impl<F> hyper::rt::Executor<F> for TokioExecutor
+where
+    F: std::future::Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    fn execute(&self, fut: F) {
+        tokio::task::spawn(fut);
+    }
+}
 
 /// A Timer that uses the tokio runtime.
 

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -4,15 +4,13 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::marker::PhantomData;
 use std::sync::Arc;
-#[cfg(feature = "runtime")]
 use std::time::Duration;
 
 use http::{Request, Response};
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use crate::Recv;
-use crate::body::Body;
 use super::super::dispatch;
+use crate::body::Body;
 use crate::common::time::Time;
 use crate::common::{
     exec::{BoxSendFuture, Exec},
@@ -20,6 +18,7 @@ use crate::common::{
 };
 use crate::proto;
 use crate::rt::{Executor, Timer};
+use crate::Recv;
 
 /// The sender side of an established connection.
 pub struct SendRequest<B> {
@@ -309,11 +308,6 @@ impl Builder {
     /// Pass `None` to disable HTTP2 keep-alive.
     ///
     /// Default is currently disabled.
-    ///
-    /// # Cargo Feature
-    ///
-    /// Requires the `runtime` cargo feature to be enabled.
-    #[cfg(feature = "runtime")]
     #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_interval(
@@ -330,11 +324,6 @@ impl Builder {
     /// be closed. Does nothing if `http2_keep_alive_interval` is disabled.
     ///
     /// Default is 20 seconds.
-    ///
-    /// # Cargo Feature
-    ///
-    /// Requires the `runtime` cargo feature to be enabled.
-    #[cfg(feature = "runtime")]
     #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
@@ -350,11 +339,6 @@ impl Builder {
     /// disabled.
     ///
     /// Default is `false`.
-    ///
-    /// # Cargo Feature
-    ///
-    /// Requires the `runtime` cargo feature to be enabled.
-    #[cfg(feature = "runtime")]
     #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_while_idle(&mut self, enabled: bool) -> &mut Self {
@@ -416,9 +400,12 @@ impl Builder {
             let h2 = proto::h2::client::handshake(io, rx, &opts.h2_builder, opts.exec, opts.timer)
                 .await?;
             Ok((
-                SendRequest { dispatch: tx.unbound() },
-                //SendRequest { dispatch: tx },
-                Connection { inner: (PhantomData, h2) },
+                SendRequest {
+                    dispatch: tx.unbound(),
+                },
+                Connection {
+                    inner: (PhantomData, h2),
+                },
             ))
         }
     }

--- a/src/client/conn/mod.rs
+++ b/src/client/conn/mod.rs
@@ -11,7 +11,7 @@
 //! ## Example
 //! A simple example that uses the `SendRequest` struct to talk HTTP over a Tokio TCP stream
 //! ```no_run
-//! # #[cfg(all(feature = "client", feature = "http1", feature = "runtime"))]
+//! # #[cfg(all(feature = "client", feature = "http1"))]
 //! # mod rt {
 //! use bytes::Bytes;
 //! use http::{Request, StatusCode};
@@ -61,7 +61,7 @@ use std::fmt;
 #[cfg(not(all(feature = "http1", feature = "http2")))]
 use std::marker::PhantomData;
 use std::sync::Arc;
-#[cfg(all(feature = "runtime", feature = "http2"))]
+#[cfg(feature = "http2")]
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -84,8 +84,8 @@ use crate::proto;
 use crate::rt::Executor;
 #[cfg(feature = "http1")]
 use crate::upgrade::Upgraded;
-use crate::{Recv, Request, Response};
 use crate::{common::time::Time, rt::Timer};
+use crate::{Recv, Request, Response};
 
 #[cfg(feature = "http1")]
 pub mod http1;
@@ -126,9 +126,7 @@ pin_project! {
 ///
 /// This is a shortcut for `Builder::new().handshake(io)`.
 /// See [`client::conn`](crate::client::conn) for more.
-pub async fn handshake<T, B>(
-    io: T,
-) -> crate::Result<(SendRequest<B>, Connection<T, B>)>
+pub async fn handshake<T, B>(io: T) -> crate::Result<(SendRequest<B>, Connection<T, B>)>
 where
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     B: Body + 'static,
@@ -724,11 +722,6 @@ impl Builder {
     /// Pass `None` to disable HTTP2 keep-alive.
     ///
     /// Default is currently disabled.
-    ///
-    /// # Cargo Feature
-    ///
-    /// Requires the `runtime` cargo feature to be enabled.
-    #[cfg(feature = "runtime")]
     #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_interval(
@@ -745,11 +738,6 @@ impl Builder {
     /// be closed. Does nothing if `http2_keep_alive_interval` is disabled.
     ///
     /// Default is 20 seconds.
-    ///
-    /// # Cargo Feature
-    ///
-    /// Requires the `runtime` cargo feature to be enabled.
-    #[cfg(feature = "runtime")]
     #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
@@ -765,11 +753,6 @@ impl Builder {
     /// disabled.
     ///
     /// Default is `false`.
-    ///
-    /// # Cargo Feature
-    ///
-    /// Requires the `runtime` cargo feature to be enabled.
-    #[cfg(feature = "runtime")]
     #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_while_idle(&mut self, enabled: bool) -> &mut Self {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,7 +7,7 @@
 //! For a small example program simply fetching a URL, take a look at the
 //! [full client example](https://github.com/hyperium/hyper/blob/master/examples/client.rs).
 
-#[cfg(all(test, feature = "runtime"))]
+#[cfg(test)]
 mod tests;
 
 cfg_feature! {

--- a/src/common/exec.rs
+++ b/src/common/exec.rs
@@ -33,7 +33,7 @@ impl Exec {
     {
         match *self {
             Exec::Default => {
-                tokio::task::spawn(fut);
+                panic!("executor must be set");
             }
             Exec::Executor(ref e) => {
                 e.execute(Box::pin(fut));

--- a/src/common/exec.rs
+++ b/src/common/exec.rs
@@ -33,15 +33,7 @@ impl Exec {
     {
         match *self {
             Exec::Default => {
-                #[cfg(feature = "runtime")]
-                {
-                    tokio::task::spawn(fut);
-                }
-
-                #[cfg(not(feature = "runtime"))]
-                {
-                    panic!("executor must be set")
-                }
+                tokio::task::spawn(fut);
             }
             Exec::Executor(ref e) => {
                 e.execute(Box::pin(fut));

--- a/src/common/exec.rs
+++ b/src/common/exec.rs
@@ -16,8 +16,9 @@ pub trait ConnStreamExec<F, B: Body>: Clone {
 
 pub(crate) type BoxSendFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
-// Either the user provides an executor for background tasks, or we use
-// `tokio::spawn`.
+// Either the user provides an executor for background tasks, or we panic.
+// TODO: with the `runtime`feature, `Exec::Default` used `tokio::spawn`. With the
+// removal of the opt-in default runtime, this should be refactored.
 #[derive(Clone)]
 pub enum Exec {
     Default,

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -113,6 +113,7 @@ mod tests {
     use bytes::Bytes;
     use tokio::io::AsyncReadExt;
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn partial_rewind() {
         let underlying = [104, 101, 108, 108, 111];
@@ -135,6 +136,7 @@ mod tests {
         assert_eq!(&buf, &underlying);
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn full_rewind() {
         let underlying = [104, 101, 108, 108, 111];

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -19,7 +19,7 @@ pub(crate) mod task;
 pub(crate) mod time;
 pub(crate) mod watch;
 
-#[cfg(any(feature = "http1", feature = "http2", feature = "runtime"))]
+#[cfg(any(feature = "http1", feature = "http2"))]
 pub(crate) use self::never::Never;
 pub(crate) use self::task::Poll;
 

--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -1,11 +1,11 @@
 use std::{fmt, sync::Arc};
-#[cfg(all(feature = "server", feature = "runtime"))]
+#[cfg(feature = "server")]
 use std::{
     pin::Pin,
     time::{Duration, Instant},
 };
 
-#[cfg(all(feature = "server", feature = "runtime"))]
+#[cfg(feature = "server")]
 use crate::rt::Sleep;
 use crate::rt::Timer;
 
@@ -56,7 +56,7 @@ impl<F> Future for HyperTimeout<F> where F: Future {
 }
 */
 
-#[cfg(all(feature = "server", feature = "runtime"))]
+#[cfg(feature = "server")]
 impl Time {
     pub(crate) fn sleep(&self, duration: Duration) -> Box<dyn Sleep + Unpin> {
         match *self {

--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -1,11 +1,9 @@
 use std::{fmt, sync::Arc};
-#[cfg(feature = "server")]
 use std::{
     pin::Pin,
     time::{Duration, Instant},
 };
 
-#[cfg(feature = "server")]
 use crate::rt::Sleep;
 use crate::rt::Timer;
 
@@ -56,7 +54,6 @@ impl<F> Future for HyperTimeout<F> where F: Future {
 }
 */
 
-#[cfg(feature = "server")]
 impl Time {
     pub(crate) fn sleep(&self, duration: Duration) -> Box<dyn Sleep + Unpin> {
         match *self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,7 @@ pub(super) enum Kind {
     #[cfg(all(feature = "tcp", feature = "server"))]
     Listen,
     /// User took too long to send headers
-    #[cfg(all(feature = "http1", feature = "server", feature = "runtime"))]
+    #[cfg(all(feature = "http1", feature = "server"))]
     HeaderTimeout,
     /// Error while reading a body from connection.
     #[cfg(any(feature = "http1", feature = "http2"))]
@@ -278,7 +278,7 @@ impl Error {
         Error::new_user(User::UnexpectedHeader)
     }
 
-    #[cfg(all(feature = "http1", feature = "server", feature = "runtime"))]
+    #[cfg(all(feature = "http1", feature = "server"))]
     pub(super) fn new_header_timeout() -> Error {
         Error::new(Kind::HeaderTimeout)
     }
@@ -370,7 +370,7 @@ impl Error {
             Kind::Canceled => "operation was canceled",
             #[cfg(all(feature = "server", feature = "tcp"))]
             Kind::Listen => "error creating server listener",
-            #[cfg(all(feature = "http1", feature = "server", feature = "runtime"))]
+            #[cfg(all(feature = "http1", feature = "server"))]
             Kind::HeaderTimeout => "read header from client timeout",
             #[cfg(any(feature = "http1", feature = "http2"))]
             Kind::Body => "error reading a body from connection",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,6 @@
 //! - `http2`: Enables HTTP/2 support.
 //! - `client`: Enables the HTTP `client`.
 //! - `server`: Enables the HTTP `server`.
-//! - `runtime`: Enables convenient integration with `tokio`, providing
-//!   connectors and acceptors for TCP, and a default executor.
 //!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -1038,7 +1038,7 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(miri)))]
     #[bench]
     fn bench_read_head_short(b: &mut ::test::Bencher) {
         use super::*;

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::io;
 use std::marker::PhantomData;
-#[cfg(all(feature = "server", feature = "runtime"))]
+#[cfg(feature = "server")]
 use std::time::Duration;
 
 use bytes::{Buf, Bytes};
@@ -14,12 +14,12 @@ use tracing::{debug, error, trace};
 use super::io::Buffered;
 use super::{Decoder, Encode, EncodedBuf, Encoder, Http1Transaction, ParseContext, Wants};
 use crate::body::DecodedLength;
-#[cfg(all(feature = "server", feature = "runtime"))]
+#[cfg(feature = "server")]
 use crate::common::time::Time;
 use crate::common::{task, Pin, Poll, Unpin};
 use crate::headers::connection_keep_alive;
 use crate::proto::{BodyLength, MessageHead};
-#[cfg(all(feature = "server", feature = "runtime"))]
+#[cfg(feature = "server")]
 use crate::rt::Sleep;
 
 const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
@@ -53,13 +53,13 @@ where
                 keep_alive: KA::Busy,
                 method: None,
                 h1_parser_config: ParserConfig::default(),
-                #[cfg(all(feature = "server", feature = "runtime"))]
+                #[cfg(feature = "server")]
                 h1_header_read_timeout: None,
-                #[cfg(all(feature = "server", feature = "runtime"))]
+                #[cfg(feature = "server")]
                 h1_header_read_timeout_fut: None,
-                #[cfg(all(feature = "server", feature = "runtime"))]
+                #[cfg(feature = "server")]
                 h1_header_read_timeout_running: false,
-                #[cfg(all(feature = "server", feature = "runtime"))]
+                #[cfg(feature = "server")]
                 timer: Time::Empty,
                 preserve_header_case: false,
                 #[cfg(feature = "ffi")]
@@ -82,7 +82,7 @@ where
         }
     }
 
-    #[cfg(all(feature = "server", feature = "runtime"))]
+    #[cfg(feature = "server")]
     pub(crate) fn set_timer(&mut self, timer: Time) {
         self.state.timer = timer;
     }
@@ -132,7 +132,7 @@ where
         self.state.h09_responses = true;
     }
 
-    #[cfg(all(feature = "server", feature = "runtime"))]
+    #[cfg(feature = "server")]
     pub(crate) fn set_http1_header_read_timeout(&mut self, val: Duration) {
         self.state.h1_header_read_timeout = Some(val);
     }
@@ -205,13 +205,13 @@ where
                 cached_headers: &mut self.state.cached_headers,
                 req_method: &mut self.state.method,
                 h1_parser_config: self.state.h1_parser_config.clone(),
-                #[cfg(all(feature = "server", feature = "runtime"))]
+                #[cfg(feature = "server")]
                 h1_header_read_timeout: self.state.h1_header_read_timeout,
-                #[cfg(all(feature = "server", feature = "runtime"))]
+                #[cfg(feature = "server")]
                 h1_header_read_timeout_fut: &mut self.state.h1_header_read_timeout_fut,
-                #[cfg(all(feature = "server", feature = "runtime"))]
+                #[cfg(feature = "server")]
                 h1_header_read_timeout_running: &mut self.state.h1_header_read_timeout_running,
-                #[cfg(all(feature = "server", feature = "runtime"))]
+                #[cfg(feature = "server")]
                 timer: self.state.timer.clone(),
                 preserve_header_case: self.state.preserve_header_case,
                 #[cfg(feature = "ffi")]
@@ -810,13 +810,13 @@ struct State {
     /// a body or not.
     method: Option<Method>,
     h1_parser_config: ParserConfig,
-    #[cfg(all(feature = "server", feature = "runtime"))]
+    #[cfg(feature = "server")]
     h1_header_read_timeout: Option<Duration>,
-    #[cfg(all(feature = "server", feature = "runtime"))]
+    #[cfg(feature = "server")]
     h1_header_read_timeout_fut: Option<Pin<Box<dyn Sleep>>>,
-    #[cfg(all(feature = "server", feature = "runtime"))]
+    #[cfg(feature = "server")]
     h1_header_read_timeout_running: bool,
-    #[cfg(all(feature = "server", feature = "runtime"))]
+    #[cfg(feature = "server")]
     timer: Time,
     preserve_header_case: bool,
     #[cfg(feature = "ffi")]
@@ -1048,8 +1048,7 @@ mod tests {
 
         // an empty IO, we'll be skipping and using the read buffer anyways
         let io = tokio_test::io::Builder::new().build();
-        let mut conn =
-            Conn::<_, bytes::Bytes, crate::proto::h1::ServerTransaction>::new(io);
+        let mut conn = Conn::<_, bytes::Bytes, crate::proto::h1::ServerTransaction>::new(io);
         *conn.io.read_buf_mut() = ::bytes::BytesMut::from(&s[..]);
         conn.state.cached_headers = Some(HeaderMap::with_capacity(2));
 

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -95,7 +95,10 @@ impl Decoder {
     // methods
 
     pub(crate) fn is_eof(&self) -> bool {
-        matches!(self.kind, Length(0) | Chunked(ChunkedState::End, _) | Eof(true))
+        matches!(
+            self.kind,
+            Length(0) | Chunked(ChunkedState::End, _) | Eof(true)
+        )
     }
 
     pub(crate) fn decode<R: MemRead>(
@@ -471,6 +474,7 @@ mod tests {
     use crate::mock::AsyncIo;
     */
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn test_read_chunk_size() {
         use std::io::ErrorKind::{InvalidData, InvalidInput, UnexpectedEof};
@@ -553,6 +557,7 @@ mod tests {
         read_err("f0000000000000003\r\n", InvalidData).await;
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn test_read_sized_early_eof() {
         let mut bytes = &b"foo bar"[..];
@@ -562,6 +567,7 @@ mod tests {
         assert_eq!(e.kind(), io::ErrorKind::UnexpectedEof);
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn test_read_chunked_early_eof() {
         let mut bytes = &b"\
@@ -574,6 +580,7 @@ mod tests {
         assert_eq!(e.kind(), io::ErrorKind::UnexpectedEof);
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn test_read_chunked_single_read() {
         let mut mock_buf = &b"10\r\n1234567890abcdef\r\n0\r\n"[..];
@@ -586,6 +593,7 @@ mod tests {
         assert_eq!("1234567890abcdef", &result);
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn test_read_chunked_trailer_with_missing_lf() {
         let mut mock_buf = &b"10\r\n1234567890abcdef\r\n0\r\nbad\r\r\n"[..];
@@ -595,6 +603,7 @@ mod tests {
         assert_eq!(e.kind(), io::ErrorKind::InvalidInput);
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn test_read_chunked_after_eof() {
         let mut mock_buf = &b"10\r\n1234567890abcdef\r\n0\r\n\r\n"[..];
@@ -659,12 +668,14 @@ mod tests {
         }
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn test_read_length_async() {
         let content = "foobar";
         all_async_cases(content, content, Decoder::length(content.len() as u64)).await;
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn test_read_chunked_async() {
         let content = "3\r\nfoo\r\n3\r\nbar\r\n0\r\n\r\n";
@@ -672,13 +683,14 @@ mod tests {
         all_async_cases(content, expected, Decoder::chunked()).await;
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn test_read_eof_async() {
         let content = "foobar";
         all_async_cases(content, content, Decoder::eof()).await;
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(miri)))]
     #[bench]
     fn bench_decode_chunked_1kb(b: &mut test::Bencher) {
         let rt = new_runtime();
@@ -702,7 +714,7 @@ mod tests {
         });
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", not(miri)))]
     #[bench]
     fn bench_decode_length_1kb(b: &mut test::Bencher) {
         let rt = new_runtime();

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -6,7 +6,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::{debug, trace};
 
 use super::{Http1Transaction, Wants};
-use crate::body::{Recv, DecodedLength, Body};
+use crate::body::{Body, DecodedLength, Recv};
 use crate::common::{task, Future, Pin, Poll, Unpin};
 use crate::proto::{BodyLength, Conn, Dispatched, MessageHead, RequestHead};
 use crate::upgrade::OnUpgrade;
@@ -683,6 +683,7 @@ mod tests {
         });
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn client_flushing_is_not_ready_for_next_request() {
         let _ = pretty_env_logger::try_init();
@@ -706,10 +707,7 @@ mod tests {
             body
         };
 
-        let req = crate::Request::builder()
-            .method("POST")
-            .body(body)
-            .unwrap();
+        let req = crate::Request::builder().method("POST").body(body).unwrap();
 
         let res = tx.try_send(req).unwrap().await.expect("response");
         drop(res);
@@ -717,6 +715,7 @@ mod tests {
         assert!(!tx.is_ready());
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn body_empty_chunks_ignored() {
         let _ = pretty_env_logger::try_init();

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -705,6 +705,7 @@ mod tests {
         // io_buf.flush().await.expect("should short-circuit flush");
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn parse_reads_until_blocked() {
         use crate::proto::h1::ClientTransaction;
@@ -893,6 +894,7 @@ mod tests {
     }
     */
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn write_buf_flatten() {
         let _ = pretty_env_logger::try_init();
@@ -946,6 +948,7 @@ mod tests {
         assert_eq!(write_buf.headers.pos, 0);
     }
 
+    #[cfg(not(miri))]
     #[tokio::test]
     async fn write_buf_queue_disable_auto() {
         let _ = pretty_env_logger::try_init();

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 use std::fmt;
-#[cfg(all(feature = "server", feature = "runtime"))]
+#[cfg(feature = "server")]
 use std::future::Future;
 use std::io::{self, IoSlice};
 use std::marker::Unpin;
@@ -183,13 +183,13 @@ where
                     cached_headers: parse_ctx.cached_headers,
                     req_method: parse_ctx.req_method,
                     h1_parser_config: parse_ctx.h1_parser_config.clone(),
-                    #[cfg(all(feature = "server", feature = "runtime"))]
+                    #[cfg(feature = "server")]
                     h1_header_read_timeout: parse_ctx.h1_header_read_timeout,
-                    #[cfg(all(feature = "server", feature = "runtime"))]
+                    #[cfg(feature = "server")]
                     h1_header_read_timeout_fut: parse_ctx.h1_header_read_timeout_fut,
-                    #[cfg(all(feature = "server", feature = "runtime"))]
+                    #[cfg(feature = "server")]
                     h1_header_read_timeout_running: parse_ctx.h1_header_read_timeout_running,
-                    #[cfg(all(feature = "server", feature = "runtime"))]
+                    #[cfg(feature = "server")]
                     timer: parse_ctx.timer.clone(),
                     preserve_header_case: parse_ctx.preserve_header_case,
                     #[cfg(feature = "ffi")]
@@ -204,7 +204,7 @@ where
                 Some(msg) => {
                     debug!("parsed {} headers", msg.head.headers.len());
 
-                    #[cfg(all(feature = "server", feature = "runtime"))]
+                    #[cfg(feature = "server")]
                     {
                         *parse_ctx.h1_header_read_timeout_running = false;
                         parse_ctx.h1_header_read_timeout_fut.take();
@@ -218,7 +218,7 @@ where
                         return Poll::Ready(Err(crate::Error::new_too_large()));
                     }
 
-                    #[cfg(all(feature = "server", feature = "runtime"))]
+                    #[cfg(feature = "server")]
                     if *parse_ctx.h1_header_read_timeout_running {
                         if let Some(h1_header_read_timeout_fut) =
                             parse_ctx.h1_header_read_timeout_fut
@@ -727,13 +727,9 @@ mod tests {
                 cached_headers: &mut None,
                 req_method: &mut None,
                 h1_parser_config: Default::default(),
-                #[cfg(feature = "runtime")]
                 h1_header_read_timeout: None,
-                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_fut: &mut None,
-                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_running: &mut false,
-                #[cfg(feature = "runtime")]
                 timer: Time::Empty,
                 preserve_header_case: false,
                 #[cfg(feature = "ffi")]

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "server", feature = "runtime"))]
+#[cfg(feature = "server")]
 use std::{pin::Pin, time::Duration};
 
 use bytes::BytesMut;
@@ -6,10 +6,10 @@ use http::{HeaderMap, Method};
 use httparse::ParserConfig;
 
 use crate::body::DecodedLength;
-#[cfg(all(feature = "server", feature = "runtime"))]
+#[cfg(feature = "server")]
 use crate::common::time::Time;
 use crate::proto::{BodyLength, MessageHead};
-#[cfg(all(feature = "server", feature = "runtime"))]
+#[cfg(feature = "server")]
 use crate::rt::Sleep;
 
 pub(crate) use self::conn::Conn;
@@ -78,13 +78,13 @@ pub(crate) struct ParseContext<'a> {
     cached_headers: &'a mut Option<HeaderMap>,
     req_method: &'a mut Option<Method>,
     h1_parser_config: ParserConfig,
-    #[cfg(all(feature = "server", feature = "runtime"))]
+    #[cfg(feature = "server")]
     h1_header_read_timeout: Option<Duration>,
-    #[cfg(all(feature = "server", feature = "runtime"))]
+    #[cfg(feature = "server")]
     h1_header_read_timeout_fut: &'a mut Option<Pin<Box<dyn Sleep>>>,
-    #[cfg(all(feature = "server", feature = "runtime"))]
+    #[cfg(feature = "server")]
     h1_header_read_timeout_running: &'a mut bool,
-    #[cfg(all(feature = "server", feature = "runtime"))]
+    #[cfg(feature = "server")]
     timer: Time,
     preserve_header_case: bool,
     #[cfg(feature = "ffi")]

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Write};
 use std::mem::MaybeUninit;
-#[cfg(all(feature = "server", feature = "runtime"))]
+#[cfg(feature = "server")]
 use std::time::Instant;
 
 use bytes::Bytes;
@@ -75,7 +75,7 @@ where
     let span = trace_span!("parse_headers");
     let _s = span.enter();
 
-    #[cfg(all(feature = "server", feature = "runtime"))]
+    #[cfg(feature = "server")]
     if !*ctx.h1_header_read_timeout_running {
         if let Some(h1_header_read_timeout) = ctx.h1_header_read_timeout {
             let deadline = Instant::now() + h1_header_read_timeout;
@@ -1565,7 +1565,6 @@ fn extend(dst: &mut Vec<u8>, data: &[u8]) {
 mod tests {
     use bytes::BytesMut;
 
-    #[cfg(feature = "runtime")]
     use crate::common::time::Time;
 
     use super::*;
@@ -1581,13 +1580,9 @@ mod tests {
                 cached_headers: &mut None,
                 req_method: &mut method,
                 h1_parser_config: Default::default(),
-                #[cfg(feature = "runtime")]
                 h1_header_read_timeout: None,
-                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_fut: &mut None,
-                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_running: &mut false,
-                #[cfg(feature = "runtime")]
                 timer: Time::Empty,
                 preserve_header_case: false,
                 #[cfg(feature = "ffi")]
@@ -1618,13 +1613,9 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
-            #[cfg(feature = "runtime")]
             timer: Time::Empty,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1650,13 +1641,9 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut None,
             h1_parser_config: Default::default(),
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
-            #[cfg(feature = "runtime")]
             timer: Time::Empty,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1680,13 +1667,9 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
-            #[cfg(feature = "runtime")]
             timer: Time::Empty,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1712,13 +1695,9 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
-            #[cfg(feature = "runtime")]
             timer: Time::Empty,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1748,13 +1727,9 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
-            #[cfg(feature = "runtime")]
             timer: Time::Empty,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1781,13 +1756,9 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
-            #[cfg(feature = "runtime")]
             timer: Time::Empty,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1809,13 +1780,9 @@ mod tests {
             cached_headers: &mut None,
             req_method: &mut None,
             h1_parser_config: Default::default(),
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout: None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_fut: &mut None,
-            #[cfg(feature = "runtime")]
             h1_header_read_timeout_running: &mut false,
-            #[cfg(feature = "runtime")]
             timer: Time::Empty,
             preserve_header_case: true,
             #[cfg(feature = "ffi")]
@@ -1858,13 +1825,9 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
-                    #[cfg(feature = "runtime")]
                     timer: Time::Empty,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -1888,13 +1851,9 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
-                    #[cfg(feature = "runtime")]
                     timer: Time::Empty,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -2127,13 +2086,9 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut Some(Method::GET),
                     h1_parser_config: Default::default(),
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
-                    #[cfg(feature = "runtime")]
                     timer: Time::Empty,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -2157,13 +2112,9 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut Some(m),
                     h1_parser_config: Default::default(),
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
-                    #[cfg(feature = "runtime")]
                     timer: Time::Empty,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -2187,13 +2138,9 @@ mod tests {
                     cached_headers: &mut None,
                     req_method: &mut Some(Method::GET),
                     h1_parser_config: Default::default(),
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
-                    #[cfg(feature = "runtime")]
                     timer: Time::Empty,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -2712,13 +2659,9 @@ mod tests {
                 cached_headers: &mut None,
                 req_method: &mut Some(Method::GET),
                 h1_parser_config: Default::default(),
-                #[cfg(feature = "runtime")]
                 h1_header_read_timeout: None,
-                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_fut: &mut None,
-                #[cfg(feature = "runtime")]
                 h1_header_read_timeout_running: &mut false,
-                #[cfg(feature = "runtime")]
                 timer: Time::Empty,
                 preserve_header_case: false,
                 #[cfg(feature = "ffi")]
@@ -2806,13 +2749,9 @@ mod tests {
                     cached_headers: &mut headers,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
-                    #[cfg(feature = "runtime")]
                     timer: Time::Empty,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -2856,13 +2795,9 @@ mod tests {
                     cached_headers: &mut headers,
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout: None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_fut: &mut None,
-                    #[cfg(feature = "runtime")]
                     h1_header_read_timeout_running: &mut false,
-                    #[cfg(feature = "runtime")]
                     timer: Time::Empty,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -1,5 +1,4 @@
 use std::error::Error as StdError;
-#[cfg(feature = "runtime")]
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -46,11 +45,8 @@ pub(crate) struct Config {
     pub(crate) initial_conn_window_size: u32,
     pub(crate) initial_stream_window_size: u32,
     pub(crate) max_frame_size: u32,
-    #[cfg(feature = "runtime")]
     pub(crate) keep_alive_interval: Option<Duration>,
-    #[cfg(feature = "runtime")]
     pub(crate) keep_alive_timeout: Duration,
-    #[cfg(feature = "runtime")]
     pub(crate) keep_alive_while_idle: bool,
     pub(crate) max_concurrent_reset_streams: Option<usize>,
     pub(crate) max_send_buffer_size: usize,
@@ -63,11 +59,8 @@ impl Default for Config {
             initial_conn_window_size: DEFAULT_CONN_WINDOW,
             initial_stream_window_size: DEFAULT_STREAM_WINDOW,
             max_frame_size: DEFAULT_MAX_FRAME_SIZE,
-            #[cfg(feature = "runtime")]
             keep_alive_interval: None,
-            #[cfg(feature = "runtime")]
             keep_alive_timeout: Duration::from_secs(20),
-            #[cfg(feature = "runtime")]
             keep_alive_while_idle: false,
             max_concurrent_reset_streams: None,
             max_send_buffer_size: DEFAULT_MAX_SEND_BUF_SIZE,
@@ -96,11 +89,8 @@ fn new_ping_config(config: &Config) -> ping::Config {
         } else {
             None
         },
-        #[cfg(feature = "runtime")]
         keep_alive_interval: config.keep_alive_interval,
-        #[cfg(feature = "runtime")]
         keep_alive_timeout: config.keep_alive_timeout,
-        #[cfg(feature = "runtime")]
         keep_alive_while_idle: config.keep_alive_while_idle,
     }
 }
@@ -147,7 +137,6 @@ where
                     conn.set_target_window_size(wnd);
                     conn.set_initial_window_size(wnd)?;
                 }
-                #[cfg(feature = "runtime")]
                 Poll::Ready(ping::Ponged::KeepAliveTimedOut) => {
                     debug!("connection keep-alive timed out");
                     return Poll::Ready(Ok(()));

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -1,6 +1,6 @@
 use std::error::Error as StdError;
 use std::marker::Unpin;
-#[cfg(feature = "runtime")]
+
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -47,9 +47,7 @@ pub(crate) struct Config {
     pub(crate) max_frame_size: u32,
     pub(crate) enable_connect_protocol: bool,
     pub(crate) max_concurrent_streams: Option<u32>,
-    #[cfg(feature = "runtime")]
     pub(crate) keep_alive_interval: Option<Duration>,
-    #[cfg(feature = "runtime")]
     pub(crate) keep_alive_timeout: Duration,
     pub(crate) max_send_buffer_size: usize,
     pub(crate) max_header_list_size: u32,
@@ -64,9 +62,7 @@ impl Default for Config {
             max_frame_size: DEFAULT_MAX_FRAME_SIZE,
             enable_connect_protocol: false,
             max_concurrent_streams: None,
-            #[cfg(feature = "runtime")]
             keep_alive_interval: None,
-            #[cfg(feature = "runtime")]
             keep_alive_timeout: Duration::from_secs(20),
             max_send_buffer_size: DEFAULT_MAX_SEND_BUF_SIZE,
             max_header_list_size: DEFAULT_SETTINGS_MAX_HEADER_LIST_SIZE,
@@ -146,13 +142,10 @@ where
 
         let ping_config = ping::Config {
             bdp_initial_window: bdp,
-            #[cfg(feature = "runtime")]
             keep_alive_interval: config.keep_alive_interval,
-            #[cfg(feature = "runtime")]
             keep_alive_timeout: config.keep_alive_timeout,
             // If keep-alive is enabled for servers, always enabled while
             // idle, so it can more aggressively close dead connections.
-            #[cfg(feature = "runtime")]
             keep_alive_while_idle: true,
         };
 
@@ -208,11 +201,7 @@ where
                     let mut conn = ready!(Pin::new(hs).poll(cx).map_err(crate::Error::new_h2))?;
                     let ping = if ping_config.is_enabled() {
                         let pp = conn.ping_pong().expect("conn.ping_pong");
-                        Some(ping::channel(
-                            pp,
-                            ping_config.clone(),
-                            me.timer.clone(),
-                        ))
+                        Some(ping::channel(pp, ping_config.clone(), me.timer.clone()))
                     } else {
                         None
                     };
@@ -371,7 +360,6 @@ where
                     self.conn.set_target_window_size(wnd);
                     let _ = self.conn.set_initial_window_size(wnd);
                 }
-                #[cfg(feature = "runtime")]
                 Poll::Ready(ping::Ponged::KeepAliveTimedOut) => {
                     debug!("keep-alive timed out, closing connection");
                     self.conn.abrupt_shutdown(h2::Reason::NO_ERROR);

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -8,7 +8,7 @@
 //! ## Example
 //! A simple example that uses the `Http` struct to talk HTTP over a Tokio TCP stream
 //! ```no_run
-//! # #[cfg(all(feature = "http1", feature = "runtime"))]
+//! # #[cfg(feature = "http1")]
 //! # mod rt {
 //! use http::{Request, Response, StatusCode};
 //! use http_body_util::Full;
@@ -47,7 +47,7 @@
 ))]
 use std::marker::PhantomData;
 use std::sync::Arc;
-#[cfg(all(any(feature = "http1", feature = "http2"), feature = "runtime"))]
+#[cfg(any(feature = "http1", feature = "http2"))]
 use std::time::Duration;
 
 #[cfg(feature = "http2")]
@@ -93,7 +93,7 @@ pub struct Http<E = Exec> {
     h1_keep_alive: bool,
     h1_title_case_headers: bool,
     h1_preserve_header_case: bool,
-    #[cfg(all(feature = "http1", feature = "runtime"))]
+    #[cfg(feature = "http1")]
     h1_header_read_timeout: Option<Duration>,
     h1_writev: Option<bool>,
     #[cfg(feature = "http2")]
@@ -233,7 +233,7 @@ impl Http {
             h1_keep_alive: true,
             h1_title_case_headers: false,
             h1_preserve_header_case: false,
-            #[cfg(all(feature = "http1", feature = "runtime"))]
+            #[cfg(feature = "http1")]
             h1_header_read_timeout: None,
             h1_writev: None,
             #[cfg(feature = "http2")]
@@ -326,8 +326,8 @@ impl<E> Http<E> {
     /// transmit the entire header within this time, the connection is closed.
     ///
     /// Default is None.
-    #[cfg(all(feature = "http1", feature = "runtime"))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "http1", feature = "runtime"))))]
+    #[cfg(feature = "http1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
     pub fn http1_header_read_timeout(&mut self, read_timeout: Duration) -> &mut Self {
         self.h1_header_read_timeout = Some(read_timeout);
         self
@@ -460,8 +460,6 @@ impl<E> Http<E> {
     ///
     /// # Cargo Feature
     ///
-    /// Requires the `runtime` cargo feature to be enabled.
-    #[cfg(feature = "runtime")]
     #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_interval(
@@ -481,8 +479,6 @@ impl<E> Http<E> {
     ///
     /// # Cargo Feature
     ///
-    /// Requires the `runtime` cargo feature to be enabled.
-    #[cfg(feature = "runtime")]
     #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
     pub fn http2_keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
@@ -563,7 +559,7 @@ impl<E> Http<E> {
             h1_keep_alive: self.h1_keep_alive,
             h1_title_case_headers: self.h1_title_case_headers,
             h1_preserve_header_case: self.h1_preserve_header_case,
-            #[cfg(all(feature = "http1", feature = "runtime"))]
+            #[cfg(feature = "http1")]
             h1_header_read_timeout: self.h1_header_read_timeout,
             h1_writev: self.h1_writev,
             #[cfg(feature = "http2")]
@@ -586,7 +582,7 @@ impl<E> Http<E> {
             h1_keep_alive: self.h1_keep_alive,
             h1_title_case_headers: self.h1_title_case_headers,
             h1_preserve_header_case: self.h1_preserve_header_case,
-            #[cfg(all(feature = "http1", feature = "runtime"))]
+            #[cfg(feature = "http1")]
             h1_header_read_timeout: self.h1_header_read_timeout,
             h1_writev: self.h1_writev,
             #[cfg(feature = "http2")]
@@ -638,7 +634,6 @@ impl<E> Http<E> {
         macro_rules! h1 {
             () => {{
                 let mut conn = proto::Conn::new(io);
-                #[cfg(feature = "runtime")]
                 {
                     conn.set_timer(self.timer.clone());
                 }
@@ -654,7 +649,7 @@ impl<E> Http<E> {
                 if self.h1_preserve_header_case {
                     conn.set_preserve_header_case();
                 }
-                #[cfg(all(feature = "http1", feature = "runtime"))]
+                #[cfg(feature = "http1")]
                 if let Some(header_read_timeout) = self.h1_header_read_timeout {
                     conn.set_http1_header_read_timeout(header_read_timeout);
                 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1348,7 +1348,7 @@ mod conn {
 
     use super::{concat, s, support, tcp_connect, FutureHyperExt};
 
-    use support::TokioTimer;
+    use support::{TokioExecutor, TokioTimer};
 
     #[tokio::test]
     async fn get() {
@@ -1901,7 +1901,7 @@ mod conn {
 
                         let mut shdn_rx = shdn_rx.clone();
                         tokio::task::spawn(async move {
-                            let mut conn = Http::new().http2_only(true).serve_connection(stream, service);
+                            let mut conn = Http::new().with_executor(TokioExecutor).http2_only(true).serve_connection(stream, service);
 
                             tokio::select! {
                                 res = &mut conn => {
@@ -1923,6 +1923,7 @@ mod conn {
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
         let (mut client, conn) = conn::Builder::new()
+            .executor(TokioExecutor)
             .http2_only(true)
             .handshake(io)
             .await
@@ -1985,6 +1986,7 @@ mod conn {
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
         let (_client, conn) = conn::Builder::new()
+            .executor(TokioExecutor)
             .timer(TokioTimer)
             .http2_only(true)
             .http2_keep_alive_interval(Duration::from_secs(1))
@@ -2019,6 +2021,7 @@ mod conn {
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
         let (mut client, conn) = conn::Builder::new()
+            .executor(TokioExecutor)
             .timer(TokioTimer)
             .http2_only(true)
             .http2_keep_alive_interval(Duration::from_secs(1))
@@ -2056,6 +2059,7 @@ mod conn {
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
         let (mut client, conn) = conn::Builder::new()
+            .executor(TokioExecutor)
             .timer(TokioTimer)
             .http2_only(true)
             .http2_keep_alive_interval(Duration::from_secs(1))
@@ -2103,6 +2107,7 @@ mod conn {
         tokio::spawn(async move {
             let sock = listener.accept().await.unwrap().0;
             hyper::server::conn::Http::new()
+                .with_executor(TokioExecutor)
                 .with_timer(TokioTimer)
                 .http2_only(true)
                 .serve_connection(
@@ -2122,6 +2127,7 @@ mod conn {
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
         let (mut client, conn) = conn::Builder::new()
+            .executor(TokioExecutor)
             .timer(TokioTimer)
             .http2_only(true)
             .http2_keep_alive_interval(Duration::from_secs(1))
@@ -2183,6 +2189,7 @@ mod conn {
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
         let (mut client, conn) = conn::Builder::new()
+            .executor(TokioExecutor)
             .http2_only(true)
             .handshake(io)
             .await
@@ -2239,6 +2246,7 @@ mod conn {
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
         let (mut client, conn) = conn::Builder::new()
+            .executor(TokioExecutor)
             .http2_only(true)
             .handshake::<_, Empty<Bytes>>(io)
             .await

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -22,7 +22,7 @@ use h2::{RecvStream, SendStream};
 use http::header::{HeaderName, HeaderValue};
 use http_body_util::{combinators::BoxBody, BodyExt, Empty, Full, StreamBody};
 use hyper::rt::Timer;
-use support::TokioTimer;
+use support::{TokioExecutor, TokioTimer};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener as TkTcpListener, TcpListener, TcpStream as TkTcpStream};
@@ -1820,6 +1820,7 @@ async fn h2_connect() {
 
     let (socket, _) = listener.accept().await.unwrap();
     Http::new()
+        .with_executor(TokioExecutor)
         .http2_only(true)
         .serve_connection(socket, svc)
         .with_upgrades()
@@ -1932,6 +1933,7 @@ async fn h2_connect_multiplex() {
 
     let (socket, _) = listener.accept().await.unwrap();
     Http::new()
+        .with_executor(TokioExecutor)
         .http2_only(true)
         .serve_connection(socket, svc)
         .with_upgrades()
@@ -2007,6 +2009,7 @@ async fn h2_connect_large_body() {
 
     let (socket, _) = listener.accept().await.unwrap();
     Http::new()
+        .with_executor(TokioExecutor)
         .http2_only(true)
         .serve_connection(socket, svc)
         .with_upgrades()
@@ -2079,6 +2082,7 @@ async fn h2_connect_empty_frames() {
 
     let (socket, _) = listener.accept().await.unwrap();
     Http::new()
+        .with_executor(TokioExecutor)
         .http2_only(true)
         .serve_connection(socket, svc)
         .with_upgrades()
@@ -2513,6 +2517,7 @@ async fn http2_keep_alive_with_responsive_client() {
         let (socket, _) = listener.accept().await.expect("accept");
 
         Http::new()
+            .with_executor(TokioExecutor)
             .with_timer(TokioTimer)
             .http2_only(true)
             .http2_keep_alive_interval(Duration::from_secs(1))
@@ -2524,6 +2529,7 @@ async fn http2_keep_alive_with_responsive_client() {
 
     let tcp = connect_async(addr).await;
     let (mut client, conn) = hyper::client::conn::Builder::new()
+        .executor(TokioExecutor)
         .http2_only(true)
         .handshake(tcp)
         .await
@@ -2968,7 +2974,7 @@ impl ServeOptions {
                                 let (stream, _) = res.unwrap();
 
                                 tokio::task::spawn(async move {
-                                    let mut http = Http::new();
+                                    let mut http = Http::new().with_executor(TokioExecutor);
 
                                     #[cfg(feature = "http1")]
                                     let http = http
@@ -3152,6 +3158,7 @@ impl TestClient {
 
         let mut builder = hyper::client::conn::Builder::new();
         builder.http2_only(self.http2_only);
+        builder.executor(TokioExecutor);
 
         let stream = TkTcpStream::connect(format!("{}:{}", host, port))
             .await


### PR DESCRIPTION
This removes the `runtime` cargo feature flag. 

Removing tokio as a opt-in runtime means the `common::exec::Exec::Default` variant will always panic. This should be refactored in a follow-up PR/issue, so that the user must always provide an executor (ref discussion in review comment). 

Closes #2857 