### PR TITLE
refactor(rt): Clean up Timer trait

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -28,10 +28,3 @@ cfg_proto! {
     pub(crate) use std::marker::Unpin;
 }
 pub(crate) use std::{future::Future, pin::Pin};
-
-pub(crate) fn into_pin<T: ?Sized>(boxed: Box<T>) -> Pin<Box<T>> {
-    // It's not possible to move or replace the insides of a `Pin<Box<T>>`
-    // when `T: !Unpin`, so it's safe to pin it directly without any
-    // additional requirements.
-    unsafe { Pin::new_unchecked(boxed) }
-}

--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -55,7 +55,7 @@ impl<F> Future for HyperTimeout<F> where F: Future {
 */
 
 impl Time {
-    pub(crate) fn sleep(&self, duration: Duration) -> Box<dyn Sleep + Unpin> {
+    pub(crate) fn sleep(&self, duration: Duration) -> Pin<Box<dyn Sleep>> {
         match *self {
             Time::Empty => {
                 panic!("You must supply a timer.")
@@ -64,7 +64,7 @@ impl Time {
         }
     }
 
-    pub(crate) fn sleep_until(&self, deadline: Instant) -> Box<dyn Sleep + Unpin> {
+    pub(crate) fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Sleep>> {
         match *self {
             Time::Empty => {
                 panic!("You must supply a timer.")

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -87,8 +87,7 @@ where
                 }
                 None => {
                     debug!("setting h1 header read timeout timer");
-                    *ctx.h1_header_read_timeout_fut =
-                        Some(crate::common::into_pin(ctx.timer.sleep_until(deadline)));
+                    *ctx.h1_header_read_timeout_fut = Some(ctx.timer.sleep_until(deadline));
                 }
             }
         }

--- a/src/proto/h2/ping.rs
+++ b/src/proto/h2/ping.rs
@@ -61,7 +61,7 @@ pub(super) fn channel(ping_pong: PingPong, config: Config, __timer: Time) -> (Re
         interval,
         timeout: config.keep_alive_timeout,
         while_idle: config.keep_alive_while_idle,
-        sleep: crate::common::into_pin(__timer.sleep(interval)),
+        sleep: __timer.sleep(interval),
         state: KeepAliveState::Init,
         timer: __timer,
     });

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -20,16 +20,16 @@ pub trait Executor<Fut> {
 /// A timer which provides timer-like functions.
 pub trait Timer {
     /// Return a future that resolves in `duration` time.
-    fn sleep(&self, duration: Duration) -> Box<dyn Sleep + Unpin>;
+    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Sleep>>;
 
     /// Return a future that resolves at `deadline`.
-    fn sleep_until(&self, deadline: Instant) -> Box<dyn Sleep + Unpin>;
+    fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Sleep>>;
 
     /// Reset a future to resolve at `new_deadline` instead.
     fn reset(&self, sleep: &mut Pin<Box<dyn Sleep>>, new_deadline: Instant) {
-        *sleep = crate::common::into_pin(self.sleep_until(new_deadline));
+        *sleep = self.sleep_until(new_deadline);
     }
 }
 
 /// A future returned by a `Timer`.
-pub trait Sleep: Send + Sync + Unpin + Future<Output = ()> {}
+pub trait Sleep: Send + Sync + Future<Output = ()> {}


### PR DESCRIPTION
This both avoids an unnecessary extra layer of boxing and removes some dubious unsafe code.

Closes #3028