### PR TITLE
fix(h2): add http2_max_header_list_size to hyper::server::Builder

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -425,6 +425,16 @@ impl<I, E> Builder<I, E> {
         self
     }
 
+    /// Sets the max size of received header frames.
+    ///
+    /// Default is currently ~16MB, but may change.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_header_list_size(mut self, max: u32) -> Self {
+        self.protocol.http2_max_header_list_size(max);
+        self
+    }
+
     /// Sets the [`SETTINGS_MAX_CONCURRENT_STREAMS`][spec] option for HTTP2
     /// connections.
     ///


### PR DESCRIPTION
fix incomplete changes introduced from #2828
