### PR TITLE
docs(rt): make purpose of `Executor` trait clearer

### DIFF
--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -15,7 +15,7 @@ use std::{
 
 /// An executor of futures.
 ///
-/// This trait should be implemented for any future.
+/// This trait allows Hyper to abstract over async runtimes. Implement this trait for your own type.
 ///
 /// # Example
 ///


### PR DESCRIPTION
Make the purpose of `Executor` clearer by explaining why it is necessary.

