### PR TITLE
Remove version specific prefixes from builders

### DIFF
--- a/examples/http_proxy.rs
+++ b/examples/http_proxy.rs
@@ -90,8 +90,8 @@ async fn proxy(
         let stream = TcpStream::connect(addr).await.unwrap();
 
         let (mut sender, conn) = Builder::new()
-            .http1_preserve_header_case(true)
-            .http1_title_case_headers(true)
+            .preserve_header_case(true)
+            .title_case_headers(true)
             .handshake(stream)
             .await?;
         tokio::task::spawn(async move {

--- a/examples/http_proxy.rs
+++ b/examples/http_proxy.rs
@@ -31,8 +31,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         tokio::task::spawn(async move {
             if let Err(err) = http1::Builder::new()
-                .http1_preserve_header_case(true)
-                .http1_title_case_headers(true)
+                .preserve_header_case(true)
+                .title_case_headers(true)
                 .serve_connection(stream, service_fn(proxy))
                 .with_upgrades()
                 .await

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -333,8 +333,6 @@ impl Builder {
     /// > of 400 (Bad Request). A proxy MUST remove any such whitespace from a
     /// > response message before forwarding the message downstream.
     ///
-    /// Note that this setting does not affect HTTP/2.
-    ///
     /// Default is false.
     ///
     /// [RFC 7230 Section 3.2.4.]: https://tools.ietf.org/html/rfc7230#section-3.2.4
@@ -376,8 +374,6 @@ impl Builder {
     /// > obs-fold with one or more SP octets prior to interpreting the field
     /// > value.
     ///
-    /// Note that this setting does not affect HTTP/2.
-    ///
     /// Default is false.
     ///
     /// [RFC 7230 Section 3.2.4.]: https://tools.ietf.org/html/rfc7230#section-3.2.4
@@ -395,8 +391,6 @@ impl Builder {
     /// If this is enabled and and a header line does not start with a valid header
     /// name, or does not include a colon at all, the line will be silently ignored
     /// and no error will be reported.
-    ///
-    /// Note that this setting does not affect HTTP/2.
     ///
     /// Default is false.
     pub fn ignore_invalid_headers_in_responses(&mut self, enabled: bool) -> &mut Builder {
@@ -425,8 +419,6 @@ impl Builder {
     /// Set whether HTTP/1 connections will write header names as title case at
     /// the socket level.
     ///
-    /// Note that this setting does not affect HTTP/2.
-    ///
     /// Default is false.
     pub fn title_case_headers(&mut self, enabled: bool) -> &mut Builder {
         self.h1_title_case_headers = enabled;
@@ -443,8 +435,6 @@ impl Builder {
     /// interact with the original cases. The only effect this can have now is
     /// to forward the cases in a proxy-like fashion.
     ///
-    /// Note that this setting does not affect HTTP/2.
-    ///
     /// Default is false.
     pub fn preserve_header_case(&mut self, enabled: bool) -> &mut Builder {
         self.h1_preserve_header_case = enabled;
@@ -456,8 +446,6 @@ impl Builder {
     /// Currently, this will record the order in which headers are received, and store this
     /// ordering in a private extension on the `Response`. It will also look for and use
     /// such an extension in any provided `Request`.
-    ///
-    /// Note that this setting does not affect HTTP/2.
     ///
     /// Default is false.
     #[cfg(feature = "ffi")]

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -338,7 +338,7 @@ impl Builder {
     /// Default is false.
     ///
     /// [RFC 7230 Section 3.2.4.]: https://tools.ietf.org/html/rfc7230#section-3.2.4
-    pub fn http1_allow_spaces_after_header_name_in_responses(
+    pub fn allow_spaces_after_header_name_in_responses(
         &mut self,
         enabled: bool,
     ) -> &mut Builder {
@@ -381,7 +381,7 @@ impl Builder {
     /// Default is false.
     ///
     /// [RFC 7230 Section 3.2.4.]: https://tools.ietf.org/html/rfc7230#section-3.2.4
-    pub fn http1_allow_obsolete_multiline_headers_in_responses(
+    pub fn allow_obsolete_multiline_headers_in_responses(
         &mut self,
         enabled: bool,
     ) -> &mut Builder {
@@ -399,7 +399,7 @@ impl Builder {
     /// Note that this setting does not affect HTTP/2.
     ///
     /// Default is false.
-    pub fn http1_ignore_invalid_headers_in_responses(&mut self, enabled: bool) -> &mut Builder {
+    pub fn ignore_invalid_headers_in_responses(&mut self, enabled: bool) -> &mut Builder {
         self.h1_parser_config
             .ignore_invalid_headers_in_responses(enabled);
         self
@@ -417,7 +417,7 @@ impl Builder {
     ///
     /// Default is `auto`. In this mode hyper will try to guess which
     /// mode to use
-    pub fn http1_writev(&mut self, enabled: bool) -> &mut Builder {
+    pub fn writev(&mut self, enabled: bool) -> &mut Builder {
         self.h1_writev = Some(enabled);
         self
     }
@@ -428,7 +428,7 @@ impl Builder {
     /// Note that this setting does not affect HTTP/2.
     ///
     /// Default is false.
-    pub fn http1_title_case_headers(&mut self, enabled: bool) -> &mut Builder {
+    pub fn title_case_headers(&mut self, enabled: bool) -> &mut Builder {
         self.h1_title_case_headers = enabled;
         self
     }
@@ -446,7 +446,7 @@ impl Builder {
     /// Note that this setting does not affect HTTP/2.
     ///
     /// Default is false.
-    pub fn http1_preserve_header_case(&mut self, enabled: bool) -> &mut Builder {
+    pub fn preserve_header_case(&mut self, enabled: bool) -> &mut Builder {
         self.h1_preserve_header_case = enabled;
         self
     }
@@ -461,17 +461,17 @@ impl Builder {
     ///
     /// Default is false.
     #[cfg(feature = "ffi")]
-    pub fn http1_preserve_header_order(&mut self, enabled: bool) -> &mut Builder {
+    pub fn preserve_header_order(&mut self, enabled: bool) -> &mut Builder {
         self.h1_preserve_header_order = enabled;
         self
     }
 
     /// Sets the exact size of the read buffer to *always* use.
     ///
-    /// Note that setting this option unsets the `http1_max_buf_size` option.
+    /// Note that setting this option unsets the `max_buf_size` option.
     ///
     /// Default is an adaptive read buffer.
-    pub fn http1_read_buf_exact_size(&mut self, sz: Option<usize>) -> &mut Builder {
+    pub fn read_buf_exact_size(&mut self, sz: Option<usize>) -> &mut Builder {
         self.h1_read_buf_exact_size = sz;
         self.h1_max_buf_size = None;
         self
@@ -481,12 +481,12 @@ impl Builder {
     ///
     /// Default is ~400kb.
     ///
-    /// Note that setting this option unsets the `http1_read_exact_buf_size` option.
+    /// Note that setting this option unsets the `read_exact_buf_size` option.
     ///
     /// # Panics
     ///
     /// The minimum value allowed is 8192. This method panics if the passed `max` is less than the minimum.
-    pub fn http1_max_buf_size(&mut self, max: usize) -> &mut Self {
+    pub fn max_buf_size(&mut self, max: usize) -> &mut Self {
         assert!(
             max >= proto::h1::MINIMUM_MAX_BUFFER_SIZE,
             "the max_buf_size cannot be smaller than the minimum that h1 specifies."

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -278,7 +278,7 @@ impl Builder {
     /// If not set, hyper will use a default.
     ///
     /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
-    pub fn http2_initial_stream_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+    pub fn initial_stream_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         if let Some(sz) = sz.into() {
             self.h2_builder.adaptive_window = false;
             self.h2_builder.initial_stream_window_size = sz;
@@ -291,7 +291,7 @@ impl Builder {
     /// Passing `None` will do nothing.
     ///
     /// If not set, hyper will use a default.
-    pub fn http2_initial_connection_window_size(
+    pub fn initial_connection_window_size(
         &mut self,
         sz: impl Into<Option<u32>>,
     ) -> &mut Self {
@@ -305,9 +305,9 @@ impl Builder {
     /// Sets whether to use an adaptive flow control.
     ///
     /// Enabling this will override the limits set in
-    /// `http2_initial_stream_window_size` and
-    /// `http2_initial_connection_window_size`.
-    pub fn http2_adaptive_window(&mut self, enabled: bool) -> &mut Self {
+    /// `initial_stream_window_size` and
+    /// `initial_connection_window_size`.
+    pub fn adaptive_window(&mut self, enabled: bool) -> &mut Self {
         use proto::h2::SPEC_WINDOW_SIZE;
 
         self.h2_builder.adaptive_window = enabled;
@@ -323,7 +323,7 @@ impl Builder {
     /// Passing `None` will do nothing.
     ///
     /// If not set, hyper will use a default.
-    pub fn http2_max_frame_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+    pub fn max_frame_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         if let Some(sz) = sz.into() {
             self.h2_builder.max_frame_size = sz;
         }
@@ -336,7 +336,7 @@ impl Builder {
     /// Pass `None` to disable HTTP2 keep-alive.
     ///
     /// Default is currently disabled.
-    pub fn http2_keep_alive_interval(
+    pub fn keep_alive_interval(
         &mut self,
         interval: impl Into<Option<Duration>>,
     ) -> &mut Self {
@@ -347,10 +347,10 @@ impl Builder {
     /// Sets a timeout for receiving an acknowledgement of the keep-alive ping.
     ///
     /// If the ping is not acknowledged within the timeout, the connection will
-    /// be closed. Does nothing if `http2_keep_alive_interval` is disabled.
+    /// be closed. Does nothing if `keep_alive_interval` is disabled.
     ///
     /// Default is 20 seconds.
-    pub fn http2_keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
+    pub fn keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.h2_builder.keep_alive_timeout = timeout;
         self
     }
@@ -359,11 +359,11 @@ impl Builder {
     ///
     /// If disabled, keep-alive pings are only sent while there are open
     /// request/responses streams. If enabled, pings are also sent when no
-    /// streams are active. Does nothing if `http2_keep_alive_interval` is
+    /// streams are active. Does nothing if `keep_alive_interval` is
     /// disabled.
     ///
     /// Default is `false`.
-    pub fn http2_keep_alive_while_idle(&mut self, enabled: bool) -> &mut Self {
+    pub fn keep_alive_while_idle(&mut self, enabled: bool) -> &mut Self {
         self.h2_builder.keep_alive_while_idle = enabled;
         self
     }
@@ -376,7 +376,7 @@ impl Builder {
     /// The default value is determined by the `h2` crate.
     ///
     /// [`h2::client::Builder::max_concurrent_reset_streams`]: https://docs.rs/h2/client/struct.Builder.html#method.max_concurrent_reset_streams
-    pub fn http2_max_concurrent_reset_streams(&mut self, max: usize) -> &mut Self {
+    pub fn max_concurrent_reset_streams(&mut self, max: usize) -> &mut Self {
         self.h2_builder.max_concurrent_reset_streams = Some(max);
         self
     }
@@ -388,7 +388,7 @@ impl Builder {
     /// # Panics
     ///
     /// The value must be no larger than `u32::MAX`.
-    pub fn http2_max_send_buf_size(&mut self, max: usize) -> &mut Self {
+    pub fn max_send_buf_size(&mut self, max: usize) -> &mut Self {
         assert!(max <= std::u32::MAX as usize);
         self.h2_builder.max_send_buffer_size = max;
         self

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -76,7 +76,7 @@ impl fmt::Debug for Protocol {
 /// A map from header names to their original casing as received in an HTTP message.
 ///
 /// If an HTTP/1 response `res` is parsed on a connection whose option
-/// [`http1_preserve_header_case`] was set to true and the response included
+/// [`preserve_header_case`] was set to true and the response included
 /// the following headers:
 ///
 /// ```ignore
@@ -93,7 +93,7 @@ impl fmt::Debug for Protocol {
 /// })
 /// ```
 ///
-/// [`http1_preserve_header_case`]: /client/struct.Client.html#method.http1_preserve_header_case
+/// [`preserve_header_case`]: /client/struct.Client.html#method.preserve_header_case
 #[derive(Clone, Debug)]
 pub(crate) struct HeaderCaseMap(HeaderMap<Bytes>);
 

--- a/src/ffi/client.rs
+++ b/src/ffi/client.rs
@@ -70,9 +70,9 @@ ffi_fn! {
 
             conn::http1::Builder::new()
                 .executor(options.exec.clone())
-                .http1_allow_obsolete_multiline_headers_in_responses(options.http1_allow_obsolete_multiline_headers_in_responses)
-                .http1_preserve_header_case(options.http1_preserve_header_case)
-                .http1_preserve_header_order(options.http1_preserve_header_order)
+                .allow_obsolete_multiline_headers_in_responses(options.http1_allow_obsolete_multiline_headers_in_responses)
+                .preserve_header_case(options.http1_preserve_header_case)
+                .preserve_header_order(options.http1_preserve_header_order)
                 .handshake::<_, crate::body::Incoming>(io)
                 .await
                 .map(|(tx, conn)| {

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -224,7 +224,7 @@ impl Builder {
     /// detects an EOF in the middle of a request.
     ///
     /// Default is `false`.
-    pub fn http1_half_close(&mut self, val: bool) -> &mut Self {
+    pub fn half_close(&mut self, val: bool) -> &mut Self {
         self.h1_half_close = val;
         self
     }
@@ -232,7 +232,7 @@ impl Builder {
     /// Enables or disables HTTP/1 keep-alive.
     ///
     /// Default is true.
-    pub fn http1_keep_alive(&mut self, val: bool) -> &mut Self {
+    pub fn keep_alive(&mut self, val: bool) -> &mut Self {
         self.h1_keep_alive = val;
         self
     }
@@ -243,7 +243,7 @@ impl Builder {
     /// Note that this setting does not affect HTTP/2.
     ///
     /// Default is false.
-    pub fn http1_title_case_headers(&mut self, enabled: bool) -> &mut Self {
+    pub fn title_case_headers(&mut self, enabled: bool) -> &mut Self {
         self.h1_title_case_headers = enabled;
         self
     }
@@ -261,7 +261,7 @@ impl Builder {
     /// Note that this setting does not affect HTTP/2.
     ///
     /// Default is false.
-    pub fn http1_preserve_header_case(&mut self, enabled: bool) -> &mut Self {
+    pub fn preserve_header_case(&mut self, enabled: bool) -> &mut Self {
         self.h1_preserve_header_case = enabled;
         self
     }
@@ -270,7 +270,7 @@ impl Builder {
     /// transmit the entire header within this time, the connection is closed.
     ///
     /// Default is None.
-    pub fn http1_header_read_timeout(&mut self, read_timeout: Duration) -> &mut Self {
+    pub fn header_read_timeout(&mut self, read_timeout: Duration) -> &mut Self {
         self.h1_header_read_timeout = Some(read_timeout);
         self
     }
@@ -287,7 +287,7 @@ impl Builder {
     ///
     /// Default is `auto`. In this mode hyper will try to guess which
     /// mode to use
-    pub fn http1_writev(&mut self, val: bool) -> &mut Self {
+    pub fn writev(&mut self, val: bool) -> &mut Self {
         self.h1_writev = Some(val);
         self
     }

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -240,8 +240,6 @@ impl Builder {
     /// Set whether HTTP/1 connections will write header names as title case at
     /// the socket level.
     ///
-    /// Note that this setting does not affect HTTP/2.
-    ///
     /// Default is false.
     pub fn title_case_headers(&mut self, enabled: bool) -> &mut Self {
         self.h1_title_case_headers = enabled;
@@ -257,8 +255,6 @@ impl Builder {
     /// Since the relevant extension is still private, there is no way to
     /// interact with the original cases. The only effect this can have now is
     /// to forward the cases in a proxy-like fashion.
-    ///
-    /// Note that this setting does not affect HTTP/2.
     ///
     /// Default is false.
     pub fn preserve_header_case(&mut self, enabled: bool) -> &mut Self {

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -116,7 +116,7 @@ impl<E> Builder<E> {
     /// If not set, hyper will use a default.
     ///
     /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_INITIAL_WINDOW_SIZE
-    pub fn http2_initial_stream_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+    pub fn initial_stream_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         if let Some(sz) = sz.into() {
             self.h2_builder.adaptive_window = false;
             self.h2_builder.initial_stream_window_size = sz;
@@ -129,7 +129,7 @@ impl<E> Builder<E> {
     /// Passing `None` will do nothing.
     ///
     /// If not set, hyper will use a default.
-    pub fn http2_initial_connection_window_size(
+    pub fn initial_connection_window_size(
         &mut self,
         sz: impl Into<Option<u32>>,
     ) -> &mut Self {
@@ -143,9 +143,9 @@ impl<E> Builder<E> {
     /// Sets whether to use an adaptive flow control.
     ///
     /// Enabling this will override the limits set in
-    /// `http2_initial_stream_window_size` and
-    /// `http2_initial_connection_window_size`.
-    pub fn http2_adaptive_window(&mut self, enabled: bool) -> &mut Self {
+    /// `initial_stream_window_size` and
+    /// `initial_connection_window_size`.
+    pub fn adaptive_window(&mut self, enabled: bool) -> &mut Self {
         use proto::h2::SPEC_WINDOW_SIZE;
 
         self.h2_builder.adaptive_window = enabled;
@@ -161,7 +161,7 @@ impl<E> Builder<E> {
     /// Passing `None` will do nothing.
     ///
     /// If not set, hyper will use a default.
-    pub fn http2_max_frame_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
+    pub fn max_frame_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         if let Some(sz) = sz.into() {
             self.h2_builder.max_frame_size = sz;
         }
@@ -174,7 +174,7 @@ impl<E> Builder<E> {
     /// Default is no limit (`std::u32::MAX`). Passing `None` will do nothing.
     ///
     /// [spec]: https://http2.github.io/http2-spec/#SETTINGS_MAX_CONCURRENT_STREAMS
-    pub fn http2_max_concurrent_streams(&mut self, max: impl Into<Option<u32>>) -> &mut Self {
+    pub fn max_concurrent_streams(&mut self, max: impl Into<Option<u32>>) -> &mut Self {
         self.h2_builder.max_concurrent_streams = max.into();
         self
     }
@@ -188,7 +188,7 @@ impl<E> Builder<E> {
     ///
     /// # Cargo Feature
     ///
-    pub fn http2_keep_alive_interval(
+    pub fn keep_alive_interval(
         &mut self,
         interval: impl Into<Option<Duration>>,
     ) -> &mut Self {
@@ -199,13 +199,13 @@ impl<E> Builder<E> {
     /// Sets a timeout for receiving an acknowledgement of the keep-alive ping.
     ///
     /// If the ping is not acknowledged within the timeout, the connection will
-    /// be closed. Does nothing if `http2_keep_alive_interval` is disabled.
+    /// be closed. Does nothing if `keep_alive_interval` is disabled.
     ///
     /// Default is 20 seconds.
     ///
     /// # Cargo Feature
     ///
-    pub fn http2_keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
+    pub fn keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.h2_builder.keep_alive_timeout = timeout;
         self
     }
@@ -217,7 +217,7 @@ impl<E> Builder<E> {
     /// # Panics
     ///
     /// The value must be no larger than `u32::MAX`.
-    pub fn http2_max_send_buf_size(&mut self, max: usize) -> &mut Self {
+    pub fn max_send_buf_size(&mut self, max: usize) -> &mut Self {
         assert!(max <= std::u32::MAX as usize);
         self.h2_builder.max_send_buffer_size = max;
         self
@@ -226,7 +226,7 @@ impl<E> Builder<E> {
     /// Enables the [extended CONNECT protocol].
     ///
     /// [extended CONNECT protocol]: https://datatracker.ietf.org/doc/html/rfc8441#section-4
-    pub fn http2_enable_connect_protocol(&mut self) -> &mut Self {
+    pub fn enable_connect_protocol(&mut self) -> &mut Self {
         self.h2_builder.enable_connect_protocol = true;
         self
     }
@@ -234,7 +234,7 @@ impl<E> Builder<E> {
     /// Sets the max size of received header frames.
     ///
     /// Default is currently ~16MB, but may change.
-    pub fn http2_max_header_list_size(&mut self, max: u32) -> &mut Self {
+    pub fn max_header_list_size(&mut self, max: u32) -> &mut Self {
         self.h2_builder.max_header_list_size = max;
         self
     }

--- a/src/server/conn/mod.rs
+++ b/src/server/conn/mod.rs
@@ -30,7 +30,7 @@
 //!         let (tcp_stream, _) = tcp_listener.accept().await?;
 //!         tokio::task::spawn(async move {
 //!             if let Err(http_err) = http1::Builder::new()
-//!                     .http1_keep_alive(true)
+//!                     .keep_alive(true)
 //!                     .serve_connection(tcp_stream, service_fn(hello))
 //!                     .await {
 //!                 eprintln!("Error while serving HTTP connection: {}", http_err);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1982,10 +1982,10 @@ mod conn {
         let (_client, conn) = conn::http2::Builder::new()
             .executor(TokioExecutor)
             .timer(TokioTimer)
-            .http2_keep_alive_interval(Duration::from_secs(1))
-            .http2_keep_alive_timeout(Duration::from_secs(1))
+            .keep_alive_interval(Duration::from_secs(1))
+            .keep_alive_timeout(Duration::from_secs(1))
             // enable while idle since we aren't sending requests
-            .http2_keep_alive_while_idle(true)
+            .keep_alive_while_idle(true)
             .handshake::<_, hyper::body::Incoming>(io)
             .await
             .expect("http handshake");
@@ -2011,8 +2011,8 @@ mod conn {
         let (mut client, conn) = conn::http2::Builder::new()
             .executor(TokioExecutor)
             .timer(TokioTimer)
-            .http2_keep_alive_interval(Duration::from_secs(1))
-            .http2_keep_alive_timeout(Duration::from_secs(1))
+            .keep_alive_interval(Duration::from_secs(1))
+            .keep_alive_timeout(Duration::from_secs(1))
             .handshake::<_, hyper::body::Incoming>(io)
             .await
             .expect("http handshake");
@@ -2043,8 +2043,8 @@ mod conn {
         let (mut client, conn) = conn::http2::Builder::new()
             .executor(TokioExecutor)
             .timer(TokioTimer)
-            .http2_keep_alive_interval(Duration::from_secs(1))
-            .http2_keep_alive_timeout(Duration::from_secs(1))
+            .keep_alive_interval(Duration::from_secs(1))
+            .keep_alive_timeout(Duration::from_secs(1))
             .handshake(io)
             .await
             .expect("http handshake");
@@ -2103,8 +2103,8 @@ mod conn {
         let (mut client, conn) = conn::http2::Builder::new()
             .executor(TokioExecutor)
             .timer(TokioTimer)
-            .http2_keep_alive_interval(Duration::from_secs(1))
-            .http2_keep_alive_timeout(Duration::from_secs(1))
+            .keep_alive_interval(Duration::from_secs(1))
+            .keep_alive_timeout(Duration::from_secs(1))
             .handshake(io)
             .await
             .expect("http handshake");

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1197,7 +1197,7 @@ test! {
 
     client:
         options: {
-            http1_title_case_headers: true,
+            title_case_headers: true,
         },
         request: {
             method: GET,
@@ -1311,7 +1311,7 @@ test! {
 
     client:
         options: {
-            http1_allow_obsolete_multiline_headers_in_responses: true,
+            allow_obsolete_multiline_headers_in_responses: true,
         },
         request: {
             method: GET,

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2363,8 +2363,8 @@ async fn http2_keep_alive_detects_unresponsive_client() {
 
     let err = http2::Builder::new(TokioExecutor)
         .timer(TokioTimer)
-        .http2_keep_alive_interval(Duration::from_secs(1))
-        .http2_keep_alive_timeout(Duration::from_secs(1))
+        .keep_alive_interval(Duration::from_secs(1))
+        .keep_alive_timeout(Duration::from_secs(1))
         .serve_connection(socket, unreachable_service())
         .await
         .expect_err("serve_connection should error");
@@ -2381,8 +2381,8 @@ async fn http2_keep_alive_with_responsive_client() {
 
         http2::Builder::new(TokioExecutor)
             .timer(TokioTimer)
-            .http2_keep_alive_interval(Duration::from_secs(1))
-            .http2_keep_alive_timeout(Duration::from_secs(1))
+            .keep_alive_interval(Duration::from_secs(1))
+            .keep_alive_timeout(Duration::from_secs(1))
             .serve_connection(socket, HelloWorld)
             .await
             .expect("serve_connection");
@@ -2445,8 +2445,8 @@ async fn http2_keep_alive_count_server_pings() {
 
         http2::Builder::new(TokioExecutor)
             .timer(TokioTimer)
-            .http2_keep_alive_interval(Duration::from_secs(1))
-            .http2_keep_alive_timeout(Duration::from_secs(1))
+            .keep_alive_interval(Duration::from_secs(1))
+            .keep_alive_timeout(Duration::from_secs(1))
             .serve_connection(socket, unreachable_service())
             .await
             .expect("serve_connection");

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1247,7 +1247,7 @@ async fn http1_allow_half_close() {
 
     let (socket, _) = listener.accept().await.unwrap();
     http1::Builder::new()
-        .http1_half_close(true)
+        .half_close(true)
         .serve_connection(
             socket,
             service_fn(|_| {
@@ -1274,7 +1274,7 @@ async fn disconnect_after_reading_request_before_responding() {
 
     let (socket, _) = listener.accept().await.unwrap();
     http1::Builder::new()
-        .http1_half_close(false)
+        .half_close(false)
         .serve_connection(
             socket,
             service_fn(|_| {
@@ -1370,7 +1370,7 @@ async fn header_read_timeout_slow_writes() {
     let (socket, _) = listener.accept().await.unwrap();
     let conn = http1::Builder::new()
         .timer(TokioTimer)
-        .http1_header_read_timeout(Duration::from_secs(5))
+        .header_read_timeout(Duration::from_secs(5))
         .serve_connection(
             socket,
             service_fn(|_| {
@@ -1445,7 +1445,7 @@ async fn header_read_timeout_slow_writes_multiple_requests() {
     let (socket, _) = listener.accept().await.unwrap();
     let conn = http1::Builder::new()
         .timer(TokioTimer)
-        .http1_header_read_timeout(Duration::from_secs(5))
+        .header_read_timeout(Duration::from_secs(5))
         .serve_connection(
             socket,
             service_fn(|_| {
@@ -2839,7 +2839,7 @@ impl ServeOptions {
                                             .serve_connection(stream, service).await.unwrap();
                                     } else {
                                         http1::Builder::new()
-                                            .http1_keep_alive(_options.keep_alive)
+                                            .keep_alive(_options.keep_alive)
                                             .pipeline_flush(_options.pipeline)
                                             .serve_connection(stream, service).await.unwrap();
                                     }


### PR DESCRIPTION
Fixes #3085 

Should I also change thet non-public methods in `proto::h1::conn`?
  - `set_http1_header_read_timeout`
  - `set_h1_parser_config`


