### PR TITLE
feat(CI): check external types

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
       - ffi
       - ffi-header
       - doc
+      - check-external-types
     steps:
       - run: exit 0
 
@@ -210,3 +211,26 @@ jobs:
 
       - name: cargo doc
         run: cargo rustdoc --features full,ffi -- --cfg docsrs --cfg hyper_unstable_ffi -D broken-intra-doc-links
+
+  check-external-types:
+    name: Check exposed types
+    needs: [style, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2023-05-31  # Compatible version for cargo-check-external-types
+
+      - name: Install cargo-check-external-types
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-check-external-types
+          version: 0.1.7
+          use-tool-cache: true
+
+      - name: check-external-types
+        run: cargo check-external-types --config .github/workflows/external-types.toml

--- a/.github/workflows/external-types.toml
+++ b/.github/workflows/external-types.toml
@@ -1,0 +1,15 @@
+allowed_external_types = [
+    "bytes::buf::buf_impl::Buf",
+    "bytes::bytes::Bytes",
+    "http::header",
+    "http::header::map::HeaderMap",
+    "http::method::Method",
+    "http::request::Request",
+    "http::response::Response",
+    "http::status::StatusCode",
+    "http::uri::Uri",
+    "http::version::Version",
+    "http_body::Body",
+    "http_body::frame::Frame",
+    "http_body::size_hint::SizeHint",
+]


### PR DESCRIPTION
This adds CI job that runs `cargo-check-external-types` against a whitelist of exported types.

Whitelist in https://github.com/hyperium/hyper/issues/2925#issuecomment-1362473727 didn't change.

For now the nightly for this needs to be pinned to `nightly-2022-11-16`, because `cargo-check-external-types` doesn't work with the latest nightly json doc format.

Resolves #2925
Superseeds #2957