### PR TITLE
feat(server): `server::conn::http1` and `server::conn::http2` modules

### DIFF
--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -1,0 +1,514 @@
+//! HTTP/1 Server Connections
+
+use std::error::Error as StdError;
+use std::fmt;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::body::{Body, Recv};
+use crate::common::exec::{ConnStreamExec, Exec};
+use crate::common::{task, Future, Pin, Poll, Unpin};
+use crate::{common::time::Time, rt::Timer};
+use crate::proto;
+use crate::service::HttpService;
+
+type Http1Dispatcher<T, B, S> =
+    proto::h1::Dispatcher<proto::h1::dispatch::Server<S, Recv>, B, T, proto::ServerTransaction>;
+
+
+pin_project_lite::pin_project! {
+    /// A future binding an http1 connection with a Service.
+    ///
+    /// Polling this future will drive HTTP forward.
+    #[must_use = "futures do nothing unless polled"]
+    pub struct Connection<T, S, E>
+    where
+        S: HttpService<Recv>,
+    {
+        conn: Option<Http1Dispatcher<T, S::ResBody, S>>,
+        // can we remove this?
+        _exec: PhantomData<E>,
+    }
+}
+
+
+/// A configuration builder for HTTP/1 server connections.
+#[derive(Clone, Debug)]
+pub struct Builder<E = Exec> {
+    pub(crate) _exec: E,
+    pub(crate) timer: Time,
+    h1_half_close: bool,
+    h1_keep_alive: bool,
+    h1_title_case_headers: bool,
+    h1_preserve_header_case: bool,
+    h1_header_read_timeout: Option<Duration>,
+    h1_writev: Option<bool>,
+    max_buf_size: Option<usize>,
+    pipeline_flush: bool,
+}
+
+/// Deconstructed parts of a `Connection`.
+///
+/// This allows taking apart a `Connection` at a later time, in order to
+/// reclaim the IO object, and additional related pieces.
+#[derive(Debug)]
+pub struct Parts<T, S> {
+    /// The original IO object used in the handshake.
+    pub io: T,
+    /// A buffer of bytes that have been read but not processed as HTTP.
+    ///
+    /// If the client sent additional bytes after its last request, and
+    /// this connection "ended" with an upgrade, the read buffer will contain
+    /// those bytes.
+    ///
+    /// You will want to check for any existing bytes if you plan to continue
+    /// communicating on the IO object.
+    pub read_buf: Bytes,
+    /// The `Service` used to serve this connection.
+    pub service: S,
+    _inner: (),
+}
+
+// ===== impl Connection =====
+
+impl<I, S, E> fmt::Debug for Connection<I, S, E>
+where
+    S: HttpService<Recv>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Connection").finish()
+    }
+}
+
+impl<I, B, S, E> Connection<I, S, E>
+where
+    S: HttpService<Recv, ResBody = B>,
+    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    I: AsyncRead + AsyncWrite + Unpin,
+    B: Body + 'static,
+    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    E: ConnStreamExec<S::Future, B>,
+{
+    /// Start a graceful shutdown process for this connection.
+    ///
+    /// This `Connection` should continue to be polled until shutdown
+    /// can finish.
+    ///
+    /// # Note
+    ///
+    /// This should only be called while the `Connection` future is still
+    /// pending. If called after `Connection::poll` has resolved, this does
+    /// nothing.
+    pub fn graceful_shutdown(mut self: Pin<&mut Self>) {
+        match self.conn {
+            Some(ref mut h1) => {
+                h1.disable_keep_alive();
+            }
+            None => (),
+        }
+    }
+
+    /// Return the inner IO object, and additional information.
+    ///
+    /// If the IO object has been "rewound" the io will not contain those bytes rewound.
+    /// This should only be called after `poll_without_shutdown` signals
+    /// that the connection is "done". Otherwise, it may not have finished
+    /// flushing all necessary HTTP bytes.
+    ///
+    /// # Panics
+    /// This method will panic if this connection is using an h2 protocol.
+    pub fn into_parts(self) -> Parts<I, S> {
+        self.try_into_parts()
+            .unwrap_or_else(|| panic!("h2 cannot into_inner"))
+    }
+
+    /// Return the inner IO object, and additional information, if available.
+    ///
+    ///
+    /// TODO:(mike) does this need to return none for h1 or is it expected to always be present? previously used an "unwrap"
+    /// This method will return a `None` if this connection is using an h2 protocol.
+    pub fn try_into_parts(self) -> Option<Parts<I, S>> {
+        self.conn.map(|h1| {
+            let (io, read_buf, dispatch) = h1.into_inner();
+            Parts {
+                io,
+                read_buf,
+                service: dispatch.into_service(),
+                _inner: (),
+            }
+        })
+    }
+
+    /// Poll the connection for completion, but without calling `shutdown`
+    /// on the underlying IO.
+    ///
+    /// This is useful to allow running a connection while doing an HTTP
+    /// upgrade. Once the upgrade is completed, the connection would be "done",
+    /// but it is not desired to actually shutdown the IO object. Instead you
+    /// would take it back using `into_parts`.
+    pub fn poll_without_shutdown(&mut self, cx: &mut task::Context<'_>) -> Poll<crate::Result<()>>
+    where
+        S: Unpin,
+        S::Future: Unpin,
+        B: Unpin,
+    {
+        self.conn.as_mut().unwrap().poll_without_shutdown(cx)
+    }
+
+    /// Prevent shutdown of the underlying IO object at the end of service the request,
+    /// instead run `into_parts`. This is a convenience wrapper over `poll_without_shutdown`.
+    ///
+    /// # Error
+    ///
+    /// This errors if the underlying connection protocol is not HTTP/1.
+    pub fn without_shutdown(self) -> impl Future<Output = crate::Result<Parts<I, S>>>
+    where
+        S: Unpin,
+        S::Future: Unpin,
+        B: Unpin,
+    {
+        // TODO(mike): "new_without_shutdown_not_h1" is not possible here
+        let mut conn = Some(self);
+        futures_util::future::poll_fn(move |cx| {
+            ready!(conn.as_mut().unwrap().poll_without_shutdown(cx))?;
+            Poll::Ready(
+                conn.take()
+                    .unwrap()
+                    .try_into_parts()
+                    .ok_or_else(crate::Error::new_without_shutdown_not_h1),
+            )
+        })
+    }
+
+    /// Enable this connection to support higher-level HTTP upgrades.
+    ///
+    /// See [the `upgrade` module](crate::upgrade) for more.
+    pub fn with_upgrades(self) -> upgrades::UpgradeableConnection<I, S, E>
+    where
+        I: Send,
+    {
+        upgrades::UpgradeableConnection { inner: self }
+    }
+}
+
+
+impl<I, B, S, E> Future for Connection<I, S, E>
+where
+    S: HttpService<Recv, ResBody = B>,
+    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    I: AsyncRead + AsyncWrite + Unpin + 'static,
+    B: Body + 'static,
+    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    E: ConnStreamExec<S::Future, B>,
+{
+    type Output = crate::Result<()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        match ready!(Pin::new(self.conn.as_mut().unwrap()).poll(cx)) {
+            Ok(done) => {
+                match done {
+                    proto::Dispatched::Shutdown => {}
+                    proto::Dispatched::Upgrade(pending) => {
+                        // With no `Send` bound on `I`, we can't try to do
+                        // upgrades here. In case a user was trying to use
+                        // `Body::on_upgrade` with this API, send a special
+                        // error letting them know about that.
+                        pending.manual();
+                    }
+                };
+                return Poll::Ready(Ok(()));
+            }
+            Err(e) =>  Poll::Ready(Err(e)),
+        }
+    }
+}
+
+// ===== impl Builder =====
+
+impl<E> Builder<E> {
+    /// Create a new connection builder.
+    ///
+    /// This starts with the default options, and an executor.
+    pub fn new(exec: E) -> Self {
+        Self {
+            _exec: exec,
+            timer: Time::Empty,
+            h1_half_close: false,
+            h1_keep_alive: true,
+            h1_title_case_headers: false,
+            h1_preserve_header_case: false,
+            h1_header_read_timeout: None,
+            h1_writev: None,
+            max_buf_size: None,
+            pipeline_flush: false,
+        }
+    }
+    /// Set whether HTTP/1 connections should support half-closures.
+    ///
+    /// Clients can chose to shutdown their write-side while waiting
+    /// for the server to respond. Setting this to `true` will
+    /// prevent closing the connection immediately if `read`
+    /// detects an EOF in the middle of a request.
+    ///
+    /// Default is `false`.
+    pub fn http1_half_close(&mut self, val: bool) -> &mut Self {
+        self.h1_half_close = val;
+        self
+    }
+
+    /// Enables or disables HTTP/1 keep-alive.
+    ///
+    /// Default is true.
+    pub fn http1_keep_alive(&mut self, val: bool) -> &mut Self {
+        self.h1_keep_alive = val;
+        self
+    }
+
+    /// Set whether HTTP/1 connections will write header names as title case at
+    /// the socket level.
+    ///
+    /// Note that this setting does not affect HTTP/2.
+    ///
+    /// Default is false.
+    pub fn http1_title_case_headers(&mut self, enabled: bool) -> &mut Self {
+        self.h1_title_case_headers = enabled;
+        self
+    }
+
+    /// Set whether to support preserving original header cases.
+    ///
+    /// Currently, this will record the original cases received, and store them
+    /// in a private extension on the `Request`. It will also look for and use
+    /// such an extension in any provided `Response`.
+    ///
+    /// Since the relevant extension is still private, there is no way to
+    /// interact with the original cases. The only effect this can have now is
+    /// to forward the cases in a proxy-like fashion.
+    ///
+    /// Note that this setting does not affect HTTP/2.
+    ///
+    /// Default is false.
+    pub fn http1_preserve_header_case(&mut self, enabled: bool) -> &mut Self {
+        self.h1_preserve_header_case = enabled;
+        self
+    }
+
+    /// Set a timeout for reading client request headers. If a client does not
+    /// transmit the entire header within this time, the connection is closed.
+    ///
+    /// Default is None.
+    pub fn http1_header_read_timeout(&mut self, read_timeout: Duration) -> &mut Self {
+        self.h1_header_read_timeout = Some(read_timeout);
+        self
+    }
+
+    /// Set whether HTTP/1 connections should try to use vectored writes,
+    /// or always flatten into a single buffer.
+    ///
+    /// Note that setting this to false may mean more copies of body data,
+    /// but may also improve performance when an IO transport doesn't
+    /// support vectored writes well, such as most TLS implementations.
+    ///
+    /// Setting this to true will force hyper to use queued strategy
+    /// which may eliminate unnecessary cloning on some TLS backends
+    ///
+    /// Default is `auto`. In this mode hyper will try to guess which
+    /// mode to use
+    pub fn http1_writev(&mut self, val: bool) -> &mut Self {
+        self.h1_writev = Some(val);
+        self
+    }
+
+    /// Set the maximum buffer size for the connection.
+    ///
+    /// Default is ~400kb.
+    ///
+    /// # Panics
+    ///
+    /// The minimum value allowed is 8192. This method panics if the passed `max` is less than the minimum.
+    #[cfg(feature = "http1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
+    pub fn max_buf_size(&mut self, max: usize) -> &mut Self {
+        assert!(
+            max >= proto::h1::MINIMUM_MAX_BUFFER_SIZE,
+            "the max_buf_size cannot be smaller than the minimum that h1 specifies."
+        );
+        self.max_buf_size = Some(max);
+        self
+    }
+
+    /// Aggregates flushes to better support pipelined responses.
+    ///
+    /// Experimental, may have bugs.
+    ///
+    /// Default is false.
+    pub fn pipeline_flush(&mut self, enabled: bool) -> &mut Self {
+        self.pipeline_flush = enabled;
+        self
+    }
+
+    /// Set the executor used to spawn background tasks.
+    ///
+    /// Default uses implicit default (like `tokio::spawn`).
+    pub fn with_executor<E2>(self, exec: E2) -> Builder<E2> {
+        Builder {
+            _exec: exec,
+            timer: self.timer,
+            h1_half_close: self.h1_half_close,
+            h1_keep_alive: self.h1_keep_alive,
+            h1_title_case_headers: self.h1_title_case_headers,
+            h1_preserve_header_case: self.h1_preserve_header_case,
+            h1_header_read_timeout: self.h1_header_read_timeout,
+            h1_writev: self.h1_writev,
+            max_buf_size: self.max_buf_size,
+            pipeline_flush: self.pipeline_flush,
+        }
+    }
+
+    /// Set the timer used in background tasks.
+    pub fn timer<M>(&mut self, timer: M) -> &mut Self
+    where
+        M: Timer + Send + Sync + 'static,
+    {
+        self.timer = Time::Timer(Arc::new(timer));
+        self
+    }
+
+    /// Bind a connection together with a [`Service`](crate::service::Service).
+    ///
+    /// This returns a Future that must be polled in order for HTTP to be
+    /// driven on the connection.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use hyper::{Recv, Request, Response};
+    /// # use hyper::service::Service;
+    /// # use hyper::server::conn::Http;
+    /// # use tokio::io::{AsyncRead, AsyncWrite};
+    /// # async fn run<I, S>(some_io: I, some_service: S)
+    /// # where
+    /// #     I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    /// #     S: Service<hyper::Request<Recv>, Response=hyper::Response<Recv>> + Send + 'static,
+    /// #     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    /// #     S::Future: Send,
+    /// # {
+    /// let http = Http::new();
+    /// let conn = http.serve_connection(some_io, some_service);
+    ///
+    /// if let Err(e) = conn.await {
+    ///     eprintln!("server connection error: {}", e);
+    /// }
+    /// # }
+    /// # fn main() {}
+    /// ```
+    pub fn serve_connection<S, I, Bd>(&self, io: I, service: S) -> Connection<I, S, E>
+    where
+        S: HttpService<Recv, ResBody = Bd>,
+        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        Bd: Body + 'static,
+        Bd::Error: Into<Box<dyn StdError + Send + Sync>>,
+        I: AsyncRead + AsyncWrite + Unpin,
+        E: ConnStreamExec<S::Future, Bd>,
+    {
+        let mut conn = proto::Conn::new(io);
+        conn.set_timer(self.timer.clone());
+        if !self.h1_keep_alive {
+            conn.disable_keep_alive();
+        }
+        if self.h1_half_close {
+            conn.set_allow_half_close();
+        }
+        if self.h1_title_case_headers {
+            conn.set_title_case_headers();
+        }
+        if self.h1_preserve_header_case {
+            conn.set_preserve_header_case();
+        }
+        if let Some(header_read_timeout) = self.h1_header_read_timeout {
+            conn.set_http1_header_read_timeout(header_read_timeout);
+        }
+        if let Some(writev) = self.h1_writev {
+            if writev {
+                conn.set_write_strategy_queue();
+            } else {
+                conn.set_write_strategy_flatten();
+            }
+        }
+        conn.set_flush_pipeline(self.pipeline_flush);
+        if let Some(max) = self.max_buf_size {
+            conn.set_max_buf_size(max);
+        }
+        let sd = proto::h1::dispatch::Server::new(service);
+        let proto = proto::h1::Dispatcher::new(sd, conn);
+        Connection {
+            conn: Some(proto),
+            _exec: PhantomData,
+        }
+    }
+}
+
+mod upgrades {
+    use crate::upgrade::Upgraded;
+
+    use super::*;
+
+    // A future binding a connection with a Service with Upgrade support.
+    //
+    // This type is unnameable outside the crate, and so basically just an
+    // `impl Future`, without requiring Rust 1.26.
+    #[must_use = "futures do nothing unless polled"]
+    #[allow(missing_debug_implementations)]
+    pub struct UpgradeableConnection<T, S, E>
+    where
+        S: HttpService<Recv>,
+    {
+        pub(super) inner: Connection<T, S, E>,
+    }
+
+    impl<I, B, S, E> UpgradeableConnection<I, S, E>
+    where
+        S: HttpService<Recv, ResBody = B>,
+        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        I: AsyncRead + AsyncWrite + Unpin,
+        B: Body + 'static,
+        B::Error: Into<Box<dyn StdError + Send + Sync>>,
+        E: ConnStreamExec<S::Future, B>,
+    {
+        /// Start a graceful shutdown process for this connection.
+        ///
+        /// This `Connection` should continue to be polled until shutdown
+        /// can finish.
+        pub fn graceful_shutdown(mut self: Pin<&mut Self>) {
+            Pin::new(&mut self.inner).graceful_shutdown()
+        }
+    }
+
+    impl<I, B, S, E> Future for UpgradeableConnection<I, S, E>
+    where
+        S: HttpService<Recv, ResBody = B>,
+        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        B: Body + 'static,
+        B::Error: Into<Box<dyn StdError + Send + Sync>>,
+        E: ConnStreamExec<S::Future, B>,
+    {
+        type Output = crate::Result<()>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+            match ready!(Pin::new(self.inner.conn.as_mut().unwrap()).poll(cx)) {
+                Ok(proto::Dispatched::Shutdown) => Poll::Ready(Ok(())),
+                Ok(proto::Dispatched::Upgrade(pending)) => {
+                    let (io, buf, _) = self.inner.conn.take().unwrap().into_inner();
+                    pending.fulfill(Upgraded::new(io, buf));
+                    Poll::Ready(Ok(()))
+                }
+                Err(e) => Poll::Ready(Err(e)),
+            }
+        }
+    }
+}

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -1,0 +1,331 @@
+//! HTTP/2 Server Connections
+
+use std::error::Error as StdError;
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+
+use pin_project_lite::pin_project;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::body::{Body, Recv};
+use crate::common::exec::{ConnStreamExec};
+use crate::common::{task, Future, Pin, Poll, Unpin};
+use crate::{common::time::Time, rt::Timer};
+use crate::proto;
+use crate::service::HttpService;
+
+pin_project! {
+    /// A future binding an HTTP/2 connection with a Service.
+    ///
+    /// Polling this future will drive HTTP forward.
+    #[must_use = "futures do nothing unless polled"]
+    pub struct Connection<T, S, E>
+    where
+        S: HttpService<Recv>,
+    {
+        conn: proto::h2::Server<T, S, S::ResBody, E>,
+    }
+}
+
+/// A configuration builder for HTTP/2 server connections.
+#[derive(Clone, Debug)]
+pub struct Builder<E> {
+    exec: E,
+    timer: Time,
+    h2_builder: proto::h2::server::Config,
+}
+
+// ===== impl Connection =====
+
+impl<I, S, E> fmt::Debug for Connection<I, S, E>
+where
+    S: HttpService<Recv>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Connection").finish()
+    }
+}
+
+impl<I, B, S, E> Connection<I, S, E>
+where
+    S: HttpService<Recv, ResBody = B>,
+    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    I: AsyncRead + AsyncWrite + Unpin,
+    B: Body + 'static,
+    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    E: ConnStreamExec<S::Future, B>,
+{
+    /// Start a graceful shutdown process for this connection.
+    ///
+    /// This `Connection` should continue to be polled until shutdown
+    /// can finish.
+    ///
+    /// # Note
+    ///
+    /// This should only be called while the `Connection` future is still
+    /// pending. If called after `Connection::poll` has resolved, this does
+    /// nothing.
+    pub fn graceful_shutdown(mut self: Pin<&mut Self>) {
+        self.conn.graceful_shutdown();
+    }
+}
+
+impl<I, B, S, E> Future for Connection<I, S, E>
+where
+    S: HttpService<Recv, ResBody = B>,
+    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    I: AsyncRead + AsyncWrite + Unpin + 'static,
+    B: Body + 'static,
+    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    E: ConnStreamExec<S::Future, B>,
+{
+    type Output = crate::Result<()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        match ready!(Pin::new(&mut self.conn).poll(cx)) {
+            Ok(_done) => {
+                //TODO: the proto::h2::Server no longer needs to return
+                //the Dispatched enum
+                Poll::Ready(Ok(()))
+            }
+            Err(e) => {
+                Poll::Ready(Err(e))
+            }
+        }
+    }
+}
+
+// ===== impl Builder =====
+
+impl<E> Builder<E> {
+    /// Create a new connection builder.
+    ///
+    /// This starts with the default options, and an executor.
+    pub fn new(exec: E) -> Self {
+        Self {
+            exec: exec,
+            timer: Time::Empty,
+            h2_builder: Default::default(),
+        }
+    }
+
+    /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
+    /// stream-level flow control.
+    ///
+    /// Passing `None` will do nothing.
+    ///
+    /// If not set, hyper will use a default.
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_initial_stream_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        if let Some(sz) = sz.into() {
+            self.h2_builder.adaptive_window = false;
+            self.h2_builder.initial_stream_window_size = sz;
+        }
+        self
+    }
+
+    /// Sets the max connection-level flow control for HTTP2.
+    ///
+    /// Passing `None` will do nothing.
+    ///
+    /// If not set, hyper will use a default.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_initial_connection_window_size(
+        &mut self,
+        sz: impl Into<Option<u32>>,
+    ) -> &mut Self {
+        if let Some(sz) = sz.into() {
+            self.h2_builder.adaptive_window = false;
+            self.h2_builder.initial_conn_window_size = sz;
+        }
+        self
+    }
+
+    /// Sets whether to use an adaptive flow control.
+    ///
+    /// Enabling this will override the limits set in
+    /// `http2_initial_stream_window_size` and
+    /// `http2_initial_connection_window_size`.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_adaptive_window(&mut self, enabled: bool) -> &mut Self {
+        use proto::h2::SPEC_WINDOW_SIZE;
+
+        self.h2_builder.adaptive_window = enabled;
+        if enabled {
+            self.h2_builder.initial_conn_window_size = SPEC_WINDOW_SIZE;
+            self.h2_builder.initial_stream_window_size = SPEC_WINDOW_SIZE;
+        }
+        self
+    }
+
+    /// Sets the maximum frame size to use for HTTP2.
+    ///
+    /// Passing `None` will do nothing.
+    ///
+    /// If not set, hyper will use a default.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_frame_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+        if let Some(sz) = sz.into() {
+            self.h2_builder.max_frame_size = sz;
+        }
+        self
+    }
+
+    /// Sets the [`SETTINGS_MAX_CONCURRENT_STREAMS`][spec] option for HTTP2
+    /// connections.
+    ///
+    /// Default is no limit (`std::u32::MAX`). Passing `None` will do nothing.
+    ///
+    /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_MAX_CONCURRENT_STREAMS
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_concurrent_streams(&mut self, max: impl Into<Option<u32>>) -> &mut Self {
+        self.h2_builder.max_concurrent_streams = max.into();
+        self
+    }
+
+    /// Sets an interval for HTTP2 Ping frames should be sent to keep a
+    /// connection alive.
+    ///
+    /// Pass `None` to disable HTTP2 keep-alive.
+    ///
+    /// Default is currently disabled.
+    ///
+    /// # Cargo Feature
+    ///
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_keep_alive_interval(
+        &mut self,
+        interval: impl Into<Option<Duration>>,
+    ) -> &mut Self {
+        self.h2_builder.keep_alive_interval = interval.into();
+        self
+    }
+
+    /// Sets a timeout for receiving an acknowledgement of the keep-alive ping.
+    ///
+    /// If the ping is not acknowledged within the timeout, the connection will
+    /// be closed. Does nothing if `http2_keep_alive_interval` is disabled.
+    ///
+    /// Default is 20 seconds.
+    ///
+    /// # Cargo Feature
+    ///
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.h2_builder.keep_alive_timeout = timeout;
+        self
+    }
+
+    /// Set the maximum write buffer size for each HTTP/2 stream.
+    ///
+    /// Default is currently ~400KB, but may change.
+    ///
+    /// # Panics
+    ///
+    /// The value must be no larger than `u32::MAX`.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_send_buf_size(&mut self, max: usize) -> &mut Self {
+        assert!(max <= std::u32::MAX as usize);
+        self.h2_builder.max_send_buffer_size = max;
+        self
+    }
+
+    /// Enables the [extended CONNECT protocol].
+    ///
+    /// [extended CONNECT protocol]: https://datatracker.ietf.org/doc/html/rfc8441#section-4
+    #[cfg(feature = "http2")]
+    pub fn http2_enable_connect_protocol(&mut self) -> &mut Self {
+        self.h2_builder.enable_connect_protocol = true;
+        self
+    }
+
+    /// Sets the max size of received header frames.
+    ///
+    /// Default is currently ~16MB, but may change.
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http2_max_header_list_size(&mut self, max: u32) -> &mut Self {
+        self.h2_builder.max_header_list_size = max;
+        self
+    }
+
+    /// Set the executor used to spawn background tasks.
+    ///
+    /// Default uses implicit default (like `tokio::spawn`).
+    pub fn with_executor<E2>(self, exec: E2) -> Builder<E2> {
+        Builder {
+            exec,
+            timer: self.timer,
+            h2_builder: self.h2_builder,
+        }
+    }
+
+    /// Set the timer used in background tasks.
+    pub fn timer<M>(&mut self, timer: M) -> &mut Self
+    where
+        M: Timer + Send + Sync + 'static,
+    {
+        self.timer = Time::Timer(Arc::new(timer));
+        self
+    }
+
+    /// Bind a connection together with a [`Service`](crate::service::Service).
+    ///
+    /// This returns a Future that must be polled in order for HTTP to be
+    /// driven on the connection.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use hyper::{Recv, Request, Response};
+    /// # use hyper::service::Service;
+    /// # use hyper::server::conn::Http;
+    /// # use tokio::io::{AsyncRead, AsyncWrite};
+    /// # async fn run<I, S>(some_io: I, some_service: S)
+    /// # where
+    /// #     I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    /// #     S: Service<hyper::Request<Recv>, Response=hyper::Response<Recv>> + Send + 'static,
+    /// #     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    /// #     S::Future: Send,
+    /// # {
+    /// let http = Http::new();
+    /// let conn = http.serve_connection(some_io, some_service);
+    ///
+    /// if let Err(e) = conn.await {
+    ///     eprintln!("server connection error: {}", e);
+    /// }
+    /// # }
+    /// # fn main() {}
+    /// ```
+    pub fn serve_connection<S, I, Bd>(&self, io: I, service: S) -> Connection<I, S, E>
+    where
+        S: HttpService<Recv, ResBody = Bd>,
+        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        Bd: Body + 'static,
+        Bd::Error: Into<Box<dyn StdError + Send + Sync>>,
+        I: AsyncRead + AsyncWrite + Unpin,
+        E: ConnStreamExec<S::Future, Bd>,
+    {
+        let proto = proto::h2::Server::new(
+            io,
+            service,
+            &self.h2_builder,
+            self.exec.clone(),
+            self.timer.clone(),
+        );
+        Connection {
+            conn: proto,
+        }
+    }
+}

--- a/src/server/conn/mod.rs
+++ b/src/server/conn/mod.rs
@@ -58,6 +58,11 @@ use crate::error::{Kind, Parse};
 use crate::upgrade::Upgraded;
 use crate::{common::time::Time, rt::Timer};
 
+#[cfg(feature = "http1")]
+pub mod http1;
+#[cfg(feature = "http2")]
+pub mod http2;
+
 cfg_feature! {
     #![any(feature = "http1", feature = "http2")]
 


### PR DESCRIPTION
This creates submodules of `hyper::server::conn` for HTTP/1 and HTTP/2. Each module contains a `Builder` and `Connection`, with options and methods specific to their version.

This takes over what was started in #2996.

