### PR TITLE
Get the MSRV for the build job from the package metadata

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,26 +94,23 @@ jobs:
           args: --benches ${{ matrix.features }}
 
   msrv:
-    name: Check MSRV (${{ matrix.rust }})
+    name: Check MSRV
     needs: [style]
-    strategy:
-      matrix:
-        rust:
-          - 1.56 # keep in sync with MSRV.md dev doc
 
-        os:
-          - ubuntu-latest
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Rust (${{ matrix.rust }})
+      - name: Get MSRV from package metadata
+        id: msrv
+        run: grep rust-version Cargo.toml | cut -d'"' -f2 | sed 's/^/version=/' >> $GITHUB_OUTPUT
+
+      - name: Install Rust (${{ steps.msrv.outputs.version }})
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: ${{ steps.msrv.outputs.version }}
 
       - name: Check
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Sean McArthur <sean@seanmonstar.com>"]
 keywords = ["http", "hyper", "hyperium"]
 categories = ["network-programming", "web-programming::http-client", "web-programming::http-server"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.56" # keep in sync with MSRV.md dev doc
 
 include = [
   "Cargo.toml",


### PR DESCRIPTION
That leaves only two places where the MSRV needs to be updated.