### PR TITLE
docs(examples): update dependencies (#3099)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,25 +1,34 @@
 # Examples of using hyper
 
-These examples show of how to do common tasks using `hyper`. You may also find the [Guides](https://hyper.rs/guides) helpful.
+These examples show how to do common tasks using `hyper`. You may also find the [Guides](https://hyper.rs/guides/1/) helpful.
 
-If you checkout this repository, you can run any of the examples `cargo run --example example_name`.
+If you checkout this repository, you can run any of the examples with the command:
+
+ `cargo run --example {example_name}`
 
 ### Dependencies
 
-Most of these examples use these dependencies:
+A complete list of dependencies used across these examples:
 
 ```toml
 [dependencies]
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "1.0.0-rc.3", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
 pretty_env_logger = "0.4"
+http-body-util = "0.1.0-rc.2"
+bytes = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+url = "2.2"
+http = "0.2"
+futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 ```
 
 ## Getting Started
 
 ### Clients
 
-* [`client`](client.rs) - A simple CLI http client that request the url passed in parameters and outputs the response content and details to the stdout, reading content chunk-by-chunk.
+* [`client`](client.rs) - A simple CLI http client that requests the url passed in parameters and outputs the response content and details to the stdout, reading content chunk-by-chunk.
 
 * [`client_json`](client_json.rs) - A simple program that GETs some json, reads the body asynchronously, parses it with serde and outputs the result.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ These examples show how to do common tasks using `hyper`. You may also find the 
 
 If you checkout this repository, you can run any of the examples with the command:
 
- `cargo run --example {example_name}`
+ `cargo run --example {example_name} --features="full"`
 
 ### Dependencies
 


### PR DESCRIPTION
# Overview

As discussed: #3099. This PR includes:

- updating dependencies to hyper 1.0
- linking to hyper 1.0 guides
- fixes for spelling and formatting

# Method

Copied every example into a fresh project and tallied all of the necessary dependencies. Then I referenced [hyper's toml file](https://github.com/hyperium/hyper/blob/master/Cargo.toml) and copied the master branch dependency versions.

# Testing

Tested by dropping the new batch of dependencies into a freshly gen'd cargo project and copying in every example in turn and making sure it runs.

Tested on:

`rustc 1.69.0 (84c898d65 2023-04-16)`

Which now gives me pause in regard to MSRV 🤔. Perhaps not, since this is a version specific update.

# Criticism Welcome 😄 

I will make any necessary changes to this work to achieve the desired results 👍🏻 