### PR TITLE
Make private traits in public api, sealed and public

### DIFF
--- a/src/common/exec.rs
+++ b/src/common/exec.rs
@@ -3,16 +3,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-#[cfg(feature = "server")]
-use crate::body::Body;
-#[cfg(all(feature = "http2", feature = "server"))]
-use crate::proto::h2::server::H2Stream;
 use crate::rt::Executor;
-
-#[cfg(feature = "server")]
-pub trait ConnStreamExec<F, B: Body>: Clone {
-    fn execute_h2stream(&mut self, fut: H2Stream<F, B>);
-}
 
 pub(crate) type BoxSendFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 
@@ -46,31 +37,6 @@ impl Exec {
 impl fmt::Debug for Exec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Exec").finish()
-    }
-}
-
-#[cfg(feature = "server")]
-impl<F, B> ConnStreamExec<F, B> for Exec
-where
-    H2Stream<F, B>: Future<Output = ()> + Send + 'static,
-    B: Body,
-{
-    fn execute_h2stream(&mut self, fut: H2Stream<F, B>) {
-        self.execute(fut)
-    }
-}
-
-// ==== impl Executor =====
-
-#[cfg(feature = "server")]
-impl<E, F, B> ConnStreamExec<F, B> for E
-where
-    E: Executor<H2Stream<F, B>> + Clone,
-    H2Stream<F, B>: Future<Output = ()>,
-    B: Body,
-{
-    fn execute_h2stream(&mut self, fut: H2Stream<F, B>) {
-        self.execute(fut)
     }
 }
 

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -13,7 +13,7 @@ use tracing::{debug, trace, warn};
 
 use super::{ping, PipeToSendStream, SendBuf};
 use crate::body::{Body, Incoming as IncomingBody};
-use crate::common::exec::ConnStreamExec;
+use crate::rt::bounds::Http2ConnExec;
 use crate::common::time::Time;
 use crate::common::{date, task, Future, Pin, Poll};
 use crate::ext::Protocol;
@@ -110,7 +110,7 @@ where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: Body + 'static,
-    E: ConnStreamExec<S::Future, B>,
+    E: Http2ConnExec<S::Future, B>,
 {
     pub(crate) fn new(
         io: T,
@@ -186,7 +186,7 @@ where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: Body + 'static,
-    E: ConnStreamExec<S::Future, B>,
+    E: Http2ConnExec<S::Future, B>,
 {
     type Output = crate::Result<Dispatched>;
 
@@ -240,7 +240,7 @@ where
     where
         S: HttpService<IncomingBody, ResBody = B>,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
-        E: ConnStreamExec<S::Future, B>,
+        E: Http2ConnExec<S::Future, B>,
     {
         if self.closing.is_none() {
             loop {

--- a/src/rt/bounds.rs
+++ b/src/rt/bounds.rs
@@ -1,4 +1,7 @@
-//! Sealed traits
+//! Trait aliases
+//!
+//! Traits in this module ease setting bounds and usually automatically
+//! implemented by implementing another trait.
 
 #[cfg(all(feature = "server", feature = "http2"))]
 pub use self::h2::Http2ConnExec;
@@ -12,7 +15,12 @@ mod h2 {
 
     /// An executor to spawn http2 connections.
     ///
+    /// This trait is implemented for any type that implements [`Executor`]
+    /// trait for any future.
+    ///
     /// This trait is sealed and cannot be implemented for types outside this crate.
+    ///
+    /// [`Executor`]: crate::rt::Executor
     pub trait Http2ConnExec<F, B: Body>: sealed::Sealed<(F, B)> + Clone {
         #[doc(hidden)]
         fn execute_h2stream(&mut self, fut: H2Stream<F, B>);

--- a/src/rt/bounds.rs
+++ b/src/rt/bounds.rs
@@ -1,0 +1,61 @@
+//! Sealed traits
+
+#[cfg(all(feature = "server", feature = "http2"))]
+pub use self::h2::Http2ConnExec;
+
+#[cfg(all(feature = "server", feature = "http2"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "server", feature = "http2"))))]
+mod h2 {
+    use crate::{common::exec::Exec, proto::h2::server::H2Stream, rt::Executor};
+    use http_body::Body;
+    use std::future::Future;
+
+    /// An executor to spawn http2 connections.
+    ///
+    /// This trait is sealed and cannot be implemented for types outside this crate.
+    pub trait Http2ConnExec<F, B: Body>: sealed::Sealed<(F, B)> + Clone {
+        #[doc(hidden)]
+        fn execute_h2stream(&mut self, fut: H2Stream<F, B>);
+    }
+
+    impl<F, B> Http2ConnExec<F, B> for Exec
+    where
+        H2Stream<F, B>: Future<Output = ()> + Send + 'static,
+        B: Body,
+    {
+        fn execute_h2stream(&mut self, fut: H2Stream<F, B>) {
+            self.execute(fut)
+        }
+    }
+
+    impl<F, B> sealed::Sealed<(F, B)> for Exec
+    where
+        H2Stream<F, B>: Future<Output = ()> + Send + 'static,
+        B: Body,
+    {
+    }
+
+    #[doc(hidden)]
+    impl<E, F, B> Http2ConnExec<F, B> for E
+    where
+        E: Executor<H2Stream<F, B>> + Clone,
+        H2Stream<F, B>: Future<Output = ()>,
+        B: Body,
+    {
+        fn execute_h2stream(&mut self, fut: H2Stream<F, B>) {
+            self.execute(fut)
+        }
+    }
+
+    impl<E, F, B> sealed::Sealed<(F, B)> for E
+    where
+        E: Executor<H2Stream<F, B>> + Clone,
+        H2Stream<F, B>: Future<Output = ()>,
+        B: Body,
+    {
+    }
+
+    mod sealed {
+        pub trait Sealed<T> {}
+    }
+}

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -14,6 +14,26 @@ use std::{
 };
 
 /// An executor of futures.
+///
+/// This trait should be implemented for any future.
+///
+/// # Example
+///
+/// ```
+/// # use hyper::rt::Executor;
+/// # use std::future::Future;
+/// struct TokioExecutor;
+///
+/// impl<F> Executor<F> for TokioExecutor
+/// where
+///     F: Future + Send + 'static,
+///     F::Output: Send + 'static,
+/// {
+///     fn execute(&self, future: F) {
+///         tokio::spawn(future);
+///     }
+/// }
+/// ```
 pub trait Executor<Fut> {
     /// Place the future into the executor to be run.
     fn execute(&self, fut: Fut);

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -5,6 +5,8 @@
 //! If the `runtime` feature is disabled, the types in this module can be used
 //! to plug in other runtimes.
 
+pub mod bounds;
+
 use std::{
     future::Future,
     pin::Pin,

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -9,9 +9,9 @@ use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::body::{Body, Incoming as IncomingBody};
-use crate::common::exec::ConnStreamExec;
 use crate::common::{task, Future, Pin, Poll, Unpin};
 use crate::proto;
+use crate::rt::bounds::Http2ConnExec;
 use crate::service::HttpService;
 use crate::{common::time::Time, rt::Timer};
 
@@ -54,7 +54,7 @@ where
     I: AsyncRead + AsyncWrite + Unpin,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
-    E: ConnStreamExec<S::Future, B>,
+    E: Http2ConnExec<S::Future, B>,
 {
     /// Start a graceful shutdown process for this connection.
     ///
@@ -78,7 +78,7 @@ where
     I: AsyncRead + AsyncWrite + Unpin + 'static,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
-    E: ConnStreamExec<S::Future, B>,
+    E: Http2ConnExec<S::Future, B>,
 {
     type Output = crate::Result<()>;
 
@@ -259,7 +259,7 @@ impl<E> Builder<E> {
         Bd: Body + 'static,
         Bd::Error: Into<Box<dyn StdError + Send + Sync>>,
         I: AsyncRead + AsyncWrite + Unpin,
-        E: ConnStreamExec<S::Future, Bd>,
+        E: Http2ConnExec<S::Future, Bd>,
     {
         let proto = proto::h2::Server::new(
             io,

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -99,7 +99,10 @@ where
 impl<E> Builder<E> {
     /// Create a new connection builder.
     ///
-    /// This starts with the default options, and an executor.
+    /// This starts with the default options, and an executor which is a type
+    /// that implements [`Http2ConnExec`] trait.
+    ///
+    /// [`Http2ConnExec`]: crate::rt::bounds::Http2ConnExec
     pub fn new(exec: E) -> Self {
         Self {
             exec: exec,

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -26,7 +26,7 @@ mod service;
 mod util;
 
 #[cfg(all(any(feature = "http1", feature = "http2"), feature = "server"))]
-pub(super) use self::http::HttpService;
+pub use self::http::HttpService;
 #[cfg(all(
     any(feature = "http1", feature = "http2"),
     any(feature = "server", feature = "client")


### PR DESCRIPTION
Resolves #2051, resolves #3097 

- Moved, sealed, renamed `ConnStreamExec` to `Http2ConnExec` and made it public.
- Changed `pub(super)` restriction of `HttpService` to `pub`.