### PR TITLE
Revert "fix(ffi): add `repr(transparent)` to `hyper_context` (#3191)"

### DIFF
--- a/src/ffi/task.rs
+++ b/src/ffi/task.rs
@@ -66,7 +66,6 @@ struct TaskFuture {
 }
 
 /// An async context for a task that contains the related waker.
-#[repr(transparent)]
 pub struct hyper_context<'a>(Context<'a>);
 
 /// A waker that is saved and used to waken a pending task.
@@ -379,7 +378,7 @@ where
 
 impl hyper_context<'_> {
     pub(crate) fn wrap<'a, 'b>(cx: &'a mut Context<'b>) -> &'a mut hyper_context<'b> {
-        // A repr(transparent) struct with only one field has the same layout as that field.
+        // A struct with only one field has the same layout as that field.
         unsafe { std::mem::transmute::<&mut Context<'_>, &mut hyper_context<'_>>(cx) }
     }
 }


### PR DESCRIPTION
This reverts commit 187b8f2af984da78b84c28c94b900f16fedf90d8. It changed the generation of the `hyper.h` file.

cc @LegionMammal978 
