### PR TITLE
Supports configuration of all TCP Keepalive parameters per  https://en.wikipedia.org/wiki/Keepalive

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -2,10 +2,15 @@ use std::error::Error as StdError;
 use std::fmt;
 #[cfg(feature = "tcp")]
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
-#[cfg(any(feature = "tcp", feature = "http1"))]
+
+#[cfg(feature = "tcp")]
 use std::time::Duration;
 
 use pin_project_lite::pin_project;
+
+#[cfg(feature = "tcp")]
+use crate::socket2::TcpKeepalive;
+
 use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::trace;
 
@@ -564,8 +569,16 @@ impl<E> Builder<AddrIncoming, E> {
     /// If `None` is specified, keepalive is disabled, otherwise the duration
     /// specified will be the time to remain idle before sending TCP keepalive
     /// probes.
+    #[deprecated(since="0.14.21", note="please use `tcp_keepalive2` instead")]
     pub fn tcp_keepalive(mut self, keepalive: Option<Duration>) -> Self {
+        #[allow(deprecated)]
         self.incoming.set_keepalive(keepalive);
+        self
+    }
+
+    /// Set TCP keepalive parameters on accepted connections.
+    pub fn tcp_keepalive2(mut self, tcp_keepalive: Option<TcpKeepalive>) -> Self {
+        self.incoming.set_tcp_keepalive(tcp_keepalive);
         self
     }
 

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::io;
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::time::Duration;
+use socket2::TcpKeepalive;
 
 use tokio::net::TcpListener;
 use tokio::time::Sleep;
@@ -19,7 +20,7 @@ pub struct AddrIncoming {
     addr: SocketAddr,
     listener: TcpListener,
     sleep_on_errors: bool,
-    tcp_keepalive_timeout: Option<Duration>,
+    tcp_keepalive: Option<TcpKeepalive>,
     tcp_nodelay: bool,
     timeout: Option<Pin<Box<Sleep>>>,
 }
@@ -52,7 +53,7 @@ impl AddrIncoming {
             listener,
             addr,
             sleep_on_errors: true,
-            tcp_keepalive_timeout: None,
+            tcp_keepalive: None,
             tcp_nodelay: false,
             timeout: None,
         })
@@ -68,8 +69,19 @@ impl AddrIncoming {
     /// If `None` is specified, keepalive is disabled, otherwise the duration
     /// specified will be the time to remain idle before sending TCP keepalive
     /// probes.
+    #[deprecated(since="0.14.21", note="please use `set_tcp_keepalive` instead")]
     pub fn set_keepalive(&mut self, keepalive: Option<Duration>) -> &mut Self {
-        self.tcp_keepalive_timeout = keepalive;
+        self.tcp_keepalive = keepalive.map(|duration| {
+            TcpKeepalive::new().with_time(duration)
+        });
+        self
+    }
+
+    /// Set whether TCP keepalive messages are enabled on accepted connections.
+    ///
+    /// If `None` is specified, keepalive is disabled.
+    pub fn set_tcp_keepalive(&mut self, tcp_keepalive: Option<TcpKeepalive>) -> &mut Self {
+        self.tcp_keepalive = tcp_keepalive;
         self
     }
 
@@ -108,10 +120,9 @@ impl AddrIncoming {
         loop {
             match ready!(self.listener.poll_accept(cx)) {
                 Ok((socket, remote_addr)) => {
-                    if let Some(dur) = self.tcp_keepalive_timeout {
-                        let socket = socket2::SockRef::from(&socket);
-                        let conf = socket2::TcpKeepalive::new().with_time(dur);
-                        if let Err(e) = socket.set_tcp_keepalive(&conf) {
+                    if let Some(tcp_keepalive) = &self.tcp_keepalive {
+                        let sock_ref = socket2::SockRef::from(&socket);
+                        if let Err(e) = sock_ref.set_tcp_keepalive(tcp_keepalive) {
                             trace!("error trying to set TCP keepalive: {}", e);
                         }
                     }
@@ -188,7 +199,7 @@ impl fmt::Debug for AddrIncoming {
         f.debug_struct("AddrIncoming")
             .field("addr", &self.addr)
             .field("sleep_on_errors", &self.sleep_on_errors)
-            .field("tcp_keepalive_timeout", &self.tcp_keepalive_timeout)
+            .field("tcp_keepalive", &self.tcp_keepalive)
             .field("tcp_nodelay", &self.tcp_nodelay)
             .finish()
     }


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Keepalive, TCP Keepalive has three parameters:
*  `Keepalive time` is the duration between two keepalive transmissions in idle condition. TCP keepalive period is required to be configurable and by default is set to no less than 2 hours.
* `Keepalive interval` is the duration between two successive keepalive retransmissions, if acknowledgement to the previous keepalive transmission is not received.
* `Keepalive retry` is the number of retransmissions to be carried out before declaring that remote end is not available

Currently, however, only the first  parameter `Keepalive time` is configurable in hyper.

This CR is a proposed enhancement for a backward compatible change on the `0.14.x` branch such that so that all the three TCP Keepalive parameters become configurable.  (In this PR, the next release is assumed to be `0.14.21`, but can easily adjust the proposed deprecation message if that was not the case.)