### PR TITLE
feat(body): rename `Recv` to `Incoming`

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -4,15 +4,16 @@ use std::net::SocketAddr;
 
 use bytes::Bytes;
 use http_body_util::{combinators::BoxBody, BodyExt, Empty, Full};
-use hyper::body::Body as _;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
-use hyper::{Method, Recv, Request, Response, StatusCode};
+use hyper::{body::Body, Method, Request, Response, StatusCode};
 use tokio::net::TcpListener;
 
 /// This is our service handler. It receives a Request, routes on its
 /// path, and returns a Future of a Response.
-async fn echo(req: Request<Recv>) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
+async fn echo(
+    req: Request<hyper::body::Incoming>,
+) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     match (req.method(), req.uri().path()) {
         // Serve some instructions at /
         (&Method::GET, "/") => Ok(Response::new(full(

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -7,10 +7,10 @@ use bytes::Bytes;
 use http_body_util::Full;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
-use hyper::{Recv, Request, Response};
+use hyper::{Request, Response};
 use tokio::net::TcpListener;
 
-async fn hello(_: Request<Recv>) -> Result<Response<Full<Bytes>>, Infallible> {
+async fn hello(_: Request<hyper::body::Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
     Ok(Response::new(Full::new(Bytes::from("Hello World!"))))
 }
 

--- a/examples/http_proxy.rs
+++ b/examples/http_proxy.rs
@@ -8,7 +8,7 @@ use hyper::client::conn::http1::Builder;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::upgrade::Upgraded;
-use hyper::{Method, Recv, Request, Response};
+use hyper::{Method, Request, Response};
 
 use tokio::net::{TcpListener, TcpStream};
 
@@ -43,7 +43,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-async fn proxy(req: Request<Recv>) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
+async fn proxy(
+    req: Request<hyper::body::Incoming>,
+) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     println!("req: {:?}", req);
 
     if Method::CONNECT == req.method() {

--- a/examples/multi_server.rs
+++ b/examples/multi_server.rs
@@ -8,17 +8,17 @@ use futures_util::future::join;
 use http_body_util::Full;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
-use hyper::{Recv, Request, Response};
+use hyper::{Request, Response};
 use tokio::net::TcpListener;
 
 static INDEX1: &[u8] = b"The 1st service!";
 static INDEX2: &[u8] = b"The 2nd service!";
 
-async fn index1(_: Request<Recv>) -> Result<Response<Full<Bytes>>, hyper::Error> {
+async fn index1(_: Request<hyper::body::Incoming>) -> Result<Response<Full<Bytes>>, hyper::Error> {
     Ok(Response::new(Full::new(Bytes::from(INDEX1))))
 }
 
-async fn index2(_: Request<Recv>) -> Result<Response<Full<Bytes>>, hyper::Error> {
+async fn index2(_: Request<hyper::body::Incoming>) -> Result<Response<Full<Bytes>>, hyper::Error> {
     Ok(Response::new(Full::new(Bytes::from(INDEX2))))
 }
 

--- a/examples/params.rs
+++ b/examples/params.rs
@@ -5,7 +5,7 @@ use bytes::Bytes;
 use http_body_util::{combinators::BoxBody, BodyExt, Empty, Full};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
-use hyper::{Method, Recv, Request, Response, StatusCode};
+use hyper::{Method, Request, Response, StatusCode};
 use tokio::net::TcpListener;
 
 use std::collections::HashMap;
@@ -19,7 +19,7 @@ static NOTNUMERIC: &[u8] = b"Number field is not numeric";
 
 // Using service_fn, we can turn this function into a `Service`.
 async fn param_example(
-    req: Request<Recv>,
+    req: Request<hyper::body::Incoming>,
 ) -> Result<Response<BoxBody<Bytes, Infallible>>, hyper::Error> {
     match (req.method(), req.uri().path()) {
         (&Method::GET, "/") | (&Method::GET, "/post") => Ok(Response::new(full(INDEX))),

--- a/examples/send_file.rs
+++ b/examples/send_file.rs
@@ -8,7 +8,7 @@ use tokio::net::TcpListener;
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::service::service_fn;
-use hyper::{Method, Recv, Request, Response, Result, StatusCode};
+use hyper::{Method, Request, Response, Result, StatusCode};
 
 static INDEX: &str = "examples/send_file_index.html";
 static NOTFOUND: &[u8] = b"Not Found";
@@ -36,7 +36,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-async fn response_examples(req: Request<Recv>) -> Result<Response<Full<Bytes>>> {
+async fn response_examples(req: Request<hyper::body::Incoming>) -> Result<Response<Full<Bytes>>> {
     match (req.method(), req.uri().path()) {
         (&Method::GET, "/") | (&Method::GET, "/index.html") => simple_file_send(INDEX).await,
         (&Method::GET, "/no_file.html") => {

--- a/examples/service_struct_impl.rs
+++ b/examples/service_struct_impl.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use http_body_util::Full;
 use hyper::server::conn::http1;
 use hyper::service::Service;
-use hyper::{Recv, Request, Response};
+use hyper::{body::Incoming as IncomingBody, Request, Response};
 use tokio::net::TcpListener;
 
 use std::future::Future;
@@ -36,12 +36,12 @@ struct Svc {
     counter: Counter,
 }
 
-impl Service<Request<Recv>> for Svc {
+impl Service<Request<IncomingBody>> for Svc {
     type Response = Response<Full<Bytes>>;
     type Error = hyper::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
-    fn call(&mut self, req: Request<Recv>) -> Self::Future {
+    fn call(&mut self, req: Request<IncomingBody>) -> Self::Future {
         fn mk_response(s: String) -> Result<Response<Full<Bytes>>, hyper::Error> {
             Ok(Response::builder().body(Full::new(Bytes::from(s))).unwrap())
         }

--- a/examples/upgrades.rs
+++ b/examples/upgrades.rs
@@ -14,7 +14,7 @@ use hyper::header::{HeaderValue, UPGRADE};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::upgrade::Upgraded;
-use hyper::{Recv, Request, Response, StatusCode};
+use hyper::{Request, Response, StatusCode};
 
 // A simple type alias so as to DRY.
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
@@ -38,7 +38,7 @@ async fn server_upgraded_io(mut upgraded: Upgraded) -> Result<()> {
 }
 
 /// Our server HTTP handler to initiate HTTP upgrades.
-async fn server_upgrade(mut req: Request<Recv>) -> Result<Response<Empty<Bytes>>> {
+async fn server_upgrade(mut req: Request<hyper::body::Incoming>) -> Result<Response<Empty<Bytes>>> {
     let mut res = Response::new(Empty::new());
 
     // Send a 400 to any request that doesn't have

--- a/examples/web_api.rs
+++ b/examples/web_api.rs
@@ -6,7 +6,7 @@ use bytes::{Buf, Bytes};
 use http_body_util::{BodyExt, Full};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
-use hyper::{header, Method, Recv, Request, Response, StatusCode};
+use hyper::{body::Incoming as IncomingBody, header, Method, Request, Response, StatusCode};
 use tokio::net::{TcpListener, TcpStream};
 
 type GenericError = Box<dyn std::error::Error + Send + Sync>;
@@ -46,7 +46,7 @@ async fn client_request_response() -> Result<Response<BoxBody>> {
     Ok(Response::new(res_body))
 }
 
-async fn api_post_response(req: Request<Recv>) -> Result<Response<BoxBody>> {
+async fn api_post_response(req: Request<IncomingBody>) -> Result<Response<BoxBody>> {
     // Aggregate the body...
     let whole_body = req.collect().await?.aggregate();
     // Decode as JSON...
@@ -77,7 +77,7 @@ async fn api_get_response() -> Result<Response<BoxBody>> {
     Ok(res)
 }
 
-async fn response_examples(req: Request<Recv>) -> Result<Response<BoxBody>> {
+async fn response_examples(req: Request<IncomingBody>) -> Result<Response<BoxBody>> {
     match (req.method(), req.uri().path()) {
         (&Method::GET, "/") | (&Method::GET, "/index.html") => Ok(Response::new(full(INDEX))),
         (&Method::GET, "/test.html") => client_request_response().await,

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -10,28 +10,28 @@
 //! - **The [`Body`](Body) trait** describes all possible bodies.
 //!   hyper allows any body type that implements `Body`, allowing
 //!   applications to have fine-grained control over their streaming.
-//! - **The [`Recv`](Recv) concrete type**, which is an implementation of
+//! - **The [`Incoming`](Incoming) concrete type**, which is an implementation of
 //!   `Body`, and returned by hyper as a "receive stream" (so, for server
-//!   requests and client responses). It is also a decent default implementation
-//!   if you don't have very custom needs of your send streams.
+//!   requests and client responses).
 
 pub use bytes::{Buf, Bytes};
 pub use http_body::Body;
 pub use http_body::Frame;
 pub use http_body::SizeHint;
 
-pub use self::body::Recv;
+pub use self::incoming::Incoming;
+
 #[cfg(feature = "http1")]
-pub(crate) use self::body::Sender;
+pub(crate) use self::incoming::Sender;
 pub(crate) use self::length::DecodedLength;
 
-mod body;
+mod incoming;
 mod length;
 
 fn _assert_send_sync() {
     fn _assert_send<T: Send>() {}
     fn _assert_sync<T: Sync>() {}
 
-    _assert_send::<Recv>();
-    _assert_sync::<Recv>();
+    _assert_send::<Incoming>();
+    _assert_sync::<Incoming>();
 }

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -9,8 +9,7 @@ use http::{Request, Response};
 use httparse::ParserConfig;
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use crate::Recv;
-use crate::body::Body;
+use crate::body::{Body, Incoming as IncomingBody};
 use super::super::dispatch;
 use crate::common::{
     exec::{BoxSendFuture, Exec},
@@ -25,7 +24,7 @@ type Dispatcher<T, B> =
 
 /// The sender side of an established connection.
 pub struct SendRequest<B> {
-    dispatch: dispatch::Sender<Request<B>, Response<Recv>>,
+    dispatch: dispatch::Sender<Request<B>, Response<IncomingBody>>,
 }
 
 /// Deconstructed parts of a `Connection`.
@@ -189,7 +188,7 @@ where
     pub fn send_request(
         &mut self,
         req: Request<B>,
-    ) -> impl Future<Output = crate::Result<Response<Recv>>> {
+    ) -> impl Future<Output = crate::Result<Response<IncomingBody>>> {
         let sent = self.dispatch.send(req);
 
         async move {

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -10,7 +10,7 @@ use http::{Request, Response};
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::super::dispatch;
-use crate::body::Body;
+use crate::body::{Body, Incoming as IncomingBody};
 use crate::common::time::Time;
 use crate::common::{
     exec::{BoxSendFuture, Exec},
@@ -18,11 +18,10 @@ use crate::common::{
 };
 use crate::proto;
 use crate::rt::{Executor, Timer};
-use crate::Recv;
 
 /// The sender side of an established connection.
 pub struct SendRequest<B> {
-    dispatch: dispatch::UnboundedSender<Request<B>, Response<Recv>>,
+    dispatch: dispatch::UnboundedSender<Request<B>, Response<IncomingBody>>,
 }
 
 /// A future that processes all HTTP state for the IO object.
@@ -128,7 +127,7 @@ where
     pub fn send_request(
         &mut self,
         req: Request<B>,
-    ) -> impl Future<Output = crate::Result<Response<Recv>>> {
+    ) -> impl Future<Output = crate::Result<Response<IncomingBody>>> {
         let sent = self.dispatch.send(req);
 
         async move {

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -379,15 +379,15 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn giver_queue_throughput(b: &mut test::Bencher) {
-        use crate::{Recv, Request, Response};
+        use crate::{body::Incoming, Request, Response};
 
         let rt = tokio::runtime::Builder::new_current_thread()
             .build()
             .unwrap();
-        let (mut tx, mut rx) = channel::<Request<Recv>, Response<Recv>>();
+        let (mut tx, mut rx) = channel::<Request<Incoming>, Response<Incoming>>();
 
         b.iter(move || {
-            let _ = tx.send(Request::new(Recv::empty())).unwrap();
+            let _ = tx.send(Request::new(Incoming::empty())).unwrap();
             rt.block_on(async {
                 loop {
                     let poll_once = PollOnce(&mut rx);

--- a/src/ffi/body.rs
+++ b/src/ffi/body.rs
@@ -8,10 +8,10 @@ use libc::{c_int, size_t};
 
 use super::task::{hyper_context, hyper_task, hyper_task_return_type, AsTaskType};
 use super::{UserDataPointer, HYPER_ITER_CONTINUE};
-use crate::body::{Bytes, Frame, Recv};
+use crate::body::{Bytes, Frame, Incoming as IncomingBody};
 
 /// A streaming HTTP body.
-pub struct hyper_body(pub(super) Recv);
+pub struct hyper_body(pub(super) IncomingBody);
 
 /// A buffer of bytes that is sent or received on a `hyper_body`.
 pub struct hyper_buf(pub(crate) Bytes);
@@ -33,7 +33,7 @@ ffi_fn! {
     ///
     /// If not configured, this body acts as an empty payload.
     fn hyper_body_new() -> *mut hyper_body {
-        Box::into_raw(Box::new(hyper_body(Recv::ffi())))
+        Box::into_raw(Box::new(hyper_body(IncomingBody::ffi())))
     } ?= ptr::null_mut()
 }
 

--- a/src/ffi/client.rs
+++ b/src/ffi/client.rs
@@ -32,9 +32,9 @@ pub struct hyper_clientconn {
 
 enum Tx {
     #[cfg(feature = "http1")]
-    Http1(conn::http1::SendRequest<crate::Recv>),
+    Http1(conn::http1::SendRequest<crate::body::Incoming>),
     #[cfg(feature = "http2")]
-    Http2(conn::http2::SendRequest<crate::Recv>),
+    Http2(conn::http2::SendRequest<crate::body::Incoming>),
 }
 
 // ===== impl hyper_clientconn =====
@@ -57,7 +57,7 @@ ffi_fn! {
             if options.http2 {
                 return conn::http2::Builder::new()
                     .executor(options.exec.clone())
-                    .handshake::<_, crate::Recv>(io)
+                    .handshake::<_, crate::body::Incoming>(io)
                     .await
                     .map(|(tx, conn)| {
                         options.exec.execute(Box::pin(async move {
@@ -73,7 +73,7 @@ ffi_fn! {
                 .http1_allow_obsolete_multiline_headers_in_responses(options.http1_allow_obsolete_multiline_headers_in_responses)
                 .http1_preserve_header_case(options.http1_preserve_header_case)
                 .http1_preserve_header_order(options.http1_preserve_header_order)
-                .handshake::<_, crate::Recv>(io)
+                .handshake::<_, crate::body::Incoming>(io)
                 .await
                 .map(|(tx, conn)| {
                     options.exec.execute(Box::pin(async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,6 @@ pub use crate::http::{header, Method, Request, Response, StatusCode, Uri, Versio
 #[doc(no_inline)]
 pub use crate::http::HeaderMap;
 
-pub use crate::body::Recv;
 pub use crate::error::{Error, Result};
 
 #[macro_use]

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1085,7 +1085,7 @@ impl Http1Transaction for Client {
             #[cfg(feature = "ffi")]
             if head.subject.is_informational() {
                 if let Some(callback) = ctx.on_informational {
-                    callback.call(head.into_response(crate::Recv::empty()));
+                    callback.call(head.into_response(crate::body::Incoming::empty()));
                 }
             }
 

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use crate::body::{Body, Recv};
+use crate::body::{Body, Incoming as IncomingBody};
 use crate::common::exec::{ConnStreamExec};
 use crate::common::{task, Future, Pin, Poll, Unpin};
 use crate::{common::time::Time, rt::Timer};
@@ -22,7 +22,7 @@ pin_project! {
     #[must_use = "futures do nothing unless polled"]
     pub struct Connection<T, S, E>
     where
-        S: HttpService<Recv>,
+        S: HttpService<IncomingBody>,
     {
         conn: proto::h2::Server<T, S, S::ResBody, E>,
     }
@@ -40,7 +40,7 @@ pub struct Builder<E> {
 
 impl<I, S, E> fmt::Debug for Connection<I, S, E>
 where
-    S: HttpService<Recv>,
+    S: HttpService<IncomingBody>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Connection").finish()
@@ -49,7 +49,7 @@ where
 
 impl<I, B, S, E> Connection<I, S, E>
 where
-    S: HttpService<Recv, ResBody = B>,
+    S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
     I: AsyncRead + AsyncWrite + Unpin,
     B: Body + 'static,
@@ -73,7 +73,7 @@ where
 
 impl<I, B, S, E> Future for Connection<I, S, E>
 where
-    S: HttpService<Recv, ResBody = B>,
+    S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
     I: AsyncRead + AsyncWrite + Unpin + 'static,
     B: Body + 'static,
@@ -286,7 +286,7 @@ impl<E> Builder<E> {
     /// driven on the connection.
     pub fn serve_connection<S, I, Bd>(&self, io: I, service: S) -> Connection<I, S, E>
     where
-        S: HttpService<Recv, ResBody = Bd>,
+        S: HttpService<IncomingBody, ResBody = Bd>,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
         Bd: Body + 'static,
         Bd::Error: Into<Box<dyn StdError + Send + Sync>>,

--- a/src/server/conn/mod.rs
+++ b/src/server/conn/mod.rs
@@ -17,7 +17,7 @@
 //! # mod rt {
 //! use http::{Request, Response, StatusCode};
 //! use http_body_util::Full;
-//! use hyper::{server::conn::http1, service::service_fn, body::Bytes};
+//! use hyper::{server::conn::http1, service::service_fn, body, body::Bytes};
 //! use std::{net::SocketAddr, convert::Infallible};
 //! use tokio::net::TcpListener;
 //!
@@ -39,7 +39,7 @@
 //!     }
 //! }
 //!
-//! async fn hello(_req: Request<hyper::Recv>) -> Result<Response<Full<Bytes>>, Infallible> {
+//! async fn hello(_req: Request<body::Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
 //!    Ok(Response::new(Full::new(Bytes::from("Hello World!"))))
 //! }
 //! # }

--- a/src/service/util.rs
+++ b/src/service/util.rs
@@ -13,11 +13,11 @@ use crate::{Request, Response};
 ///
 /// ```
 /// use bytes::Bytes;
-/// use hyper::{Recv, Request, Response, Version};
+/// use hyper::{body, Request, Response, Version};
 /// use http_body_util::Full;
 /// use hyper::service::service_fn;
 ///
-/// let service = service_fn(|req: Request<Recv>| async move {
+/// let service = service_fn(|req: Request<body::Incoming>| async move {
 ///     if req.version() == Version::HTTP_11 {
 ///         Ok(Response::new(Full::<Bytes>::from("Hello World")))
 ///     } else {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1345,7 +1345,7 @@ mod conn {
     use hyper::body::{Body, Frame};
     use hyper::client::conn;
     use hyper::upgrade::OnUpgrade;
-    use hyper::{self, Method, Recv, Request, Response, StatusCode};
+    use hyper::{Method, Request, Response, StatusCode};
 
     use super::{concat, s, support, tcp_connect, FutureHyperExt};
 
@@ -1899,7 +1899,7 @@ mod conn {
                     res = listener.accept() => {
                         let (stream, _) = res.unwrap();
 
-                        let service = service_fn(|_:Request<Recv>| future::ok::<_, hyper::Error>(Response::new(Empty::<Bytes>::new())));
+                        let service = service_fn(|_:Request<hyper::body::Incoming>| future::ok::<_, hyper::Error>(Response::new(Empty::<Bytes>::new())));
 
                         let mut shdn_rx = shdn_rx.clone();
                         tokio::task::spawn(async move {
@@ -1994,7 +1994,7 @@ mod conn {
             .http2_keep_alive_timeout(Duration::from_secs(1))
             // enable while idle since we aren't sending requests
             .http2_keep_alive_while_idle(true)
-            .handshake::<_, Recv>(io)
+            .handshake::<_, hyper::body::Incoming>(io)
             .await
             .expect("http handshake");
 
@@ -2026,7 +2026,7 @@ mod conn {
             .timer(TokioTimer)
             .http2_keep_alive_interval(Duration::from_secs(1))
             .http2_keep_alive_timeout(Duration::from_secs(1))
-            .handshake::<_, Recv>(io)
+            .handshake::<_, hyper::body::Incoming>(io)
             .await
             .expect("http handshake");
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -12,7 +12,7 @@ use hyper::server;
 use tokio::net::{TcpListener, TcpStream};
 
 use hyper::service::service_fn;
-use hyper::{Recv, Request, Response, Version};
+use hyper::{body::Incoming as IncomingBody, Request, Response, Version};
 
 pub use futures_util::{
     future, FutureExt as _, StreamExt as _, TryFutureExt as _, TryStreamExt as _,
@@ -360,7 +360,7 @@ async fn async_test(cfg: __TestConfig) {
 
             // Move a clone into the service_fn
             let serve_handles = serve_handles.clone();
-            let service = service_fn(move |req: Request<Recv>| {
+            let service = service_fn(move |req: Request<IncomingBody>| {
                 let (sreq, sres) = serve_handles.lock().unwrap().remove(0);
 
                 assert_eq!(req.uri().path(), sreq.uri, "client path");
@@ -562,7 +562,9 @@ async fn naive_proxy(cfg: ProxyConfig) -> (SocketAddr, impl Future<Output = ()>)
                         let mut builder = Response::builder().status(parts.status);
                         *builder.headers_mut().unwrap() = parts.headers;
 
-                        Result::<Response<Recv>, hyper::Error>::Ok(builder.body(body).unwrap())
+                        Result::<Response<hyper::body::Incoming>, hyper::Error>::Ok(
+                            builder.body(body).unwrap(),
+                        )
                     }
                 });
 


### PR DESCRIPTION
The concrete "recv stream" body type is renamed to `Incoming`.

Closes #2971 