### PR TITLE
Add test for a large Content-Length header in body::to_bytes

### DIFF
--- a/src/body/to_bytes.rs
+++ b/src/body/to_bytes.rs
@@ -54,8 +54,7 @@ where
 
     let content_length = body.size_hint().lower();
 
-    // If the expected content length is to large, returnan empty body.
-    // It is also possible to return an error instead.
+    // If the expected content length is to large, return an empty body.
     if content_length > MAX_ALLOWED_SIZE {
         return Ok(Bytes::new());
     }

--- a/src/body/to_bytes.rs
+++ b/src/body/to_bytes.rs
@@ -50,6 +50,17 @@ where
 {
     futures_util::pin_mut!(body);
 
+    const MAX_ALLOWED_SIZE: u64 = 10 * 1024 * 1024 * 1024;
+
+    let content_length = body.size_hint().lower();
+
+    // If the expected content length is to large, returnan empty body.
+    // It is also possible to return an error instead.
+    if content_length > MAX_ALLOWED_SIZE {
+        return Ok(Bytes::new());
+    }
+
+
     // If there's only 1 chunk, we can just return Buf::to_bytes()
     let mut first = if let Some(buf) = body.data().await {
         buf?


### PR DESCRIPTION
This is a quick fix to make sure that the expected body length is less than 10GB before reading all of it. If the expected length is too big, the function will return an empty buffer.