### PR TITLE
fix(example): change suggestion for windows compatability

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -18,7 +18,7 @@ async fn echo(
     match (req.method(), req.uri().path()) {
         // Serve some instructions at /
         (&Method::GET, "/") => Ok(Response::new(full(
-            "Try POSTing data to /echo such as: `curl localhost:3000/echo -XPOST -d 'hello world'`",
+            "Try POSTing data to /echo such as: `curl localhost:3000/echo -XPOST -d \"hello world\"`",
         ))),
 
         // Simply echo the body back to the client.


### PR DESCRIPTION
# Overview

Updated echo example service root path instructions to work for Windows users out-of-the-box.

# Inspiration

Tripped over this during some midnight coding 😵‍💫

![image](https://user-images.githubusercontent.com/46393653/236380212-216ea0b4-ec40-483f-8ee7-a9c628aea5bd.png)

![image](https://user-images.githubusercontent.com/46393653/236380227-ad21bb27-19c9-47f6-9eb3-83a9d7f70880.png)

# Testing

I put this change through a full loop[^1] of testing on:

- macbook (apple silicon)
- pc (windows 10, x86_64)
- linux ([devcontainer.json](https://pastebin.com/9iF6KzRQ))

No regressions discovered.

# Criticism Welcome 😄 

If bypassing the reporting step was inappropriate, I will abandon this PR and create an issue accordingly 👍🏻 

[^1]: repeating the process pictured above
