### PR TITLE
Remove unused `dev-dependency` on `pnet_datalink`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ include = [
   "Cargo.toml",
   "LICENSE",
   "src/**/*",
-  #"build.rs",
 ]
 
 [dependencies]
@@ -65,9 +64,6 @@ tokio = { version = "1", features = [
 tokio-test = "0.4"
 tokio-util = { version = "0.7", features = ["codec"] }
 url = "2.2"
-
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dev-dependencies]
-pnet_datalink = "0.27.2"
 
 [features]
 # Nothing by default


### PR DESCRIPTION
This is no longer needed since https://github.com/hyperium/hyper/pull/2929 landed (and then https://github.com/hyperium/hyper/pull/2949 really burned the forest) - this change saves 4 crates from the build.

The other (non-`dev`) crates reported by `cargo udeps` are harder to eliminate:

* `httpdate` used by `server AND (http1 OR http2)`
* `want` used by `client AND (http1 OR http2)`
* `tracing` used by `http1 OR http2`

Requirements of the form `A AND (B OR C)` are unrepresentable perfectly in `Cargo.toml` even with the new features syntax but we might be able to do something sensible here.  If it's a reasonable assumption that `(http1 OR http2)` is logically always true (since hyper is pretty nerfed without at least one of these) then we could make `server` depend on `httpdate` and `client` on `want` (and `tracing` drops out automatically).  Making these changes saves 2 crates for non-client builds and 1 from non-server builds.