### PR TITLE
HTTP/1 doesn't need an executor

### DIFF
--- a/src/ffi/client.rs
+++ b/src/ffi/client.rs
@@ -65,11 +65,10 @@ ffi_fn! {
                         }));
                         hyper_clientconn { tx: Tx::Http2(tx) }
                     });
-            }
+                }
             }
 
             conn::http1::Builder::new()
-                .executor(options.exec.clone())
                 .allow_obsolete_multiline_headers_in_responses(options.http1_allow_obsolete_multiline_headers_in_responses)
                 .preserve_header_case(options.http1_preserve_header_case)
                 .preserve_header_order(options.http1_preserve_header_order)

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -35,7 +35,7 @@ pin_project_lite::pin_project! {
 /// A configuration builder for HTTP/1 server connections.
 #[derive(Clone, Debug)]
 pub struct Builder {
-    pub(crate) timer: Time,
+    timer: Time,
     h1_half_close: bool,
     h1_keep_alive: bool,
     h1_title_case_headers: bool,

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -3029,7 +3029,6 @@ impl TestClient {
             sender.send_request(req).await
         } else {
             let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
-                .executor(TokioExecutor)
                 .handshake(stream)
                 .await
                 .unwrap();


### PR DESCRIPTION
HTTP/2 needs to spawn internal tasks in order to process each stream separately, but HTTP/1 does everything in one task and thus doesn't need access to an executor.  This unused field seems to have been hidden from the linter because it was marked `pub(super)` so I've removed the same visibility marker on the server side's `timer` field.

This overlaps a little with https://github.com/hyperium/hyper/issues/3017 since (at least for HTTP/1) there's no need to name the types of futures that need to be spawnable.