### PR TITLE
Backport 0.14.x: prevent sending 100-continue if user drops request body

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -748,6 +748,12 @@ where
 
     /// If the read side can be cheaply drained, do so. Otherwise, close.
     pub(super) fn poll_drain_or_close_read(&mut self, cx: &mut task::Context<'_>) {
+        if let Reading::Continue(ref decoder) = self.state.reading {
+            // skip sending the 100-continue
+            // just move forward to a read, in case a tiny body was included
+            self.state.reading = Reading::Body(decoder.clone());
+        }
+
         let _ = self.poll_read_body(cx);
 
         // If still in Reading::Body, just give up

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -973,9 +973,8 @@ async fn expect_continue_waits_for_body_poll() {
             service_fn(|req| {
                 assert_eq!(req.headers()["expect"], "100-continue");
                 // But! We're never going to poll the body!
+                drop(req);
                 tokio::time::sleep(Duration::from_millis(50)).map(move |_| {
-                    // Move and drop the req, so we don't auto-close
-                    drop(req);
                     Response::builder()
                         .status(StatusCode::BAD_REQUEST)
                         .body(hyper::Body::empty())


### PR DESCRIPTION
Backport of #3137 