### PR TITLE
feat(client): add is_ready to 1.0 compatible client conn API

### DIFF
--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -90,7 +90,7 @@ impl<B> SendRequest<B> {
         futures_util::future::poll_fn(|cx| self.poll_ready(cx)).await
     }
 
-    pub(super) fn is_ready(&self) -> bool {
+    pub fn is_ready(&self) -> bool {
         self.dispatch.is_ready()
     }
 

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -90,20 +90,9 @@ impl<B> SendRequest<B> {
         futures_util::future::poll_fn(|cx| self.poll_ready(cx)).await
     }
 
-    /*
-    pub(super) async fn when_ready(self) -> crate::Result<Self> {
-        let mut me = Some(self);
-        future::poll_fn(move |cx| {
-            ready!(me.as_mut().unwrap().poll_ready(cx))?;
-            Poll::Ready(Ok(me.take().unwrap()))
-        })
-        .await
-    }
-
     pub(super) fn is_ready(&self) -> bool {
         self.dispatch.is_ready()
     }
-    */
 
     pub(super) fn is_closed(&self) -> bool {
         self.dispatch.is_closed()

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -90,6 +90,17 @@ impl<B> SendRequest<B> {
         futures_util::future::poll_fn(|cx| self.poll_ready(cx)).await
     }
 
+    /// Checks if the connection is currently ready to send a request.
+    ///
+    /// # Note
+    ///
+    /// This is mostly a hint. Due to inherent latency of networks, it is
+    /// possible that even after checking this is ready, sending a request
+    /// may still fail because the connection was closed in the meantime.
+    pub fn is_ready(&self) -> bool {
+        self.dispatch.is_ready()
+    }
+
     pub fn is_ready(&self) -> bool {
         self.dispatch.is_ready()
     }


### PR DESCRIPTION
This address https://github.com/hyperium/hyper/pull/3155/files#r1124682210, including the is_ready() function that is part of 1.0. As noted in the comment, when_ready is removed from 1.0, so the commented code is also cleaned up.