### PR TITLE
feat(client): add `is_ready()` and `is_closed()` methods to `SendRequest`

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -141,24 +141,21 @@ impl<B> SendRequest<B> {
         futures_util::future::poll_fn(|cx| self.poll_ready(cx)).await
     }
 
-    /*
-    pub(super) async fn when_ready(self) -> crate::Result<Self> {
-        let mut me = Some(self);
-        future::poll_fn(move |cx| {
-            ready!(me.as_mut().unwrap().poll_ready(cx))?;
-            Poll::Ready(Ok(me.take().unwrap()))
-        })
-        .await
-    }
-
-    pub(super) fn is_ready(&self) -> bool {
+    /// Checks if the connection is currently ready to send a request.
+    ///
+    /// # Note
+    ///
+    /// This is mostly a hint. Due to inherent latency of networks, it is
+    /// possible that even after checking this is ready, sending a request
+    /// may still fail because the connection was closed in the meantime.
+    pub fn is_ready(&self) -> bool {
         self.dispatch.is_ready()
     }
 
-    pub(super) fn is_closed(&self) -> bool {
+    /// Checks if the connection side has been closed.
+    pub fn is_closed(&self) -> bool {
         self.dispatch.is_closed()
     }
-    */
 }
 
 impl<B> SendRequest<B>

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -92,22 +92,19 @@ impl<B> SendRequest<B> {
         futures_util::future::poll_fn(|cx| self.poll_ready(cx)).await
     }
 
-    /*
-    pub(super) async fn when_ready(self) -> crate::Result<Self> {
-        let mut me = Some(self);
-        future::poll_fn(move |cx| {
-            ready!(me.as_mut().unwrap().poll_ready(cx))?;
-            Poll::Ready(Ok(me.take().unwrap()))
-        })
-        .await
-    }
-
-    pub(super) fn is_ready(&self) -> bool {
+    /// Checks if the connection is currently ready to send a request.
+    ///
+    /// # Note
+    ///
+    /// This is mostly a hint. Due to inherent latency of networks, it is
+    /// possible that even after checking this is ready, sending a request
+    /// may still fail because the connection was closed in the meantime.
+    pub fn is_ready(&self) -> bool {
         self.dispatch.is_ready()
     }
-    */
 
-    pub(super) fn is_closed(&self) -> bool {
+    /// Checks if the connection side has been closed.
+    pub fn is_closed(&self) -> bool {
         self.dispatch.is_closed()
     }
 }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -59,16 +59,13 @@ impl<T, U> Sender<T, U> {
             .map_err(|_| crate::Error::new_closed())
     }
 
-    #[cfg(test)]
     pub(crate) fn is_ready(&self) -> bool {
         self.giver.is_wanting()
     }
 
-    /*
     pub(crate) fn is_closed(&self) -> bool {
         self.giver.is_canceled()
     }
-    */
 
     fn can_send(&mut self) -> bool {
         if self.giver.give() || !self.buffered_once {
@@ -117,11 +114,9 @@ impl<T, U> Sender<T, U> {
 
 #[cfg(feature = "http2")]
 impl<T, U> UnboundedSender<T, U> {
-    /*
     pub(crate) fn is_ready(&self) -> bool {
         !self.giver.is_canceled()
     }
-    */
 
     pub(crate) fn is_closed(&self) -> bool {
         self.giver.is_canceled()


### PR DESCRIPTION
These were private in 0.14, used by the Pool to know whether it could checkout a connection. It seems fine to make them public, other channel-like things have similar functions. For instance, Tokio's MPSC `Sender` has `is_closed()`.