### PR TITLE
0.14.x

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -6,6 +6,7 @@ use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::time::Duration;
 
 use pin_project_lite::pin_project;
+use socket2::TcpKeepalive;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::trace;
 
@@ -564,8 +565,16 @@ impl<E> Builder<AddrIncoming, E> {
     /// If `None` is specified, keepalive is disabled, otherwise the duration
     /// specified will be the time to remain idle before sending TCP keepalive
     /// probes.
+    #[deprecated(since="0.14.21", note="please use `tcp_keepalive2` instead")]
     pub fn tcp_keepalive(mut self, keepalive: Option<Duration>) -> Self {
+        #[allow(deprecated)]
         self.incoming.set_keepalive(keepalive);
+        self
+    }
+
+    /// Set TCP keepalive parameters on accepted connections.
+    pub fn tcp_keepalive2(mut self, tcp_keepalive: TcpKeepalive) -> Self {
+        self.incoming.set_tcp_keepalive(tcp_keepalive);
         self
     }
 

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -573,7 +573,7 @@ impl<E> Builder<AddrIncoming, E> {
     }
 
     /// Set TCP keepalive parameters on accepted connections.
-    pub fn tcp_keepalive2(mut self, tcp_keepalive: TcpKeepalive) -> Self {
+    pub fn tcp_keepalive2(mut self, tcp_keepalive: Option<TcpKeepalive>) -> Self {
         self.incoming.set_tcp_keepalive(tcp_keepalive);
         self
     }


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Keepalive#HTTP_keepalive, TCP Keepalive has three parameters:
*  `Keepalive time` is the duration between two keepalive transmissions in idle condition. TCP keepalive period is required to be configurable and by default is set to no less than 2 hours.
* `Keepalive interval` is the duration between two successive keepalive retransmissions, if acknowledgement to the previous keepalive transmission is not received.
* `Keepalive retry` is the number of retransmissions to be carried out before declaring that remote end is not available

Currently, however, only the first  parameter `Keepalive time` is configurable in hyper.

This CR is a proposed enhancement for a backward compatible change on the `0.14.x` branch such that so that all the three TCP Keepalive parameters become configurable.  (In this PR, the next release is assumed to be `0.14.21`, but can easily adjust the proposed deprecation message if that was not the case.)