### PR TITLE
fix RUSTSEC-2023-0034 by updating h2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ http-body = "=1.0.0-rc.2"
 http-body-util = { version = "=0.1.0-rc.2", optional = true }
 httpdate = "1.0"
 httparse = "1.8"
-h2 = { version = "0.3.9", optional = true }
+h2 = { version = "0.3.17", optional = true }
 itoa = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 pin-project-lite = "0.2.4"


### PR DESCRIPTION
Fixes https://rustsec.org/advisories/RUSTSEC-2023-0034 by updating h2