### PR TITLE
refactor(test):#1675 use fns for creating test server

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1351,13 +1351,18 @@ mod conn {
 
     use support::{TokioExecutor, TokioTimer};
 
-    #[tokio::test]
-    async fn get() {
-        let _ = ::pretty_env_logger::try_init();
+    async fn setup_test_server() -> (TkTcpListener, SocketAddr) {
+        let _ = pretty_env_logger::try_init();
         let listener = TkTcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .unwrap();
         let addr = listener.local_addr().unwrap();
+        (listener, addr)
+    }
+
+    #[tokio::test]
+    async fn get() {
+        let (listener, addr) = setup_test_server().await;
 
         let server = async move {
             let mut sock = listener.accept().await.unwrap().0;
@@ -1397,11 +1402,7 @@ mod conn {
 
     #[tokio::test]
     async fn get_custom_reason_phrase() {
-        let _ = ::pretty_env_logger::try_init();
-        let listener = TkTcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .await
-            .unwrap();
-        let addr = listener.local_addr().unwrap();
+        let (listener, addr) = setup_test_server().await;
 
         let server = async move {
             let mut sock = listener.accept().await.unwrap().0;
@@ -1883,12 +1884,8 @@ mod conn {
     async fn http2_detect_conn_eof() {
         use futures_util::future;
 
-        let _ = pretty_env_logger::try_init();
+        let (listener, addr) = setup_test_server().await;
 
-        let addr = SocketAddr::from(([127, 0, 0, 1], 0));
-        let listener = TkTcpListener::bind(addr).await.unwrap();
-
-        let addr = listener.local_addr().unwrap();
         let (shdn_tx, mut shdn_rx) = tokio::sync::watch::channel(false);
         tokio::task::spawn(async move {
             use hyper::server::conn::http2;
@@ -1966,12 +1963,7 @@ mod conn {
 
     #[tokio::test]
     async fn http2_keep_alive_detects_unresponsive_server() {
-        let _ = pretty_env_logger::try_init();
-
-        let listener = TkTcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .await
-            .unwrap();
-        let addr = listener.local_addr().unwrap();
+        let (listener, addr) = setup_test_server().await;
 
         // spawn a server that reads but doesn't write
         tokio::spawn(async move {
@@ -2007,12 +1999,7 @@ mod conn {
         // will use the default behavior which will NOT detect the server
         // is unresponsive while no streams are active.
 
-        let _ = pretty_env_logger::try_init();
-
-        let listener = TkTcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .await
-            .unwrap();
-        let addr = listener.local_addr().unwrap();
+        let (listener, addr) = setup_test_server().await;
 
         // spawn a server that reads but doesn't write
         tokio::spawn(async move {
@@ -2044,12 +2031,7 @@ mod conn {
 
     #[tokio::test]
     async fn http2_keep_alive_closes_open_streams() {
-        let _ = pretty_env_logger::try_init();
-
-        let listener = TkTcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .await
-            .unwrap();
-        let addr = listener.local_addr().unwrap();
+        let (listener, addr) = setup_test_server().await;
 
         // spawn a server that reads but doesn't write
         tokio::spawn(async move {
@@ -2095,12 +2077,7 @@ mod conn {
         // alive is enabled
         use hyper::service::service_fn;
 
-        let _ = pretty_env_logger::try_init();
-
-        let listener = TkTcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .await
-            .unwrap();
-        let addr = listener.local_addr().unwrap();
+        let (listener, addr) = setup_test_server().await;
 
         // Spawn an HTTP2 server that reads the whole body and responds
         tokio::spawn(async move {
@@ -2152,12 +2129,7 @@ mod conn {
 
     #[tokio::test]
     async fn h2_connect() {
-        let _ = pretty_env_logger::try_init();
-
-        let listener = TkTcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .await
-            .unwrap();
-        let addr = listener.local_addr().unwrap();
+        let (listener, addr) = setup_test_server().await;
 
         // Spawn an HTTP2 server that asks for bread and responds with baguette.
         tokio::spawn(async move {
@@ -2213,12 +2185,7 @@ mod conn {
 
     #[tokio::test]
     async fn h2_connect_rejected() {
-        let _ = pretty_env_logger::try_init();
-
-        let listener = TkTcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .await
-            .unwrap();
-        let addr = listener.local_addr().unwrap();
+        let (listener, addr) = setup_test_server().await;
         let (done_tx, done_rx) = oneshot::channel();
 
         tokio::spawn(async move {
@@ -2269,12 +2236,7 @@ mod conn {
 
     #[tokio::test]
     async fn test_body_panics() {
-        let _ = pretty_env_logger::try_init();
-
-        let listener = TkTcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
-            .await
-            .unwrap();
-        let addr = listener.local_addr().unwrap();
+        let (listener, addr) = setup_test_server().await;
 
         // spawn a server that reads but doesn't write
         tokio::spawn(async move {


### PR DESCRIPTION
This is a part of https://github.com/hyperium/hyper/issues/1675 issue. It
slightly reduces the number of duplicated code by using one common function for
init a logger and creating a test server.