### PR TITLE
Add example for to_bytes and trailers

### DIFF
--- a/src/body/to_bytes.rs
+++ b/src/body/to_bytes.rs
@@ -14,6 +14,23 @@ use super::Body;
 /// checks and an malicious peer might make it consume arbitrary amounts of memory. Checking the
 /// `Content-Length` is a possibility, but it is not strictly mandated to be present.
 ///
+/// Trailers are ignored by this function. If you need to handle them, you can use this function
+/// without consuming the body, and then extract trailers afterwards.
+///
+/// ```
+/// # use hyper::{Recv, Response};
+/// # async fn doc(response: Response<Recv>) -> hyper::Result<()> {
+/// # use hyper::body::Body;
+///
+/// let mut body = response.into_body();
+///
+/// let data = hyper::body::to_bytes(&mut body).await?;
+/// let trailers = body.trailers().await?;
+///
+/// # Ok(())
+/// # }
+/// ```
+///
 /// # Example
 ///
 /// ```


### PR DESCRIPTION
It is not obvious how to deal with trailers, especially since in most
cases the body gets consumed by a call to `to_bytes`, even though it is
perfectly fine to call that on a mutable reference to the body, and then
extract the trailers aftewards.

