### PR TITLE
examples: add an MPTCP using Socket2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,8 @@ ffi = ["libc"]
 nightly = []
 __internal_happy_eyeballs_tests = []
 
+mptcp = ["socket2"]
+
 [package.metadata.docs.rs]
 features = ["ffi", "full"]
 rustdoc-args = ["--cfg", "docsrs", "--cfg", "hyper_unstable_ffi"]
@@ -147,6 +149,11 @@ required-features = ["full"]
 name = "http_proxy"
 path = "examples/http_proxy.rs"
 required-features = ["full"]
+
+[[example]]
+name = "mptcp"
+path = "examples/mptcp.rs"
+required-features = ["full", "mptcp"]
 
 [[example]]
 name = "multi_server"

--- a/examples/mptcp.rs
+++ b/examples/mptcp.rs
@@ -1,0 +1,67 @@
+//! MPTCP is a new protocol added in the Linux Kernel since 5.6.
+//! The goal of MPTCP is to support multiple path (cf: ADSL & LTE).
+//! This allow for aggregation of links's bandwidth and for resiliency
+//! if any of the link fails.
+//! Even if MPTCP is added in the Linux Kernel since 5.6, you may
+//! still need to enable it manually using:
+//! `sysctl net.mptcp.enabled=1`
+//! After that your host should be compatible with MPTCP.
+//!
+//! Note: a socket running with MPTCP is still compatible with TCP.
+#![deny(warnings)]
+
+use std::convert::Infallible;
+use std::net::SocketAddr;
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper::server::conn::Http;
+use hyper::service::service_fn;
+use hyper::{Recv, Request, Response};
+use socket2::{Domain, Protocol, Socket, Type};
+use tokio::net::TcpSocket;
+
+async fn hello(_: Request<Recv>) -> Result<Response<Full<Bytes>>, Infallible> {
+    Ok(Response::new(Full::new(Bytes::from("Hello MPTCP!"))))
+}
+
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    pretty_env_logger::init();
+
+    let addr: SocketAddr = ([127, 0, 0, 1], 3000).into();
+
+    // Create the MPTCP capable socket but allow for a fallback to TCP if the host
+    // does not support MPTCP.
+    let socket = match Socket::new(
+        Domain::for_address(addr),
+        Type::STREAM,
+        Some(Protocol::MPTCP),
+    ) {
+        Ok(sock) => sock,
+        Err(_) => {
+            println!("The host does not support MPTCP, fallback to TCP");
+            Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP))?
+        }
+    };
+    // Set common options on the socket as we created it by hand.
+    socket.set_nonblocking(true)?;
+    socket.set_reuse_address(true)?;
+    socket.bind(&addr.into())?;
+
+    // Transform our Socket2 into a TcpSocket->TcpListener (tokio::net)
+    let listener = TcpSocket::from_std_stream(socket.into()).listen(1024)?;
+    println!("Listening on http://{}", addr);
+    loop {
+        let (stream, _) = listener.accept().await?;
+
+        tokio::task::spawn(async move {
+            if let Err(err) = Http::new()
+                .serve_connection(stream, service_fn(hello))
+                .await
+            {
+                println!("Error serving connection: {:?}", err);
+            }
+        });
+    }
+}


### PR DESCRIPTION
Show how one can easily create an MPTCP capable webserver using Socket2.

---

MPTCP is a new protocol added in the Linux Kernel since 5.6. The goal of MPTCP is to support multiple path (cf: ADSL & LTE).
This allow for aggregation of links's bandwidth and for resiliency if any of the link fails.

Even if MPTCP is added in the Linux Kernel since 5.6, you may still need to enable it manually using:
```
sysctl net.mptcp.enabled=1
```

Signed-off-by: Martin Andre <martin.andre@tessares.net>