### PR TITLE
style(examples): fix typo

### DIFF
--- a/examples/gateway.rs
+++ b/examples/gateway.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .serve_connection(stream, service)
                 .await
             {
-                println!("Failed to servce connection: {:?}", err);
+                println!("Failed to serve the connection: {:?}", err);
             }
         });
     }


### PR DESCRIPTION
Hello,
I have found the typo in the example.