### PR TITLE
test(benches): re-enable end_to_end benchmarks

### DIFF
--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -2,384 +2,449 @@
 #![deny(warnings)]
 
 extern crate test;
+mod support;
 
 // TODO: Reimplement Opts::bench using hyper::server::conn and hyper::client::conn
 // (instead of Server and HttpClient).
 
-// use std::net::SocketAddr;
+use std::convert::Infallible;
+use std::net::SocketAddr;
 
-// use futures_util::future::join_all;
+use futures_util::future::join_all;
 
-// use hyper::client::HttpConnector;
-// use hyper::{body::HttpBody as _, Body, Method, Request, Response, Server};
+use http_body_util::BodyExt;
+use hyper::{Method, Request, Response};
 
-// // HTTP1
+type BoxedBody = http_body_util::combinators::BoxBody<bytes::Bytes, Infallible>;
 
-// #[bench]
-// fn http1_consecutive_x1_empty(b: &mut test::Bencher) {
-//     opts().bench(b)
-// }
+// HTTP1
 
-// #[bench]
-// fn http1_consecutive_x1_req_10b(b: &mut test::Bencher) {
-//     opts()
-//         .method(Method::POST)
-//         .request_body(&[b's'; 10])
-//         .bench(b)
-// }
+#[bench]
+fn http1_consecutive_x1_empty(b: &mut test::Bencher) {
+    opts().bench(b)
+}
 
-// #[bench]
-// fn http1_consecutive_x1_both_100kb(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 100];
-//     opts()
-//         .method(Method::POST)
-//         .request_body(body)
-//         .response_body(body)
-//         .bench(b)
-// }
+#[bench]
+fn http1_consecutive_x1_req_10b(b: &mut test::Bencher) {
+    opts()
+        .method(Method::POST)
+        .request_body(&[b's'; 10])
+        .bench(b)
+}
 
-// #[bench]
-// fn http1_consecutive_x1_both_10mb(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 1024 * 10];
-//     opts()
-//         .method(Method::POST)
-//         .request_body(body)
-//         .response_body(body)
-//         .bench(b)
-// }
+#[bench]
+fn http1_consecutive_x1_both_100kb(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 100];
+    opts()
+        .method(Method::POST)
+        .request_body(body)
+        .response_body(body)
+        .bench(b)
+}
 
-// #[bench]
-// fn http1_parallel_x10_empty(b: &mut test::Bencher) {
-//     opts().parallel(10).bench(b)
-// }
+#[bench]
+fn http1_consecutive_x1_both_10mb(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 1024 * 10];
+    opts()
+        .method(Method::POST)
+        .request_body(body)
+        .response_body(body)
+        .bench(b)
+}
 
-// #[bench]
-// fn http1_parallel_x10_req_10mb(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 1024 * 10];
-//     opts()
-//         .parallel(10)
-//         .method(Method::POST)
-//         .request_body(body)
-//         .bench(b)
-// }
+#[bench]
+#[ignore]
+fn http1_parallel_x10_empty(b: &mut test::Bencher) {
+    opts().parallel(10).bench(b)
+}
 
-// #[bench]
-// fn http1_parallel_x10_req_10kb_100_chunks(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 10];
-//     opts()
-//         .parallel(10)
-//         .method(Method::POST)
-//         .request_chunks(body, 100)
-//         .bench(b)
-// }
+#[bench]
+#[ignore]
+fn http1_parallel_x10_req_10mb(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 1024 * 10];
+    opts()
+        .parallel(10)
+        .method(Method::POST)
+        .request_body(body)
+        .bench(b)
+}
 
-// #[bench]
-// fn http1_parallel_x10_res_1mb(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 1024 * 1];
-//     opts().parallel(10).response_body(body).bench(b)
-// }
+#[bench]
+#[ignore]
+fn http1_parallel_x10_req_10kb_100_chunks(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 10];
+    opts()
+        .parallel(10)
+        .method(Method::POST)
+        .request_chunks(body, 100)
+        .bench(b)
+}
 
-// #[bench]
-// fn http1_parallel_x10_res_10mb(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 1024 * 10];
-//     opts().parallel(10).response_body(body).bench(b)
-// }
+#[bench]
+#[ignore]
+fn http1_parallel_x10_res_1mb(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 1024 * 1];
+    opts().parallel(10).response_body(body).bench(b)
+}
 
-// // HTTP2
+#[bench]
+#[ignore]
+fn http1_parallel_x10_res_10mb(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 1024 * 10];
+    opts().parallel(10).response_body(body).bench(b)
+}
 
-// const HTTP2_MAX_WINDOW: u32 = std::u32::MAX >> 1;
+// HTTP2
 
-// #[bench]
-// fn http2_consecutive_x1_empty(b: &mut test::Bencher) {
-//     opts().http2().bench(b)
-// }
+const HTTP2_MAX_WINDOW: u32 = std::u32::MAX >> 1;
 
-// #[bench]
-// fn http2_consecutive_x1_req_10b(b: &mut test::Bencher) {
-//     opts()
-//         .http2()
-//         .method(Method::POST)
-//         .request_body(&[b's'; 10])
-//         .bench(b)
-// }
+#[bench]
+fn http2_consecutive_x1_empty(b: &mut test::Bencher) {
+    opts().http2().bench(b)
+}
 
-// #[bench]
-// fn http2_consecutive_x1_req_100kb(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 100];
-//     opts()
-//         .http2()
-//         .method(Method::POST)
-//         .request_body(body)
-//         .bench(b)
-// }
+#[bench]
+fn http2_consecutive_x1_req_10b(b: &mut test::Bencher) {
+    opts()
+        .http2()
+        .method(Method::POST)
+        .request_body(&[b's'; 10])
+        .bench(b)
+}
 
-// #[bench]
-// fn http2_parallel_x10_empty(b: &mut test::Bencher) {
-//     opts().http2().parallel(10).bench(b)
-// }
+#[bench]
+fn http2_consecutive_x1_req_100kb(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 100];
+    opts()
+        .http2()
+        .method(Method::POST)
+        .request_body(body)
+        .bench(b)
+}
 
-// #[bench]
-// fn http2_parallel_x10_req_10mb(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 1024 * 10];
-//     opts()
-//         .http2()
-//         .parallel(10)
-//         .method(Method::POST)
-//         .request_body(body)
-//         .http2_stream_window(HTTP2_MAX_WINDOW)
-//         .http2_conn_window(HTTP2_MAX_WINDOW)
-//         .bench(b)
-// }
+#[bench]
+fn http2_parallel_x10_empty(b: &mut test::Bencher) {
+    opts().http2().parallel(10).bench(b)
+}
 
-// #[bench]
-// fn http2_parallel_x10_req_10kb_100_chunks(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 10];
-//     opts()
-//         .http2()
-//         .parallel(10)
-//         .method(Method::POST)
-//         .request_chunks(body, 100)
-//         .bench(b)
-// }
+#[bench]
+fn http2_parallel_x10_req_10mb(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 1024 * 10];
+    opts()
+        .http2()
+        .parallel(10)
+        .method(Method::POST)
+        .request_body(body)
+        .http2_stream_window(HTTP2_MAX_WINDOW)
+        .http2_conn_window(HTTP2_MAX_WINDOW)
+        .bench(b)
+}
 
-// #[bench]
-// fn http2_parallel_x10_req_10kb_100_chunks_adaptive_window(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 10];
-//     opts()
-//         .http2()
-//         .parallel(10)
-//         .method(Method::POST)
-//         .request_chunks(body, 100)
-//         .http2_adaptive_window()
-//         .bench(b)
-// }
+#[bench]
+#[ignore]
+fn http2_parallel_x10_req_10kb_100_chunks(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 10];
+    opts()
+        .http2()
+        .parallel(10)
+        .method(Method::POST)
+        .request_chunks(body, 100)
+        .bench(b)
+}
 
-// #[bench]
-// fn http2_parallel_x10_req_10kb_100_chunks_max_window(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 10];
-//     opts()
-//         .http2()
-//         .parallel(10)
-//         .method(Method::POST)
-//         .request_chunks(body, 100)
-//         .http2_stream_window(HTTP2_MAX_WINDOW)
-//         .http2_conn_window(HTTP2_MAX_WINDOW)
-//         .bench(b)
-// }
+#[bench]
+#[ignore]
+fn http2_parallel_x10_req_10kb_100_chunks_adaptive_window(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 10];
+    opts()
+        .http2()
+        .parallel(10)
+        .method(Method::POST)
+        .request_chunks(body, 100)
+        .http2_adaptive_window()
+        .bench(b)
+}
 
-// #[bench]
-// fn http2_parallel_x10_res_1mb(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 1024 * 1];
-//     opts()
-//         .http2()
-//         .parallel(10)
-//         .response_body(body)
-//         .http2_stream_window(HTTP2_MAX_WINDOW)
-//         .http2_conn_window(HTTP2_MAX_WINDOW)
-//         .bench(b)
-// }
+#[bench]
+#[ignore]
+fn http2_parallel_x10_req_10kb_100_chunks_max_window(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 10];
+    opts()
+        .http2()
+        .parallel(10)
+        .method(Method::POST)
+        .request_chunks(body, 100)
+        .http2_stream_window(HTTP2_MAX_WINDOW)
+        .http2_conn_window(HTTP2_MAX_WINDOW)
+        .bench(b)
+}
 
-// #[bench]
-// fn http2_parallel_x10_res_10mb(b: &mut test::Bencher) {
-//     let body = &[b'x'; 1024 * 1024 * 10];
-//     opts()
-//         .http2()
-//         .parallel(10)
-//         .response_body(body)
-//         .http2_stream_window(HTTP2_MAX_WINDOW)
-//         .http2_conn_window(HTTP2_MAX_WINDOW)
-//         .bench(b)
-// }
+#[bench]
+fn http2_parallel_x10_res_1mb(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 1024 * 1];
+    opts()
+        .http2()
+        .parallel(10)
+        .response_body(body)
+        .http2_stream_window(HTTP2_MAX_WINDOW)
+        .http2_conn_window(HTTP2_MAX_WINDOW)
+        .bench(b)
+}
 
-// // ==== Benchmark Options =====
+#[bench]
+fn http2_parallel_x10_res_10mb(b: &mut test::Bencher) {
+    let body = &[b'x'; 1024 * 1024 * 10];
+    opts()
+        .http2()
+        .parallel(10)
+        .response_body(body)
+        .http2_stream_window(HTTP2_MAX_WINDOW)
+        .http2_conn_window(HTTP2_MAX_WINDOW)
+        .bench(b)
+}
 
-// struct Opts {
-//     http2: bool,
-//     http2_stream_window: Option<u32>,
-//     http2_conn_window: Option<u32>,
-//     http2_adaptive_window: bool,
-//     parallel_cnt: u32,
-//     request_method: Method,
-//     request_body: Option<&'static [u8]>,
-//     request_chunks: usize,
-//     response_body: &'static [u8],
-// }
+// ==== Benchmark Options =====
 
-// fn opts() -> Opts {
-//     Opts {
-//         http2: false,
-//         http2_stream_window: None,
-//         http2_conn_window: None,
-//         http2_adaptive_window: false,
-//         parallel_cnt: 1,
-//         request_method: Method::GET,
-//         request_body: None,
-//         request_chunks: 0,
-//         response_body: b"",
-//     }
-// }
+#[derive(Clone)]
+struct Opts {
+    http2: bool,
+    http2_stream_window: Option<u32>,
+    http2_conn_window: Option<u32>,
+    http2_adaptive_window: bool,
+    parallel_cnt: u32,
+    request_method: Method,
+    request_body: Option<&'static [u8]>,
+    request_chunks: usize,
+    response_body: &'static [u8],
+}
 
-// impl Opts {
-//     fn http2(mut self) -> Self {
-//         self.http2 = true;
-//         self
-//     }
+fn opts() -> Opts {
+    Opts {
+        http2: false,
+        http2_stream_window: None,
+        http2_conn_window: None,
+        http2_adaptive_window: false,
+        parallel_cnt: 1,
+        request_method: Method::GET,
+        request_body: None,
+        request_chunks: 0,
+        response_body: b"",
+    }
+}
 
-//     fn http2_stream_window(mut self, sz: impl Into<Option<u32>>) -> Self {
-//         assert!(!self.http2_adaptive_window);
-//         self.http2_stream_window = sz.into();
-//         self
-//     }
+impl Opts {
+    fn http2(mut self) -> Self {
+        self.http2 = true;
+        self
+    }
 
-//     fn http2_conn_window(mut self, sz: impl Into<Option<u32>>) -> Self {
-//         assert!(!self.http2_adaptive_window);
-//         self.http2_conn_window = sz.into();
-//         self
-//     }
+    fn http2_stream_window(mut self, sz: impl Into<Option<u32>>) -> Self {
+        assert!(!self.http2_adaptive_window);
+        self.http2_stream_window = sz.into();
+        self
+    }
 
-//     fn http2_adaptive_window(mut self) -> Self {
-//         assert!(self.http2_stream_window.is_none());
-//         assert!(self.http2_conn_window.is_none());
-//         self.http2_adaptive_window = true;
-//         self
-//     }
+    fn http2_conn_window(mut self, sz: impl Into<Option<u32>>) -> Self {
+        assert!(!self.http2_adaptive_window);
+        self.http2_conn_window = sz.into();
+        self
+    }
 
-//     fn method(mut self, m: Method) -> Self {
-//         self.request_method = m;
-//         self
-//     }
+    fn http2_adaptive_window(mut self) -> Self {
+        assert!(self.http2_stream_window.is_none());
+        assert!(self.http2_conn_window.is_none());
+        self.http2_adaptive_window = true;
+        self
+    }
 
-//     fn request_body(mut self, body: &'static [u8]) -> Self {
-//         self.request_body = Some(body);
-//         self
-//     }
+    fn method(mut self, m: Method) -> Self {
+        self.request_method = m;
+        self
+    }
 
-//     fn request_chunks(mut self, chunk: &'static [u8], cnt: usize) -> Self {
-//         assert!(cnt > 0);
-//         self.request_body = Some(chunk);
-//         self.request_chunks = cnt;
-//         self
-//     }
+    fn request_body(mut self, body: &'static [u8]) -> Self {
+        self.request_body = Some(body);
+        self
+    }
 
-//     fn response_body(mut self, body: &'static [u8]) -> Self {
-//         self.response_body = body;
-//         self
-//     }
+    fn request_chunks(mut self, chunk: &'static [u8], cnt: usize) -> Self {
+        assert!(cnt > 0);
+        self.request_body = Some(chunk);
+        self.request_chunks = cnt;
+        self
+    }
 
-//     fn parallel(mut self, cnt: u32) -> Self {
-//         assert!(cnt > 0, "parallel count must be larger than 0");
-//         self.parallel_cnt = cnt;
-//         self
-//     }
+    fn response_body(mut self, body: &'static [u8]) -> Self {
+        self.response_body = body;
+        self
+    }
 
-//     fn bench(self, b: &mut test::Bencher) {
-//         use std::sync::Arc;
-//         let _ = pretty_env_logger::try_init();
-//         // Create a runtime of current thread.
-//         let rt = Arc::new(
-//             tokio::runtime::Builder::new_current_thread()
-//                 .enable_all()
-//                 .build()
-//                 .expect("rt build"),
-//         );
-//         let exec = rt.clone();
+    fn parallel(mut self, cnt: u32) -> Self {
+        assert!(cnt > 0, "parallel count must be larger than 0");
+        self.parallel_cnt = cnt;
+        self
+    }
 
-//         let req_len = self.request_body.map(|b| b.len()).unwrap_or(0) as u64;
-//         let req_len = if self.request_chunks > 0 {
-//             req_len * self.request_chunks as u64
-//         } else {
-//             req_len
-//         };
-//         let bytes_per_iter = (req_len + self.response_body.len() as u64) * self.parallel_cnt as u64;
-//         b.bytes = bytes_per_iter;
+    fn bench(self, b: &mut test::Bencher) {
+        use std::sync::Arc;
+        let _ = pretty_env_logger::try_init();
+        // Create a runtime of current thread.
+        let rt = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("rt build"),
+        );
+        //let exec = rt.clone();
 
-//         let addr = spawn_server(&rt, &self);
+        let req_len = self.request_body.map(|b| b.len()).unwrap_or(0) as u64;
+        let req_len = if self.request_chunks > 0 {
+            req_len * self.request_chunks as u64
+        } else {
+            req_len
+        };
+        let bytes_per_iter = (req_len + self.response_body.len() as u64) * self.parallel_cnt as u64;
+        b.bytes = bytes_per_iter;
 
-//         let connector = HttpConnector::new();
-//         let client = hyper::Client::builder()
-//             .http2_only(self.http2)
-//             .http2_initial_stream_window_size(self.http2_stream_window)
-//             .http2_initial_connection_window_size(self.http2_conn_window)
-//             .http2_adaptive_window(self.http2_adaptive_window)
-//             .build::<_, Body>(connector);
+        let addr = spawn_server(&rt, &self);
 
-//         let url: hyper::Uri = format!("http://{}/hello", addr).parse().unwrap();
+        enum Client {
+            Http1(hyper::client::conn::http1::SendRequest<BoxedBody>),
+            Http2(hyper::client::conn::http2::SendRequest<BoxedBody>),
+        }
 
-//         let make_request = || {
-//             let chunk_cnt = self.request_chunks;
-//             let body = if chunk_cnt > 0 {
-//                 let (mut tx, body) = Body::channel();
-//                 let chunk = self
-//                     .request_body
-//                     .expect("request_chunks means request_body");
-//                 exec.spawn(async move {
-//                     for _ in 0..chunk_cnt {
-//                         tx.send_data(chunk.into()).await.expect("send_data");
-//                     }
-//                 });
-//                 body
-//             } else {
-//                 self.request_body
-//                     .map(Body::from)
-//                     .unwrap_or_else(Body::empty)
-//             };
-//             let mut req = Request::new(body);
-//             *req.method_mut() = self.request_method.clone();
-//             *req.uri_mut() = url.clone();
-//             req
-//         };
+        let mut client = rt.block_on(async {
+            if self.http2 {
+                let io = tokio::net::TcpStream::connect(&addr).await.unwrap();
+                let (tx, conn) = hyper::client::conn::http2::Builder::new()
+                    .initial_stream_window_size(self.http2_stream_window)
+                    .initial_connection_window_size(self.http2_conn_window)
+                    .adaptive_window(self.http2_adaptive_window)
+                    .executor(support::TokioExecutor)
+                    .handshake(io)
+                    .await
+                    .unwrap();
+                tokio::spawn(conn);
+                Client::Http2(tx)
+            } else if self.parallel_cnt > 1 {
+                todo!("http/1 parallel >1");
+            } else {
+                let io = tokio::net::TcpStream::connect(&addr).await.unwrap();
+                let (tx, conn) = hyper::client::conn::http1::Builder::new()
+                    .handshake(io)
+                    .await
+                    .unwrap();
+                tokio::spawn(conn);
+                Client::Http1(tx)
+            }
+        });
 
-//         let send_request = |req: Request<Body>| {
-//             let fut = client.request(req);
-//             async {
-//                 let res = fut.await.expect("client wait");
-//                 let mut body = res.into_body();
-//                 while let Some(_chunk) = body.data().await {}
-//             }
-//         };
+        let url: hyper::Uri = format!("http://{}/hello", addr).parse().unwrap();
 
-//         if self.parallel_cnt == 1 {
-//             b.iter(|| {
-//                 let req = make_request();
-//                 rt.block_on(send_request(req));
-//             });
-//         } else {
-//             b.iter(|| {
-//                 let futs = (0..self.parallel_cnt).map(|_| {
-//                     let req = make_request();
-//                     send_request(req)
-//                 });
-//                 // Await all spawned futures becoming completed.
-//                 rt.block_on(join_all(futs));
-//             });
-//         }
-//     }
-// }
+        let make_request = || {
+            let chunk_cnt = self.request_chunks;
+            let body = if chunk_cnt > 0 {
+                /*
+                let (mut tx, body) = Body::channel();
+                let chunk = self
+                    .request_body
+                    .expect("request_chunks means request_body");
+                exec.spawn(async move {
+                    for _ in 0..chunk_cnt {
+                        tx.send_data(chunk.into()).await.expect("send_data");
+                    }
+                });
+                body
+                */
+                todo!("request_chunks");
+            } else if let Some(chunk) = self.request_body {
+                http_body_util::Full::new(bytes::Bytes::from(chunk)).boxed()
+            } else {
+                http_body_util::Empty::new().boxed()
+            };
+            let mut req = Request::new(body);
+            *req.method_mut() = self.request_method.clone();
+            *req.uri_mut() = url.clone();
+            req
+        };
 
-// fn spawn_server(rt: &tokio::runtime::Runtime, opts: &Opts) -> SocketAddr {
-//     use hyper::service::{make_service_fn, service_fn};
-//     let addr = "127.0.0.1:0".parse().unwrap();
+        let mut send_request = |req| {
+            let fut = match client {
+                Client::Http1(ref mut tx) => {
+                    futures_util::future::Either::Left(tx.send_request(req))
+                }
+                Client::Http2(ref mut tx) => {
+                    futures_util::future::Either::Right(tx.send_request(req))
+                }
+            };
+            async {
+                let res = fut.await.expect("client wait");
+                let mut body = res.into_body();
+                while let Some(_chunk) = body.frame().await {}
+            }
+        };
 
-//     let body = opts.response_body;
-//     let srv = rt.block_on(async move {
-//         Server::bind(&addr)
-//             .http2_only(opts.http2)
-//             .http2_initial_stream_window_size(opts.http2_stream_window)
-//             .http2_initial_connection_window_size(opts.http2_conn_window)
-//             .http2_adaptive_window(opts.http2_adaptive_window)
-//             .serve(make_service_fn(move |_| async move {
-//                 Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| async move {
-//                     let mut req_body = req.into_body();
-//                     while let Some(_chunk) = req_body.data().await {}
-//                     Ok::<_, hyper::Error>(Response::new(Body::from(body)))
-//                 }))
-//             }))
-//     });
-//     let addr = srv.local_addr();
-//     rt.spawn(async {
-//         if let Err(err) = srv.await {
-//             panic!("server error: {}", err);
-//         }
-//     });
-//     addr
-// }
+        if self.parallel_cnt == 1 {
+            b.iter(|| {
+                let req = make_request();
+                rt.block_on(send_request(req));
+            });
+        } else {
+            b.iter(|| {
+                let futs = (0..self.parallel_cnt).map(|_| {
+                    let req = make_request();
+                    send_request(req)
+                });
+                // Await all spawned futures becoming completed.
+                rt.block_on(join_all(futs));
+            });
+        }
+    }
+}
+
+fn spawn_server(rt: &tokio::runtime::Runtime, opts: &Opts) -> SocketAddr {
+    use http_body_util::Full;
+    use hyper::service::service_fn;
+    use tokio::net::TcpListener;
+    let addr = "127.0.0.1:0".parse::<std::net::SocketAddr>().unwrap();
+
+    let listener = rt.block_on(async { TcpListener::bind(&addr).await.unwrap() });
+
+    let addr = listener.local_addr().unwrap();
+    let body = opts.response_body;
+    let opts = opts.clone();
+    rt.spawn(async move {
+        while let Ok((sock, _)) = listener.accept().await {
+            if opts.http2 {
+                tokio::spawn(
+                    hyper::server::conn::http2::Builder::new(support::TokioExecutor)
+                        .initial_stream_window_size(opts.http2_stream_window)
+                        .initial_connection_window_size(opts.http2_conn_window)
+                        .adaptive_window(opts.http2_adaptive_window)
+                        .serve_connection(
+                            sock,
+                            service_fn(move |req: Request<hyper::body::Incoming>| async move {
+                                let mut req_body = req.into_body();
+                                while let Some(_chunk) = req_body.frame().await {}
+                                Ok::<_, std::convert::Infallible>(Response::new(
+                                    Full::<bytes::Bytes>::from(body),
+                                ))
+                            }),
+                        ),
+                );
+            } else {
+                tokio::spawn(hyper::server::conn::http1::Builder::new().serve_connection(
+                    sock,
+                    service_fn(move |req: Request<hyper::body::Incoming>| async move {
+                        let mut req_body = req.into_body();
+                        while let Some(_chunk) = req_body.frame().await {}
+                        Ok::<_, std::convert::Infallible>(Response::new(
+                            Full::<bytes::Bytes>::from(body),
+                        ))
+                    }),
+                ));
+            }
+        }
+    });
+    addr
+}

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -1,3 +1,2 @@
-
 mod tokiort;
-pub use tokiort::TokioTimer;
+pub use tokiort::{TokioExecutor, TokioTimer};


### PR DESCRIPTION
Most of #2930. The parallel HTTP/1 requests, and the chunk bodies, are still disabled.