### PR TITLE
feat(server): deprecate server conn structs

### DIFF
--- a/src/server/conn.rs
+++ b/src/server/conn.rs
@@ -98,6 +98,12 @@ pub use super::tcp::{AddrIncoming, AddrStream};
 #[derive(Clone, Debug)]
 #[cfg(any(feature = "http1", feature = "http2"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "http1", feature = "http2"))))]
+#[cfg_attr(
+    feature = "deprecated",
+    deprecated(
+        note = "This struct will be replaced with `server::conn::http1::Builder` and `server::conn::http2::Builder` in 1.0, enable the \"backports\" feature to use them now."
+    )
+)]
 pub struct Http<E = Exec> {
     pub(crate) exec: E,
     h1_half_close: bool,
@@ -213,6 +219,12 @@ impl<E> Unpin for Fallback<E> {}
 #[derive(Debug)]
 #[cfg(any(feature = "http1", feature = "http2"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "http1", feature = "http2"))))]
+#[cfg_attr(
+    feature = "deprecated",
+    deprecated(
+        note = "This struct will be replaced with `server::conn::http1::Parts` in 1.0, enable the \"backports\" feature to use them now."
+    )
+)]
 pub struct Parts<T, S> {
     /// The original IO object used in the handshake.
     pub io: T,
@@ -232,6 +244,7 @@ pub struct Parts<T, S> {
 
 // ===== impl Http =====
 
+#[cfg_attr(feature = "deprecated", allow(deprecated))]
 #[cfg(any(feature = "http1", feature = "http2"))]
 impl Http {
     /// Creates a new instance of the HTTP protocol, ready to spawn a server or
@@ -255,6 +268,7 @@ impl Http {
     }
 }
 
+#[cfg_attr(feature = "deprecated", allow(deprecated))]
 #[cfg(any(feature = "http1", feature = "http2"))]
 impl<E> Http<E> {
     /// Sets whether HTTP1 is required.
@@ -738,6 +752,7 @@ where
     ///
     /// # Panics
     /// This method will panic if this connection is using an h2 protocol.
+    #[cfg_attr(feature = "deprecated", allow(deprecated))]
     pub fn into_parts(self) -> Parts<I, S> {
         self.try_into_parts()
             .unwrap_or_else(|| panic!("h2 cannot into_inner"))
@@ -746,6 +761,7 @@ where
     /// Return the inner IO object, and additional information, if available.
     ///
     /// This method will return a `None` if this connection is using an h2 protocol.
+    #[cfg_attr(feature = "deprecated", allow(deprecated))]
     pub fn try_into_parts(self) -> Option<Parts<I, S>> {
         match self.conn.unwrap() {
             #[cfg(feature = "http1")]
@@ -772,8 +788,7 @@ where
     /// upgrade. Once the upgrade is completed, the connection would be "done",
     /// but it is not desired to actually shutdown the IO object. Instead you
     /// would take it back using `into_parts`.
-    pub fn poll_without_shutdown(&mut self, cx: &mut task::Context<'_>) -> Poll<crate::Result<()>>
-    {
+    pub fn poll_without_shutdown(&mut self, cx: &mut task::Context<'_>) -> Poll<crate::Result<()>> {
         loop {
             match *self.conn.as_mut().unwrap() {
                 #[cfg(feature = "http1")]
@@ -809,8 +824,8 @@ where
     /// # Error
     ///
     /// This errors if the underlying connection protocol is not HTTP/1.
-    pub fn without_shutdown(self) -> impl Future<Output = crate::Result<Parts<I, S>>>
-    {
+    #[cfg_attr(feature = "deprecated", allow(deprecated))]
+    pub fn without_shutdown(self) -> impl Future<Output = crate::Result<Parts<I, S>>> {
         let mut conn = Some(self);
         futures_util::future::poll_fn(move |cx| {
             ready!(conn.as_mut().unwrap().poll_without_shutdown(cx))?;

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -20,6 +20,7 @@ use crate::common::exec::{ConnStreamExec, NewSvcExec};
 use crate::common::{task, Future, Pin, Poll, Unpin};
 // Renamed `Http` as `Http_` for now so that people upgrading don't see an
 // error that `hyper::server::Http` is private...
+#[cfg_attr(feature = "deprecated", allow(deprecated))]
 use super::conn::{Connection, Http as Http_, UpgradeableConnection};
 use super::shutdown::{Graceful, GracefulWatcher};
 use crate::service::{HttpService, MakeServiceRef};
@@ -46,6 +47,7 @@ pin_project! {
 #[cfg_attr(docsrs, doc(cfg(any(feature = "http1", feature = "http2"))))]
 pub struct Builder<I, E = Exec> {
     incoming: I,
+    #[cfg_attr(feature = "deprecated", allow(deprecated))]
     protocol: Http_<E>,
 }
 
@@ -57,6 +59,7 @@ impl<I> Server<I, ()> {
     pub fn builder(incoming: I) -> Builder<I> {
         Builder {
             incoming,
+            #[cfg_attr(feature = "deprecated", allow(deprecated))]
             protocol: Http_::new(),
         }
     }
@@ -237,6 +240,7 @@ impl<I: fmt::Debug, S: fmt::Debug> fmt::Debug for Server<I, S> {
 // ===== impl Builder =====
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "http1", feature = "http2"))))]
+#[cfg_attr(feature = "deprecated", allow(deprecated))]
 impl<I, E> Builder<I, E> {
     /// Start a new builder, wrapping an incoming stream and low-level options.
     ///

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -34,6 +34,7 @@ pin_project! {
     /// handlers. It is built using the [`Builder`](Builder), and the future
     /// completes when the server has been shutdown. It should be run by an
     /// `Executor`.
+    #[cfg_attr(feature = "deprecated", allow(deprecated))]
     pub struct Server<I, S, E = Exec> {
         #[pin]
         incoming: I,
@@ -189,6 +190,7 @@ where
         }
     }
 
+    #[cfg_attr(feature = "deprecated", allow(deprecated))]
     pub(super) fn poll_watch<W>(
         mut self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -46,21 +46,21 @@ pin_project! {
 /// A builder for a [`Server`](Server).
 #[derive(Debug)]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "http1", feature = "http2"))))]
+#[cfg_attr(feature = "deprecated", allow(deprecated))]
 pub struct Builder<I, E = Exec> {
     incoming: I,
-    #[cfg_attr(feature = "deprecated", allow(deprecated))]
     protocol: Http_<E>,
 }
 
 // ===== impl Server =====
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "http1", feature = "http2"))))]
+#[cfg_attr(feature = "deprecated", allow(deprecated))]
 impl<I> Server<I, ()> {
     /// Starts a [`Builder`](Builder) with the provided incoming stream.
     pub fn builder(incoming: I) -> Builder<I> {
         Builder {
             incoming,
-            #[cfg_attr(feature = "deprecated", allow(deprecated))]
             protocol: Http_::new(),
         }
     }
@@ -109,6 +109,7 @@ impl<S, E> Server<AddrIncoming, S, E> {
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "http1", feature = "http2"))))]
+#[cfg_attr(feature = "deprecated", allow(deprecated))]
 impl<I, IO, IE, S, E, B> Server<I, S, E>
 where
     I: Accept<Conn = IO, Error = IE>,
@@ -190,7 +191,6 @@ where
         }
     }
 
-    #[cfg_attr(feature = "deprecated", allow(deprecated))]
     pub(super) fn poll_watch<W>(
         mut self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
@@ -212,6 +212,7 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(any(feature = "http1", feature = "http2"))))]
+#[cfg_attr(feature = "deprecated", allow(deprecated))]
 impl<I, IO, IE, S, B, E> Future for Server<I, S, E>
 where
     I: Accept<Conn = IO, Error = IE>,
@@ -777,6 +778,7 @@ pin_project! {
     #[must_use = "futures do nothing unless polled"]
     #[derive(Debug)]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "http1", feature = "http2"))))]
+    #[cfg_attr(feature = "deprecated", allow(deprecated))]
     pub struct Connecting<I, F, E = Exec> {
         #[pin]
         future: F,

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2642,6 +2642,7 @@ async fn http2_keep_alive_count_server_pings() {
 }
 
 // Tests for backported 1.0 APIs
+#[deny(deprecated)]
 mod backports {
     use super::*;
     use hyper::server::conn::{http1, http2};


### PR DESCRIPTION
This is based on https://github.com/hyperium/hyper/pull/3102 which needs to be merged before this.

I had some difficulty with deprecations inside the `pin-project-lite` macros, it doesn't seem to be possible to set `#[cfg_attr(feature = "deprecated", allow(deprecated))]`on the fields of a struct inside `pin_project!`. That `server::conn::Connection` is inside `pin_project!` makes it difficult to deprecate as well. :thinking: I'll need to come back to this tomorrow. For example, in `hyper/server/server.rs`:

```rust
pin_project! {
    /// A listening HTTP server that accepts connections in both HTTP1 and HTTP2 by default.
    ///
    /// `Server` is a `Future` mapping a bound listener with a set of service
    /// handlers. It is built using the [`Builder`](Builder), and the future
    /// completes when the server has been shutdown. It should be run by an
    /// `Executor`.
    pub struct Server<I, S, E = Exec> {
        #[pin]
        incoming: I,
        make_service: S,
        #[cfg_attr(feature = "deprecated", allow(deprecated))] // <- This doesn't work.
        protocol: Http_<E>,
    }
}
```