### PR TITLE
feat(client): allow ignoring HTTP/1 invalid header lines in requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ http = "0.2"
 http-body = "1.0.0-rc.1"
 http-body-util = { version = "0.1.0-rc.1", optional = true }
 httpdate = "1.0"
-httparse = "1.6"
+httparse = "1.8"
 h2 = { version = "0.3.9", optional = true }
 itoa = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -390,6 +390,24 @@ impl Builder {
         self
     }
 
+    /// Set whether HTTP/1 connections will silently ignored malformed header lines.
+    ///
+    /// If this is enabled and and a header line does not start with a valid header
+    /// name, or does not include a colon at all, the line will be silently ignored
+    /// and no error will be reported.
+    ///
+    /// Note that this setting does not affect HTTP/2.
+    ///
+    /// Default is false.
+    pub fn http1_ignore_invalid_headers_in_responses(
+        &mut self,
+        enabled: bool,
+    ) -> &mut Builder {
+        self.h1_parser_config
+            .ignore_invalid_headers_in_responses(enabled);
+        self
+    }
+
     /// Set whether HTTP/1 connections should try to use vectored writes,
     /// or always flatten into a single buffer.
     ///


### PR DESCRIPTION
Cherry-picks #2819 to master.