### PR TITLE
chore(lib): update to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 keywords = ["http", "hyper", "hyperium"]
 categories = ["network-programming", "web-programming::http-client", "web-programming::http-server"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.63" # keep in sync with MSRV.md dev doc
 
 include = [

--- a/src/ext/h1_reason_phrase.rs
+++ b/src/ext/h1_reason_phrase.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use bytes::Bytes;
 
 /// A reason phrase in an HTTP/1 response.

--- a/src/ffi/body.rs
+++ b/src/ffi/body.rs
@@ -107,6 +107,7 @@ ffi_fn! {
         let userdata = UserDataPointer(userdata);
 
         Box::into_raw(hyper_task::boxed(async move {
+            let _ = &userdata;
             while let Some(item) = body.0.frame().await {
                 let frame = item?;
                 if let Ok(chunk) = frame.into_data() {

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,7 +1,6 @@
 #![deny(warnings)]
 #![deny(rust_2018_idioms)]
 
-use std::convert::TryInto;
 use std::future::Future;
 use std::io::{self, Read, Write};
 use std::net::TcpListener as StdTcpListener;


### PR DESCRIPTION
As `hyper`'s msrv is 1.56, we could use 2021 edition.