### PR TITLE
chore(ci): remove unused __internal_happy_eyeballs_tests feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ ffi = ["libc", "http-body-util"]
 
 # internal features used in CI
 nightly = []
-__internal_happy_eyeballs_tests = []
 
 [package.metadata.docs.rs]
 features = ["ffi", "full"]


### PR DESCRIPTION
The `__internal_happy_eyeballs_tests` feature is not used anywhere within this repo, now that the[ `client::connect` module lives in `hyper-util`](https://github.com/hyperium/hyper-util/blob/0e0591e32532b27311d3cc04c33b9515abfb76fa/src/client/connect/http.rs#L881). So, let's remove the feature declaration from `Cargo.toml`.