### PR TITLE
chore(dependencies): use futures-core via futures-util consistently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ include = [
 
 [dependencies]
 bytes = "1"
-futures-core = { version = "0.3", default-features = false }
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 http = "0.2"

--- a/src/body/incoming.rs
+++ b/src/body/incoming.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use bytes::Bytes;
 use futures_channel::mpsc;
 use futures_channel::oneshot;
-use futures_core::{FusedStream, Stream}; // for mpsc::Receiver
+use futures_util::{stream::FusedStream, Stream}; // for mpsc::Receiver
 use http::HeaderMap;
 use http_body::{Body, Frame, SizeHint};
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -6,6 +6,7 @@ extern crate matches;
 
 use std::convert::Infallible;
 use std::fmt;
+use std::future::Future;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener};
 use std::pin::Pin;
@@ -20,8 +21,7 @@ use hyper::{Method, Request, StatusCode, Uri, Version};
 
 use bytes::Bytes;
 use futures_channel::oneshot;
-use futures_core::{Future, TryFuture};
-use futures_util::future::{self, FutureExt, TryFutureExt};
+use futures_util::future::{self, FutureExt, TryFuture, TryFutureExt};
 use tokio::net::TcpStream;
 mod support;
 


### PR DESCRIPTION
`hyper` has already used `futures-core` via `futures-util` at many places. We could reduce some costs to maintain dependencies by doing it consistently.