### PR TITLE
docs(rt): fix executor example

### DIFF
--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -22,6 +22,7 @@ use std::{
 /// ```
 /// # use hyper::rt::Executor;
 /// # use std::future::Future;
+/// #[derive(Clone)]
 /// struct TokioExecutor;
 ///
 /// impl<F> Executor<F> for TokioExecutor


### PR DESCRIPTION
Copy pasting the tokio executor example doesn't work because the struct doesn't implement clone. This PR adds `#[derive(Clone)]` to the example.