### PR TITLE
chore(body): pub empty

### DIFF
--- a/src/body/incoming.rs
+++ b/src/body/incoming.rs
@@ -104,8 +104,9 @@ impl Incoming {
         Incoming { kind }
     }
 
+    /// Create an empty `Body` stream.
     #[allow(dead_code)]
-    pub(crate) fn empty() -> Incoming {
+    pub fn empty() -> Incoming {
         Incoming::new(Kind::Empty)
     }
 


### PR DESCRIPTION
Sometimes we want to replace the body.

```rust
BodyExt::collect(replace(req.body_mut(), IncomingBody::empty()))
```
