### PR TITLE
feat(client): remove `common::Exec::Default`

### DIFF
--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -316,11 +316,10 @@ impl Opts {
         let mut client = rt.block_on(async {
             if self.http2 {
                 let io = tokio::net::TcpStream::connect(&addr).await.unwrap();
-                let (tx, conn) = hyper::client::conn::http2::Builder::new()
+                let (tx, conn) = hyper::client::conn::http2::Builder::new(support::TokioExecutor)
                     .initial_stream_window_size(self.http2_stream_window)
                     .initial_connection_window_size(self.http2_conn_window)
                     .adaptive_window(self.http2_adaptive_window)
-                    .executor(support::TokioExecutor)
                     .handshake(io)
                     .await
                     .unwrap();

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -57,16 +57,18 @@ pub struct Builder {
 ///
 /// This is a shortcut for `Builder::new().handshake(io)`.
 /// See [`client::conn`](crate::client::conn) for more.
-pub async fn handshake<T, B>(
+pub async fn handshake<E, T, B>(
+    exec: E,
     io: T,
 ) -> crate::Result<(SendRequest<B>, Connection<T, B>)>
 where
+    E: Executor<BoxSendFuture> + Send + Sync + 'static,
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     B: Body + 'static,
     B::Data: Send,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
 {
-    Builder::new().handshake(io).await
+    Builder::new(exec).handshake(io).await
 }
 
 // ===== impl SendRequest
@@ -244,21 +246,15 @@ where
 impl Builder {
     /// Creates a new connection builder.
     #[inline]
-    pub fn new() -> Builder {
-        Builder {
-            exec: Exec::Default,
-            timer: Time::Empty,
-            h2_builder: Default::default(),
-        }
-    }
-
-    /// Provide an executor to execute background HTTP2 tasks.
-    pub fn executor<E>(&mut self, exec: E) -> &mut Builder
+    pub fn new<E>(exec: E) -> Builder 
     where
         E: Executor<BoxSendFuture> + Send + Sync + 'static,
     {
-        self.exec = Exec::Executor(Arc::new(exec));
-        self
+        Builder {
+            exec: Exec::new(exec),
+            timer: Time::Empty,
+            h2_builder: Default::default(),
+        }
     }
 
     /// Provide a timer to execute background HTTP2 tasks.

--- a/src/ffi/client.rs
+++ b/src/ffi/client.rs
@@ -55,8 +55,7 @@ ffi_fn! {
             #[cfg(feature = "http2")]
             {
             if options.http2 {
-                return conn::http2::Builder::new()
-                    .executor(options.exec.clone())
+                return conn::http2::Builder::new(options.exec.clone())
                     .handshake::<_, crate::body::Incoming>(io)
                     .await
                     .map(|(tx, conn)| {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1922,8 +1922,7 @@ mod conn {
         });
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
-        let (mut client, conn) = conn::http2::Builder::new()
-            .executor(TokioExecutor)
+        let (mut client, conn) = conn::http2::Builder::new(TokioExecutor)
             .handshake(io)
             .await
             .expect("http handshake");
@@ -1979,8 +1978,7 @@ mod conn {
         });
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
-        let (_client, conn) = conn::http2::Builder::new()
-            .executor(TokioExecutor)
+        let (_client, conn) = conn::http2::Builder::new(TokioExecutor)
             .timer(TokioTimer)
             .keep_alive_interval(Duration::from_secs(1))
             .keep_alive_timeout(Duration::from_secs(1))
@@ -2008,8 +2006,7 @@ mod conn {
         });
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
-        let (mut client, conn) = conn::http2::Builder::new()
-            .executor(TokioExecutor)
+        let (mut client, conn) = conn::http2::Builder::new(TokioExecutor)
             .timer(TokioTimer)
             .keep_alive_interval(Duration::from_secs(1))
             .keep_alive_timeout(Duration::from_secs(1))
@@ -2040,8 +2037,7 @@ mod conn {
         });
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
-        let (mut client, conn) = conn::http2::Builder::new()
-            .executor(TokioExecutor)
+        let (mut client, conn) = conn::http2::Builder::new(TokioExecutor)
             .timer(TokioTimer)
             .keep_alive_interval(Duration::from_secs(1))
             .keep_alive_timeout(Duration::from_secs(1))
@@ -2100,8 +2096,7 @@ mod conn {
         });
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
-        let (mut client, conn) = conn::http2::Builder::new()
-            .executor(TokioExecutor)
+        let (mut client, conn) = conn::http2::Builder::new(TokioExecutor)
             .timer(TokioTimer)
             .keep_alive_interval(Duration::from_secs(1))
             .keep_alive_timeout(Duration::from_secs(1))
@@ -2156,8 +2151,7 @@ mod conn {
         });
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
-        let (mut client, conn) = conn::http2::Builder::new()
-            .executor(TokioExecutor)
+        let (mut client, conn) = conn::http2::Builder::new(TokioExecutor)
             .handshake(io)
             .await
             .expect("http handshake");
@@ -2207,8 +2201,7 @@ mod conn {
         });
 
         let io = tcp_connect(&addr).await.expect("tcp connect");
-        let (mut client, conn) = conn::http2::Builder::new()
-            .executor(TokioExecutor)
+        let (mut client, conn) = conn::http2::Builder::new(TokioExecutor)
             .handshake::<_, Empty<Bytes>>(io)
             .await
             .expect("http handshake");

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2389,8 +2389,7 @@ async fn http2_keep_alive_with_responsive_client() {
     });
 
     let tcp = connect_async(addr).await;
-    let (mut client, conn) = hyper::client::conn::http2::Builder::new()
-        .executor(TokioExecutor)
+    let (mut client, conn) = hyper::client::conn::http2::Builder::new(TokioExecutor)
         .handshake(tcp)
         .await
         .expect("http handshake");
@@ -3017,8 +3016,7 @@ impl TestClient {
             .unwrap();
 
         if self.http2_only {
-            let (mut sender, conn) = hyper::client::conn::http2::Builder::new()
-                .executor(TokioExecutor)
+            let (mut sender, conn) = hyper::client::conn::http2::Builder::new(TokioExecutor)
                 .handshake(stream)
                 .await
                 .unwrap();

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -427,8 +427,7 @@ async fn async_test(cfg: __TestConfig) {
             let stream = TcpStream::connect(addr).await.unwrap();
 
             let res = if http2_only {
-                let (mut sender, conn) = hyper::client::conn::http2::Builder::new()
-                    .executor(TokioExecutor)
+                let (mut sender, conn) = hyper::client::conn::http2::Builder::new(TokioExecutor)
                     .handshake(stream)
                     .await
                     .unwrap();
@@ -526,11 +525,11 @@ async fn naive_proxy(cfg: ProxyConfig) -> (SocketAddr, impl Future<Output = ()>)
                             .unwrap();
 
                         let resp = if http2_only {
-                            let (mut sender, conn) = hyper::client::conn::http2::Builder::new()
-                                .executor(TokioExecutor)
-                                .handshake(stream)
-                                .await
-                                .unwrap();
+                            let (mut sender, conn) =
+                                hyper::client::conn::http2::Builder::new(TokioExecutor)
+                                    .handshake(stream)
+                                    .await
+                                    .unwrap();
 
                             tokio::task::spawn(async move {
                                 if let Err(err) = conn.await {


### PR DESCRIPTION
Closes #3128 

This PR removes `Exec::Default` so that we avoid panicking by asking users to provide Executor right away. `Exec::Default` serves no purpose after #2975.

Also refactors `hyper::client::conn::Http2::Builder::new` as part of the removal.