### PR TITLE
Use stable rust for building C API

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -182,7 +182,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
 
       - name: Install cbindgen
@@ -197,7 +197,7 @@ jobs:
           RUSTFLAGS: --cfg hyper_unstable_ffi
         with:
           command: rustc
-          args: --features client,http1,http2,ffi -Z unstable-options --crate-type cdylib
+          args: --features client,http1,http2,ffi --crate-type cdylib
 
       - name: Make Examples
         run: cd capi/examples && make client

--- a/capi/README.md
+++ b/capi/README.md
@@ -10,8 +10,8 @@ Because of that, it's only accessible if `--cfg hyper_unstable_ffi` is passed to
 
 ## Building
 
-The C API is part of the Rust library, but isn't compiled by default. Using a nightly release of `cargo`, starting with `nightly-2022-03-02`, it can be compiled with the following command:
+The C API is part of the Rust library, but isn't compiled by default. Using `cargo`, staring with `1.64.0`, it can be compiled with the following command:
 
 ```
-RUSTFLAGS="--cfg hyper_unstable_ffi" cargo +nightly rustc --features client,http1,http2,ffi -Z unstable-options --crate-type cdylib
+RUSTFLAGS="--cfg hyper_unstable_ffi" cargo rustc --features client,http1,http2,ffi --crate-type cdylib
 ```

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -22,10 +22,10 @@
 //! ## Building
 //!
 //! The C API is part of the Rust library, but isn't compiled by default. Using
-//! `cargo`, it can be compiled with the following command:
+//! `cargo`, staring with `1.64.0`, it can be compiled with the following command:
 //!
 //! ```notrust
-//! RUSTFLAGS="--cfg hyper_unstable_ffi" cargo build --features client,http1,http2,ffi
+//! RUSTFLAGS="--cfg hyper_unstable_ffi" cargo rustc --features client,http1,http2,ffi --crate-type cdylib
 //! ```
 
 // We may eventually allow the FFI to be enabled without `client` or `http1`,


### PR DESCRIPTION
Rust 1.64.0 stabilizes `cargo rustc --crate-type`, so hyper can use stable instead.