### PR TITLE
refactor(examples): extract `Http::new` outside loops

### DIFF
--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -44,9 +44,9 @@ fn hello_world_16(b: &mut test::Bencher) {
                     let (stream, _addr) = listener.accept().await.expect("accept");
                     http.serve_connection(
                         stream,
-                        service_fn(|_| async {
-                            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(
-                                "Hello, World!",
+                        service_fn(|_| {
+                            std::future::ready(Ok::<_, Infallible>(Response::new(Full::new(
+                                Bytes::from("Hello, World!"),
                             ))))
                         }),
                     )

--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -37,22 +37,21 @@ fn hello_world_16(b: &mut test::Bencher) {
             let listener = rt.block_on(TcpListener::bind(addr)).unwrap();
             let addr = listener.local_addr().unwrap();
 
+            let mut http = Http::new();
+            http.pipeline_flush(true);
             rt.spawn(async move {
                 loop {
                     let (stream, _addr) = listener.accept().await.expect("accept");
-
-                    Http::new()
-                        .pipeline_flush(true)
-                        .serve_connection(
-                            stream,
-                            service_fn(|_| async {
-                                Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(
-                                    "Hello, World!",
-                                ))))
-                            }),
-                        )
-                        .await
-                        .unwrap();
+                    http.serve_connection(
+                        stream,
+                        service_fn(|_| async {
+                            Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(
+                                "Hello, World!",
+                            ))))
+                        }),
+                    )
+                    .await
+                    .unwrap();
                 }
             });
 

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -34,25 +34,24 @@ macro_rules! bench_server {
                 let listener = rt.block_on(tokio::net::TcpListener::bind(addr)).unwrap();
                 let addr = listener.local_addr().unwrap();
 
+                let http = Http::new();
                 rt.spawn(async move {
                     loop {
                         let (stream, _) = listener.accept().await.expect("accept");
-
-                        Http::new()
-                            .serve_connection(
-                                stream,
-                                service_fn(|_| async {
-                                    Ok::<_, hyper::Error>(
-                                        Response::builder()
-                                            .header($header.0, $header.1)
-                                            .header("content-type", "text/plain")
-                                            .body($body())
-                                            .unwrap(),
-                                    )
-                                }),
-                            )
-                            .await
-                            .unwrap();
+                        http.serve_connection(
+                            stream,
+                            service_fn(|_| async {
+                                Ok::<_, hyper::Error>(
+                                    Response::builder()
+                                        .header($header.0, $header.1)
+                                        .header("content-type", "text/plain")
+                                        .body($body())
+                                        .unwrap(),
+                                )
+                            }),
+                        )
+                        .await
+                        .unwrap();
                     }
                 });
 

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -40,14 +40,14 @@ macro_rules! bench_server {
                         let (stream, _) = listener.accept().await.expect("accept");
                         http.serve_connection(
                             stream,
-                            service_fn(|_| async {
-                                Ok::<_, hyper::Error>(
+                            service_fn(|_| {
+                                std::future::ready(Ok::<_, hyper::Error>(
                                     Response::builder()
                                         .header($header.0, $header.1)
                                         .header("content-type", "text/plain")
                                         .body($body())
                                         .unwrap(),
-                                )
+                                ))
                             }),
                         )
                         .await

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -83,11 +83,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let listener = TcpListener::bind(addr).await?;
     println!("Listening on http://{}", addr);
+
+    let http = Http::new();
     loop {
         let (stream, _) = listener.accept().await?;
-
+        let future = http.serve_connection(stream, service_fn(echo));
         tokio::task::spawn(async move {
-            if let Err(err) = Http::new().serve_connection(stream, service_fn(echo)).await {
+            if let Err(err) = future.await {
                 println!("Error serving connection: {:?}", err);
             }
         });

--- a/examples/gateway.rs
+++ b/examples/gateway.rs
@@ -18,6 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Listening on http://{}", in_addr);
     println!("Proxying on http://{}", out_addr);
 
+    let http = Http::new();
     loop {
         let (stream, _) = listener.accept().await?;
 
@@ -55,8 +56,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         });
 
+        let future = http.serve_connection(stream, service);
         tokio::task::spawn(async move {
-            if let Err(err) = Http::new().serve_connection(stream, service).await {
+            if let Err(err) = future.await {
                 println!("Failed to servce connection: {:?}", err);
             }
         });

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -22,14 +22,13 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let listener = TcpListener::bind(addr).await?;
     println!("Listening on http://{}", addr);
+
+    let http = Http::new();
     loop {
         let (stream, _) = listener.accept().await?;
-
+        let future = http.serve_connection(stream, service_fn(hello));
         tokio::task::spawn(async move {
-            if let Err(err) = Http::new()
-                .serve_connection(stream, service_fn(hello))
-                .await
-            {
+            if let Err(err) = future.await {
                 println!("Error serving connection: {:?}", err);
             }
         });

--- a/examples/multi_server.rs
+++ b/examples/multi_server.rs
@@ -28,33 +28,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let addr1: SocketAddr = ([127, 0, 0, 1], 1337).into();
     let addr2: SocketAddr = ([127, 0, 0, 1], 1338).into();
+    let http = Http::new();
 
-    let srv1 = async move {
+    let srv1 = async {
         let listener = TcpListener::bind(addr1).await.unwrap();
         loop {
             let (stream, _) = listener.accept().await.unwrap();
-
+            let future = http.serve_connection(stream, service_fn(index1));
             tokio::task::spawn(async move {
-                if let Err(err) = Http::new()
-                    .serve_connection(stream, service_fn(index1))
-                    .await
-                {
+                if let Err(err) = future.await {
                     println!("Error serving connection: {:?}", err);
                 }
             });
         }
     };
 
-    let srv2 = async move {
+    let srv2 = async {
         let listener = TcpListener::bind(addr2).await.unwrap();
         loop {
             let (stream, _) = listener.accept().await.unwrap();
-
+            let future = http.serve_connection(stream, service_fn(index2));
             tokio::task::spawn(async move {
-                if let Err(err) = Http::new()
-                    .serve_connection(stream, service_fn(index2))
-                    .await
-                {
+                if let Err(err) = future.await {
                     println!("Error serving connection: {:?}", err);
                 }
             });

--- a/examples/params.rs
+++ b/examples/params.rs
@@ -122,14 +122,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let listener = TcpListener::bind(addr).await?;
     println!("Listening on http://{}", addr);
+
+    let http = Http::new();
     loop {
         let (stream, _) = listener.accept().await?;
-
+        let future = http.serve_connection(stream, service_fn(param_example));
         tokio::task::spawn(async move {
-            if let Err(err) = Http::new()
-                .serve_connection(stream, service_fn(param_example))
-                .await
-            {
+            if let Err(err) = future.await {
                 println!("Error serving connection: {:?}", err);
             }
         });

--- a/examples/send_file.rs
+++ b/examples/send_file.rs
@@ -22,14 +22,12 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let listener = TcpListener::bind(addr).await?;
     println!("Listening on http://{}", addr);
 
+    let http = Http::new();
     loop {
         let (stream, _) = listener.accept().await?;
-
+        let future = http.serve_connection(stream, service_fn(response_examples));
         tokio::task::spawn(async move {
-            if let Err(err) = Http::new()
-                .serve_connection(stream, service_fn(response_examples))
-                .await
-            {
+            if let Err(err) = future.await {
                 println!("Failed to serve connection: {:?}", err);
             }
         });

--- a/examples/service_struct_impl.rs
+++ b/examples/service_struct_impl.rs
@@ -18,14 +18,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let listener = TcpListener::bind(addr).await?;
     println!("Listening on http://{}", addr);
 
+    let http = Http::new();
     loop {
         let (stream, _) = listener.accept().await?;
-
+        let future = http.serve_connection(stream, Svc { counter: 81818 });
         tokio::task::spawn(async move {
-            if let Err(err) = Http::new()
-                .serve_connection(stream, Svc { counter: 81818 })
-                .await
-            {
+            if let Err(err) = future.await {
                 println!("Failed to serve connection: {:?}", err);
             }
         });

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -24,6 +24,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let listener = TcpListener::bind(addr).await?;
     println!("Listening on http://{}", addr);
+
+    let http = Http::new();
     loop {
         let (stream, _) = listener.accept().await?;
 
@@ -46,8 +48,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         });
 
-        if let Err(err) = Http::new().serve_connection(stream, service).await {
-            println!("Error serving connection: {:?}", err);
-        }
+        let future = http.serve_connection(stream, service);
+        tokio::task::spawn(async move {
+            if let Err(err) = future.await {
+                println!("Error serving connection: {:?}", err);
+            }
+        });
     }
 }

--- a/examples/upgrades.rs
+++ b/examples/upgrades.rs
@@ -149,11 +149,8 @@ async fn main() {
 
                     let mut rx = rx.clone();
                     tokio::task::spawn(async move {
-                        let conn = Http::new().serve_connection(stream, service_fn(server_upgrade));
-
                         // Don't forget to enable upgrades on the connection.
-                        let mut conn = conn.with_upgrades();
-
+                        let mut conn = Http::new().serve_connection(stream, service_fn(server_upgrade)).with_upgrades();
                         let mut conn = Pin::new(&mut conn);
 
                         tokio::select! {
@@ -170,9 +167,7 @@ async fn main() {
                         }
                     });
                 }
-                _ = rx.changed() => {
-                    break;
-                }
+                _ = rx.changed() => break,
             }
         }
     });

--- a/examples/web_api.rs
+++ b/examples/web_api.rs
@@ -107,13 +107,13 @@ async fn main() -> Result<()> {
 
     let listener = TcpListener::bind(&addr).await?;
     println!("Listening on http://{}", addr);
+
+    let http = Http::new();
     loop {
         let (stream, _) = listener.accept().await?;
-
+        let future = http.serve_connection(stream, service_fn(response_examples));
         tokio::task::spawn(async move {
-            let service = service_fn(move |req| response_examples(req));
-
-            if let Err(err) = Http::new().serve_connection(stream, service).await {
+            if let Err(err) = future.await {
                 println!("Failed to serve connection: {:?}", err);
             }
         });

--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -19,16 +19,16 @@
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //!     let addr: SocketAddr = ([127, 0, 0, 1], 8080).into();
-//!
 //!     let mut tcp_listener = TcpListener::bind(addr).await?;
+//!
+//!     let mut http = Http::new();
+//!     http.http1_only(true)
+//!         .http1_keep_alive(true);
 //!     loop {
 //!         let (tcp_stream, _) = tcp_listener.accept().await?;
+//!         let future = http.serve_connection(tcp_stream, service_fn(hello));
 //!         tokio::task::spawn(async move {
-//!             if let Err(http_err) = Http::new()
-//!                     .http1_only(true)
-//!                     .http1_keep_alive(true)
-//!                     .serve_connection(tcp_stream, service_fn(hello))
-//!                     .await {
+//!             if let Err(http_err) = future.await {
 //!                 eprintln!("Error while serving HTTP connection: {}", http_err);
 //!             }
 //!         });


### PR DESCRIPTION
Hello there! Now that #2321 has been resolved, I wanted to improve the documentation for the low-level server API. In all examples, I've noticed that the `Http::new` function is repeatedly called in loops. I figured that it would be more efficient to extract the `Http` instance (out of the loop) since `serve_connection` takes `&self` anyway (i.e., no mutability necessary). I have also updated the benches and documentation accordingly.

> As part of this year's [Hacktoberfest](https://hacktoberfest.com), it would be greatly appreciated if this PR would be labelled with [`hacktoberfest-accepted`](https://hacktoberfest.com/participation/#pr-mr-details). Thanks!

P.S. Thanks for the [shoutout at curl-up 2022](https://www.youtube.com/watch?v=tXB9AkG1QwI&t=1099s)! 🎉