### PR TITLE
chore(ci): replace unmaintained actions-rs/toolchain action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,11 +35,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
 
       - name: cargo fmt --check
@@ -79,11 +76,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust (${{ matrix.rust }})
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
 
       - name: Test
         uses: actions-rs/cargo@v1
@@ -116,11 +111,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust (${{ matrix.rust }})
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.rust }}
-          override: true
 
       - name: Check
         uses: actions-rs/cargo@v1
@@ -138,12 +131,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
           components: miri
-          override: true
 
       - name: Test
         # Can't enable tcp feature since Miri does not support the tokio runtime
@@ -158,11 +148,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cargo-hack
         run: cargo install cargo-hack
@@ -179,11 +165,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install cbindgen
         uses: actions-rs/cargo@v1
@@ -218,13 +200,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          default: true
-          override: true
-          components: cargo
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Install cbindgen
         uses: actions-rs/cargo@v1
@@ -252,11 +228,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: cargo doc
         uses: actions-rs/cargo@v1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -18,11 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
 
       # Run benchmark and stores the output to a file
       - name: Run benchmark
@@ -30,7 +26,7 @@ jobs:
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark


### PR DESCRIPTION
The @actions-rs GitHub org as a whole is unmaintained, and actions from this org will start failing around July 2023 due to [planned](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) [deprecations](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) announced by GitHub. This PR replaces the `actions-rs/toolchain` action with [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain), which is actively maintained and provides the same features.

A quick look at the CI timings shows no regressions in Rust toolchain install time.