### PR TITLE
feat(rt): replace IO traits with hyper::rt ones

### DIFF
--- a/benches/pipeline.rs
+++ b/benches/pipeline.rs
@@ -3,6 +3,8 @@
 
 extern crate test;
 
+mod support;
+
 use std::convert::Infallible;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpStream};
@@ -40,11 +42,12 @@ fn hello_world_16(b: &mut test::Bencher) {
             rt.spawn(async move {
                 loop {
                     let (stream, _addr) = listener.accept().await.expect("accept");
+                    let io = support::TokioIo::new(stream);
 
                     http1::Builder::new()
                         .pipeline_flush(true)
                         .serve_connection(
-                            stream,
+                            io,
                             service_fn(|_| async {
                                 Ok::<_, Infallible>(Response::new(Full::new(Bytes::from(
                                     "Hello, World!",

--- a/benches/server.rs
+++ b/benches/server.rs
@@ -3,6 +3,8 @@
 
 extern crate test;
 
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::mpsc;
@@ -38,10 +40,11 @@ macro_rules! bench_server {
                 rt.spawn(async move {
                     loop {
                         let (stream, _) = listener.accept().await.expect("accept");
+                        let io = support::TokioIo::new(stream);
 
                         http1::Builder::new()
                             .serve_connection(
-                                stream,
+                                io,
                                 service_fn(|_| async {
                                     Ok::<_, hyper::Error>(
                                         Response::builder()

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -1,2 +1,2 @@
 mod tokiort;
-pub use tokiort::{TokioExecutor, TokioTimer};
+pub use tokiort::{TokioExecutor, TokioIo, TokioTimer};

--- a/benches/support/tokiort.rs
+++ b/benches/support/tokiort.rs
@@ -88,3 +88,149 @@ impl TokioSleep {
         self.project().inner.as_mut().reset(deadline.into());
     }
 }
+
+pin_project! {
+    #[derive(Debug)]
+    pub struct TokioIo<T> {
+        #[pin]
+        inner: T,
+    }
+}
+
+impl<T> TokioIo<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+
+    pub fn inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> hyper::rt::Read for TokioIo<T>
+where
+    T: tokio::io::AsyncRead,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        mut buf: hyper::rt::ReadBufCursor<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        let n = unsafe {
+            let mut tbuf = tokio::io::ReadBuf::uninit(buf.as_mut());
+            match tokio::io::AsyncRead::poll_read(self.project().inner, cx, &mut tbuf) {
+                Poll::Ready(Ok(())) => tbuf.filled().len(),
+                other => return other,
+            }
+        };
+
+        unsafe {
+            buf.advance(n);
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<T> hyper::rt::Write for TokioIo<T>
+where
+    T: tokio::io::AsyncWrite,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        tokio::io::AsyncWrite::poll_write(self.project().inner, cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        tokio::io::AsyncWrite::poll_flush(self.project().inner, cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        tokio::io::AsyncWrite::poll_shutdown(self.project().inner, cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        tokio::io::AsyncWrite::is_write_vectored(&self.inner)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        tokio::io::AsyncWrite::poll_write_vectored(self.project().inner, cx, bufs)
+    }
+}
+
+impl<T> tokio::io::AsyncRead for TokioIo<T>
+where
+    T: hyper::rt::Read,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        tbuf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        //let init = tbuf.initialized().len();
+        let filled = tbuf.filled().len();
+        let sub_filled = unsafe {
+            let mut buf = hyper::rt::ReadBuf::uninit(tbuf.unfilled_mut());
+
+            match hyper::rt::Read::poll_read(self.project().inner, cx, buf.unfilled()) {
+                Poll::Ready(Ok(())) => buf.filled().len(),
+                other => return other,
+            }
+        };
+
+        let n_filled = filled + sub_filled;
+        // At least sub_filled bytes had to have been initialized.
+        let n_init = sub_filled;
+        unsafe {
+            tbuf.assume_init(n_init);
+            tbuf.set_filled(n_filled);
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<T> tokio::io::AsyncWrite for TokioIo<T>
+where
+    T: hyper::rt::Write,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        hyper::rt::Write::poll_write(self.project().inner, cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        hyper::rt::Write::poll_flush(self.project().inner, cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        hyper::rt::Write::poll_shutdown(self.project().inner, cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        hyper::rt::Write::is_write_vectored(&self.inner)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        hyper::rt::Write::poll_write_vectored(self.project().inner, cx, bufs)
+    }
+}

--- a/examples/client_json.rs
+++ b/examples/client_json.rs
@@ -7,6 +7,10 @@ use hyper::{body::Buf, Request};
 use serde::Deserialize;
 use tokio::net::TcpStream;
 
+#[path = "../benches/support/mod.rs"]
+mod support;
+use support::TokioIo;
+
 // A simple type alias so as to DRY.
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
@@ -29,8 +33,9 @@ async fn fetch_json(url: hyper::Uri) -> Result<Vec<User>> {
     let addr = format!("{}:{}", host, port);
 
     let stream = TcpStream::connect(addr).await?;
+    let io = TokioIo::new(stream);
 
-    let (mut sender, conn) = hyper::client::conn::http1::handshake(stream).await?;
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
     tokio::task::spawn(async move {
         if let Err(err) = conn.await {
             println!("Connection failed: {:?}", err);

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -10,6 +10,10 @@ use hyper::service::service_fn;
 use hyper::{body::Body, Method, Request, Response, StatusCode};
 use tokio::net::TcpListener;
 
+#[path = "../benches/support/mod.rs"]
+mod support;
+use support::TokioIo;
+
 /// This is our service handler. It receives a Request, routes on its
 /// path, and returns a Future of a Response.
 async fn echo(
@@ -92,10 +96,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("Listening on http://{}", addr);
     loop {
         let (stream, _) = listener.accept().await?;
+        let io = TokioIo::new(stream);
 
         tokio::task::spawn(async move {
             if let Err(err) = http1::Builder::new()
-                .serve_connection(stream, service_fn(echo))
+                .serve_connection(io, service_fn(echo))
                 .await
             {
                 println!("Error serving connection: {:?}", err);

--- a/examples/params.rs
+++ b/examples/params.rs
@@ -13,6 +13,10 @@ use std::convert::Infallible;
 use std::net::SocketAddr;
 use url::form_urlencoded;
 
+#[path = "../benches/support/mod.rs"]
+mod support;
+use support::TokioIo;
+
 static INDEX: &[u8] = b"<html><body><form action=\"post\" method=\"post\">Name: <input type=\"text\" name=\"name\"><br>Number: <input type=\"text\" name=\"number\"><br><input type=\"submit\"></body></html>";
 static MISSING: &[u8] = b"Missing field";
 static NOTNUMERIC: &[u8] = b"Number field is not numeric";
@@ -124,10 +128,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("Listening on http://{}", addr);
     loop {
         let (stream, _) = listener.accept().await?;
+        let io = TokioIo::new(stream);
 
         tokio::task::spawn(async move {
             if let Err(err) = http1::Builder::new()
-                .serve_connection(stream, service_fn(param_example))
+                .serve_connection(io, service_fn(param_example))
                 .await
             {
                 println!("Error serving connection: {:?}", err);

--- a/examples/send_file.rs
+++ b/examples/send_file.rs
@@ -10,6 +10,10 @@ use http_body_util::Full;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, Result, StatusCode};
 
+#[path = "../benches/support/mod.rs"]
+mod support;
+use support::TokioIo;
+
 static INDEX: &str = "examples/send_file_index.html";
 static NOTFOUND: &[u8] = b"Not Found";
 
@@ -24,10 +28,11 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     loop {
         let (stream, _) = listener.accept().await?;
+        let io = TokioIo::new(stream);
 
         tokio::task::spawn(async move {
             if let Err(err) = http1::Builder::new()
-                .serve_connection(stream, service_fn(response_examples))
+                .serve_connection(io, service_fn(response_examples))
                 .await
             {
                 println!("Failed to serve connection: {:?}", err);

--- a/examples/service_struct_impl.rs
+++ b/examples/service_struct_impl.rs
@@ -10,6 +10,10 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Mutex;
 
+#[path = "../benches/support/mod.rs"]
+mod support;
+use support::TokioIo;
+
 type Counter = i32;
 
 #[tokio::main]
@@ -21,11 +25,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     loop {
         let (stream, _) = listener.accept().await?;
+        let io = TokioIo::new(stream);
 
         tokio::task::spawn(async move {
             if let Err(err) = http1::Builder::new()
                 .serve_connection(
-                    stream,
+                    io,
                     Svc {
                         counter: Mutex::new(81818),
                     },

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -3,10 +3,10 @@
 use std::error::Error as StdError;
 use std::fmt;
 
+use crate::rt::{Read, Write};
 use bytes::Bytes;
 use http::{Request, Response};
 use httparse::ParserConfig;
-use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::super::dispatch;
 use crate::body::{Body, Incoming as IncomingBody};
@@ -49,7 +49,7 @@ pub struct Parts<T> {
 #[must_use = "futures do nothing unless polled"]
 pub struct Connection<T, B>
 where
-    T: AsyncRead + AsyncWrite + Send + 'static,
+    T: Read + Write + Send + 'static,
     B: Body + 'static,
 {
     inner: Option<Dispatcher<T, B>>,
@@ -57,7 +57,7 @@ where
 
 impl<T, B> Connection<T, B>
 where
-    T: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    T: Read + Write + Send + Unpin + 'static,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
 {
@@ -114,7 +114,7 @@ pub struct Builder {
 /// See [`client::conn`](crate::client::conn) for more.
 pub async fn handshake<T, B>(io: T) -> crate::Result<(SendRequest<B>, Connection<T, B>)>
 where
-    T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    T: Read + Write + Unpin + Send + 'static,
     B: Body + 'static,
     B::Data: Send,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
@@ -238,7 +238,7 @@ impl<B> fmt::Debug for SendRequest<B> {
 
 impl<T, B> fmt::Debug for Connection<T, B>
 where
-    T: AsyncRead + AsyncWrite + fmt::Debug + Send + 'static,
+    T: Read + Write + fmt::Debug + Send + 'static,
     B: Body + 'static,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -248,7 +248,7 @@ where
 
 impl<T, B> Future for Connection<T, B>
 where
-    T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    T: Read + Write + Unpin + Send + 'static,
     B: Body + Send + 'static,
     B::Data: Send,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
@@ -470,7 +470,7 @@ impl Builder {
         io: T,
     ) -> impl Future<Output = crate::Result<(SendRequest<B>, Connection<T, B>)>>
     where
-        T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        T: Read + Write + Unpin + Send + 'static,
         B: Body + 'static,
         B::Data: Send,
         B::Error: Into<Box<dyn StdError + Send + Sync>>,

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -6,8 +6,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::rt::{Read, Write};
 use http::{Request, Response};
-use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::super::dispatch;
 use crate::body::{Body, Incoming as IncomingBody};
@@ -37,7 +37,7 @@ impl<B> Clone for SendRequest<B> {
 #[must_use = "futures do nothing unless polled"]
 pub struct Connection<T, B, E>
 where
-    T: AsyncRead + AsyncWrite + 'static + Unpin,
+    T: Read + Write + 'static + Unpin,
     B: Body + 'static,
     E: ExecutorClient<B, T> + Unpin,
     B::Error: Into<Box<dyn Error + Send + Sync>>,
@@ -64,7 +64,7 @@ pub async fn handshake<E, T, B>(
     io: T,
 ) -> crate::Result<(SendRequest<B>, Connection<T, B, E>)>
 where
-    T: AsyncRead + AsyncWrite + Unpin + 'static,
+    T: Read + Write + Unpin + 'static,
     B: Body + 'static,
     B::Data: Send,
     B::Error: Into<Box<dyn Error + Send + Sync>>,
@@ -193,7 +193,7 @@ impl<B> fmt::Debug for SendRequest<B> {
 
 impl<T, B, E> Connection<T, B, E>
 where
-    T: AsyncRead + AsyncWrite + Unpin + 'static,
+    T: Read + Write + Unpin + 'static,
     B: Body + Unpin + Send + 'static,
     B::Data: Send,
     B::Error: Into<Box<dyn Error + Send + Sync>>,
@@ -215,7 +215,7 @@ where
 
 impl<T, B, E> fmt::Debug for Connection<T, B, E>
 where
-    T: AsyncRead + AsyncWrite + fmt::Debug + 'static + Unpin,
+    T: Read + Write + fmt::Debug + 'static + Unpin,
     B: Body + 'static,
     E: ExecutorClient<B, T> + Unpin,
     B::Error: Into<Box<dyn Error + Send + Sync>>,
@@ -227,7 +227,7 @@ where
 
 impl<T, B, E> Future for Connection<T, B, E>
 where
-    T: AsyncRead + AsyncWrite + Unpin + 'static,
+    T: Read + Write + Unpin + 'static,
     B: Body + 'static + Unpin,
     B::Data: Send,
     E: Unpin,
@@ -398,7 +398,7 @@ where
         io: T,
     ) -> impl Future<Output = crate::Result<(SendRequest<B>, Connection<T, B, Ex>)>>
     where
-        T: AsyncRead + AsyncWrite + Unpin + 'static,
+        T: Read + Write + Unpin + 'static,
         B: Body + 'static,
         B::Data: Send,
         B::Error: Into<Box<dyn Error + Send + Sync>>,

--- a/src/client/conn/mod.rs
+++ b/src/client/conn/mod.rs
@@ -9,7 +9,9 @@
 //! higher-level [Client](super) API.
 //!
 //! ## Example
-//! A simple example that uses the `SendRequest` struct to talk HTTP over a Tokio TCP stream
+//!
+//! A simple example that uses the `SendRequest` struct to talk HTTP over some TCP stream.
+//!
 //! ```no_run
 //! # #[cfg(all(feature = "client", feature = "http1"))]
 //! # mod rt {
@@ -17,38 +19,38 @@
 //! use http::{Request, StatusCode};
 //! use http_body_util::Empty;
 //! use hyper::client::conn;
-//! use tokio::net::TcpStream;
+//! # use hyper::rt::{Read, Write};
+//! # async fn run<I>(tcp: I) -> Result<(), Box<dyn std::error::Error>>
+//! # where
+//! #     I: Read + Write + Unpin + Send + 'static,
+//! # {
+//! let (mut request_sender, connection) = conn::http1::handshake(tcp).await?;
 //!
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let target_stream = TcpStream::connect("example.com:80").await?;
+//! // spawn a task to poll the connection and drive the HTTP state
+//! tokio::spawn(async move {
+//!     if let Err(e) = connection.await {
+//!         eprintln!("Error in connection: {}", e);
+//!     }
+//! });
 //!
-//!     let (mut request_sender, connection) = conn::http1::handshake(target_stream).await?;
+//! let request = Request::builder()
+//!     // We need to manually add the host header because SendRequest does not
+//!     .header("Host", "example.com")
+//!     .method("GET")
+//!     .body(Empty::<Bytes>::new())?;
 //!
-//!     // spawn a task to poll the connection and drive the HTTP state
-//!     tokio::spawn(async move {
-//!         if let Err(e) = connection.await {
-//!             eprintln!("Error in connection: {}", e);
-//!         }
-//!     });
+//! let response = request_sender.send_request(request).await?;
+//! assert!(response.status() == StatusCode::OK);
 //!
-//!     let request = Request::builder()
-//!         // We need to manually add the host header because SendRequest does not
-//!         .header("Host", "example.com")
-//!         .method("GET")
-//!         .body(Empty::<Bytes>::new())?;
-//!     let response = request_sender.send_request(request).await?;
-//!     assert!(response.status() == StatusCode::OK);
+//! let request = Request::builder()
+//!     .header("Host", "example.com")
+//!     .method("GET")
+//!     .body(Empty::<Bytes>::new())?;
 //!
-//!     let request = Request::builder()
-//!         .header("Host", "example.com")
-//!         .method("GET")
-//!         .body(Empty::<Bytes>::new())?;
-//!     let response = request_sender.send_request(request).await?;
-//!     assert!(response.status() == StatusCode::OK);
-//!     Ok(())
-//! }
-//!
+//! let response = request_sender.send_request(request).await?;
+//! assert!(response.status() == StatusCode::OK);
+//! # Ok(())
+//! # }
 //! # }
 //! ```
 

--- a/src/common/io/compat.rs
+++ b/src/common/io/compat.rs
@@ -1,0 +1,150 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// This adapts from `hyper` IO traits to the ones in Tokio.
+///
+/// This is currently used by `h2`, and by hyper internal unit tests.
+#[derive(Debug)]
+pub(crate) struct Compat<T>(pub(crate) T);
+
+pub(crate) fn compat<T>(io: T) -> Compat<T> {
+    Compat(io)
+}
+
+impl<T> Compat<T> {
+    fn p(self: Pin<&mut Self>) -> Pin<&mut T> {
+        // SAFETY: The simplest of projections. This is just
+        // a wrapper, we don't do anything that would undo the projection.
+        unsafe { self.map_unchecked_mut(|me| &mut me.0) }
+    }
+}
+
+impl<T> tokio::io::AsyncRead for Compat<T>
+where
+    T: crate::rt::Read,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        tbuf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        let init = tbuf.initialized().len();
+        let filled = tbuf.filled().len();
+        let (new_init, new_filled) = unsafe {
+            let mut buf = crate::rt::ReadBuf::uninit(tbuf.inner_mut());
+            buf.set_init(init);
+            buf.set_filled(filled);
+
+            match crate::rt::Read::poll_read(self.p(), cx, buf.unfilled()) {
+                Poll::Ready(Ok(())) => (buf.init_len(), buf.len()),
+                other => return other,
+            }
+        };
+
+        let n_init = new_init - init;
+        unsafe {
+            tbuf.assume_init(n_init);
+            tbuf.set_filled(new_filled);
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<T> tokio::io::AsyncWrite for Compat<T>
+where
+    T: crate::rt::Write,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        crate::rt::Write::poll_write(self.p(), cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        crate::rt::Write::poll_flush(self.p(), cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        crate::rt::Write::poll_shutdown(self.p(), cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        crate::rt::Write::is_write_vectored(&self.0)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        crate::rt::Write::poll_write_vectored(self.p(), cx, bufs)
+    }
+}
+
+#[cfg(test)]
+impl<T> crate::rt::Read for Compat<T>
+where
+    T: tokio::io::AsyncRead,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        mut buf: crate::rt::ReadBufCursor<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        let n = unsafe {
+            let mut tbuf = tokio::io::ReadBuf::uninit(buf.as_mut());
+            match tokio::io::AsyncRead::poll_read(self.p(), cx, &mut tbuf) {
+                Poll::Ready(Ok(())) => tbuf.filled().len(),
+                other => return other,
+            }
+        };
+
+        unsafe {
+            buf.advance(n);
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+impl<T> crate::rt::Write for Compat<T>
+where
+    T: tokio::io::AsyncWrite,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        tokio::io::AsyncWrite::poll_write(self.p(), cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        tokio::io::AsyncWrite::poll_flush(self.p(), cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        tokio::io::AsyncWrite::poll_shutdown(self.p(), cx)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        tokio::io::AsyncWrite::is_write_vectored(&self.0)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        tokio::io::AsyncWrite::poll_write_vectored(self.p(), cx, bufs)
+    }
+}

--- a/src/common/io/mod.rs
+++ b/src/common/io/mod.rs
@@ -1,3 +1,7 @@
+#[cfg(any(feature = "http2", test))]
+mod compat;
 mod rewind;
 
+#[cfg(any(feature = "http2", test))]
+pub(crate) use self::compat::{compat, Compat};
 pub(crate) use self::rewind::Rewind;

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -2,9 +2,9 @@ use std::marker::Unpin;
 use std::{cmp, io};
 
 use bytes::{Buf, Bytes};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::common::{task, Pin, Poll};
+use crate::rt::{Read, ReadBufCursor, Write};
 
 /// Combine a buffer with an IO, rewinding reads to use the buffer.
 #[derive(Debug)]
@@ -44,14 +44,14 @@ impl<T> Rewind<T> {
     // }
 }
 
-impl<T> AsyncRead for Rewind<T>
+impl<T> Read for Rewind<T>
 where
-    T: AsyncRead + Unpin,
+    T: Read + Unpin,
 {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
-        buf: &mut ReadBuf<'_>,
+        mut buf: ReadBufCursor<'_>,
     ) -> Poll<io::Result<()>> {
         if let Some(mut prefix) = self.pre.take() {
             // If there are no remaining bytes, let the bytes get dropped.
@@ -72,9 +72,9 @@ where
     }
 }
 
-impl<T> AsyncWrite for Rewind<T>
+impl<T> Write for Rewind<T>
 where
-    T: AsyncWrite + Unpin,
+    T: Write + Unpin,
 {
     fn poll_write(
         mut self: Pin<&mut Self>,
@@ -109,6 +109,7 @@ where
 mod tests {
     // FIXME: re-implement tests with `async/await`, this import should
     // trigger a warning to remind us
+    use super::super::compat;
     use super::Rewind;
     use bytes::Bytes;
     use tokio::io::AsyncReadExt;
@@ -120,14 +121,14 @@ mod tests {
 
         let mock = tokio_test::io::Builder::new().read(&underlying).build();
 
-        let mut stream = Rewind::new(mock);
+        let mut stream = compat(Rewind::new(compat(mock)));
 
         // Read off some bytes, ensure we filled o1
         let mut buf = [0; 2];
         stream.read_exact(&mut buf).await.expect("read1");
 
         // Rewind the stream so that it is as if we never read in the first place.
-        stream.rewind(Bytes::copy_from_slice(&buf[..]));
+        stream.0.rewind(Bytes::copy_from_slice(&buf[..]));
 
         let mut buf = [0; 5];
         stream.read_exact(&mut buf).await.expect("read1");
@@ -143,13 +144,13 @@ mod tests {
 
         let mock = tokio_test::io::Builder::new().read(&underlying).build();
 
-        let mut stream = Rewind::new(mock);
+        let mut stream = compat(Rewind::new(compat(mock)));
 
         let mut buf = [0; 5];
         stream.read_exact(&mut buf).await.expect("read1");
 
         // Rewind the stream so that it is as if we never read in the first place.
-        stream.rewind(Bytes::copy_from_slice(&buf[..]));
+        stream.0.rewind(Bytes::copy_from_slice(&buf[..]));
 
         let mut buf = [0; 5];
         stream.read_exact(&mut buf).await.expect("read1");

--- a/src/ffi/io.rs
+++ b/src/ffi/io.rs
@@ -2,8 +2,8 @@ use std::ffi::c_void;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use crate::rt::{Read, Write};
 use libc::size_t;
-use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::task::hyper_context;
 
@@ -120,13 +120,13 @@ extern "C" fn write_noop(
     0
 }
 
-impl AsyncRead for hyper_io {
+impl Read for hyper_io {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
+        mut buf: crate::rt::ReadBufCursor<'_>,
     ) -> Poll<std::io::Result<()>> {
-        let buf_ptr = unsafe { buf.unfilled_mut() }.as_mut_ptr() as *mut u8;
+        let buf_ptr = unsafe { buf.as_mut() }.as_mut_ptr() as *mut u8;
         let buf_len = buf.remaining();
 
         match (self.read)(self.userdata, hyper_context::wrap(cx), buf_ptr, buf_len) {
@@ -138,15 +138,14 @@ impl AsyncRead for hyper_io {
             ok => {
                 // We have to trust that the user's read callback actually
                 // filled in that many bytes... :(
-                unsafe { buf.assume_init(ok) };
-                buf.advance(ok);
+                unsafe { buf.advance(ok) };
                 Poll::Ready(Ok(()))
             }
         }
     }
 }
 
-impl AsyncWrite for hyper_io {
+impl Write for hyper_io {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -428,9 +428,9 @@ impl StdError for IncompleteBody {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rt::{Read, ReadBuf};
     use std::pin::Pin;
     use std::time::Duration;
-    use tokio::io::{AsyncRead, ReadBuf};
 
     impl<'a> MemRead for &'a [u8] {
         fn read_mem(&mut self, _: &mut task::Context<'_>, len: usize) -> Poll<io::Result<Bytes>> {
@@ -446,11 +446,11 @@ mod tests {
         }
     }
 
-    impl<'a> MemRead for &'a mut (dyn AsyncRead + Unpin) {
+    impl<'a> MemRead for &'a mut (dyn Read + Unpin) {
         fn read_mem(&mut self, cx: &mut task::Context<'_>, len: usize) -> Poll<io::Result<Bytes>> {
             let mut v = vec![0; len];
             let mut buf = ReadBuf::new(&mut v);
-            ready!(Pin::new(self).poll_read(cx, &mut buf)?);
+            ready!(Pin::new(self).poll_read(cx, buf.unfilled())?);
             Poll::Ready(Ok(Bytes::copy_from_slice(&buf.filled())))
         }
     }
@@ -629,7 +629,7 @@ mod tests {
     async fn read_async(mut decoder: Decoder, content: &[u8], block_at: usize) -> String {
         let mut outs = Vec::new();
 
-        let mut ins = if block_at == 0 {
+        let mut ins = crate::common::io::compat(if block_at == 0 {
             tokio_test::io::Builder::new()
                 .wait(Duration::from_millis(10))
                 .read(content)
@@ -640,9 +640,9 @@ mod tests {
                 .wait(Duration::from_millis(10))
                 .read(&content[block_at..])
                 .build()
-        };
+        });
 
-        let mut ins = &mut ins as &mut (dyn AsyncRead + Unpin);
+        let mut ins = &mut ins as &mut (dyn Read + Unpin);
 
         loop {
             let buf = decoder

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -1,8 +1,8 @@
 use std::error::Error as StdError;
 
+use crate::rt::{Read, Write};
 use bytes::{Buf, Bytes};
 use http::Request;
-use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::{debug, trace};
 
 use super::{Http1Transaction, Wants};
@@ -64,7 +64,7 @@ where
             RecvItem = MessageHead<T::Incoming>,
         > + Unpin,
     D::PollError: Into<Box<dyn StdError + Send + Sync>>,
-    I: AsyncRead + AsyncWrite + Unpin,
+    I: Read + Write + Unpin,
     T: Http1Transaction + Unpin,
     Bs: Body + 'static,
     Bs::Error: Into<Box<dyn StdError + Send + Sync>>,
@@ -97,7 +97,7 @@ where
     }
 
     /// Run this dispatcher until HTTP says this connection is done,
-    /// but don't call `AsyncWrite::shutdown` on the underlying IO.
+    /// but don't call `Write::shutdown` on the underlying IO.
     ///
     /// This is useful for old-style HTTP upgrades, but ignores
     /// newer-style upgrade API.
@@ -426,7 +426,7 @@ where
             RecvItem = MessageHead<T::Incoming>,
         > + Unpin,
     D::PollError: Into<Box<dyn StdError + Send + Sync>>,
-    I: AsyncRead + AsyncWrite + Unpin,
+    I: Read + Write + Unpin,
     T: Http1Transaction + Unpin,
     Bs: Body + 'static,
     Bs::Error: Into<Box<dyn StdError + Send + Sync>>,
@@ -664,6 +664,7 @@ cfg_client! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::io::compat;
     use crate::proto::h1::ClientTransaction;
     use std::time::Duration;
 
@@ -677,7 +678,7 @@ mod tests {
             // Block at 0 for now, but we will release this response before
             // the request is ready to write later...
             let (mut tx, rx) = crate::client::dispatch::channel();
-            let conn = Conn::<_, bytes::Bytes, ClientTransaction>::new(io);
+            let conn = Conn::<_, bytes::Bytes, ClientTransaction>::new(compat(io));
             let mut dispatcher = Dispatcher::new(Client::new(rx), conn);
 
             // First poll is needed to allow tx to send...
@@ -714,7 +715,7 @@ mod tests {
             .build_with_handle();
 
         let (mut tx, rx) = crate::client::dispatch::channel();
-        let mut conn = Conn::<_, bytes::Bytes, ClientTransaction>::new(io);
+        let mut conn = Conn::<_, bytes::Bytes, ClientTransaction>::new(compat(io));
         conn.set_write_strategy_queue();
 
         let dispatcher = Dispatcher::new(Client::new(rx), conn);
@@ -745,7 +746,7 @@ mod tests {
             .build();
 
         let (mut tx, rx) = crate::client::dispatch::channel();
-        let conn = Conn::<_, bytes::Bytes, ClientTransaction>::new(io);
+        let conn = Conn::<_, bytes::Bytes, ClientTransaction>::new(compat(io));
         let mut dispatcher = tokio_test::task::spawn(Dispatcher::new(Client::new(rx), conn));
 
         // First poll is needed to allow tx to send...

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -6,8 +6,8 @@ use std::io::{self, IoSlice};
 use std::marker::Unpin;
 use std::mem::MaybeUninit;
 
+use crate::rt::{Read, ReadBuf, Write};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tracing::{debug, trace};
 
 use super::{Http1Transaction, ParseContext, ParsedMessage};
@@ -55,7 +55,7 @@ where
 
 impl<T, B> Buffered<T, B>
 where
-    T: AsyncRead + AsyncWrite + Unpin,
+    T: Read + Write + Unpin,
     B: Buf,
 {
     pub(crate) fn new(io: T) -> Buffered<T, B> {
@@ -251,7 +251,7 @@ where
         let dst = self.read_buf.chunk_mut();
         let dst = unsafe { &mut *(dst as *mut _ as *mut [MaybeUninit<u8>]) };
         let mut buf = ReadBuf::uninit(dst);
-        match Pin::new(&mut self.io).poll_read(cx, &mut buf) {
+        match Pin::new(&mut self.io).poll_read(cx, buf.unfilled()) {
             Poll::Ready(Ok(_)) => {
                 let n = buf.filled().len();
                 trace!("received {} bytes", n);
@@ -359,7 +359,7 @@ pub(crate) trait MemRead {
 
 impl<T, B> MemRead for Buffered<T, B>
 where
-    T: AsyncRead + AsyncWrite + Unpin,
+    T: Read + Write + Unpin,
     B: Buf,
 {
     fn read_mem(&mut self, cx: &mut task::Context<'_>, len: usize) -> Poll<io::Result<Bytes>> {
@@ -662,6 +662,7 @@ enum WriteStrategy {
 
 #[cfg(test)]
 mod tests {
+    use crate::common::io::compat;
     use crate::common::time::Time;
 
     use super::*;
@@ -717,7 +718,7 @@ mod tests {
             .wait(Duration::from_secs(1))
             .build();
 
-        let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(mock);
+        let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(compat(mock));
 
         // We expect a `parse` to be not ready, and so can't await it directly.
         // Rather, this `poll_fn` will wrap the `Poll` result.
@@ -862,7 +863,7 @@ mod tests {
     #[cfg(debug_assertions)] // needs to trigger a debug_assert
     fn write_buf_requires_non_empty_bufs() {
         let mock = Mock::new().build();
-        let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(mock);
+        let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(compat(mock));
 
         buffered.buffer(Cursor::new(Vec::new()));
     }
@@ -897,7 +898,7 @@ mod tests {
 
         let mock = Mock::new().write(b"hello world, it's hyper!").build();
 
-        let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(mock);
+        let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(compat(mock));
         buffered.write_buf.set_strategy(WriteStrategy::Flatten);
 
         buffered.headers_buf().extend(b"hello ");
@@ -956,7 +957,7 @@ mod tests {
             .write(b"hyper!")
             .build();
 
-        let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(mock);
+        let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(compat(mock));
         buffered.write_buf.set_strategy(WriteStrategy::Queue);
 
         // we have 4 buffers, and vec IO disabled, but explicitly said

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -3,12 +3,12 @@ use std::marker::Unpin;
 
 use std::time::Duration;
 
+use crate::rt::{Read, Write};
 use bytes::Bytes;
 use h2::server::{Connection, Handshake, SendResponse};
 use h2::{Reason, RecvStream};
 use http::{Method, Request};
 use pin_project_lite::pin_project;
-use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::{debug, trace, warn};
 
 use super::{ping, PipeToSendStream, SendBuf};
@@ -89,7 +89,7 @@ where
 {
     Handshaking {
         ping_config: ping::Config,
-        hs: Handshake<T, SendBuf<B::Data>>,
+        hs: Handshake<crate::common::io::Compat<T>, SendBuf<B::Data>>,
     },
     Serving(Serving<T, B>),
     Closed,
@@ -100,13 +100,13 @@ where
     B: Body,
 {
     ping: Option<(ping::Recorder, ping::Ponger)>,
-    conn: Connection<T, SendBuf<B::Data>>,
+    conn: Connection<crate::common::io::Compat<T>, SendBuf<B::Data>>,
     closing: Option<crate::Error>,
 }
 
 impl<T, S, B, E> Server<T, S, B, E>
 where
-    T: AsyncRead + AsyncWrite + Unpin,
+    T: Read + Write + Unpin,
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: Body + 'static,
@@ -132,7 +132,7 @@ where
         if config.enable_connect_protocol {
             builder.enable_connect_protocol();
         }
-        let handshake = builder.handshake(io);
+        let handshake = builder.handshake(crate::common::io::compat(io));
 
         let bdp = if config.adaptive_window {
             Some(config.initial_stream_window_size)
@@ -182,7 +182,7 @@ where
 
 impl<T, S, B, E> Future for Server<T, S, B, E>
 where
-    T: AsyncRead + AsyncWrite + Unpin,
+    T: Read + Write + Unpin,
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
     B: Body + 'static,
@@ -228,7 +228,7 @@ where
 
 impl<T, B> Serving<T, B>
 where
-    T: AsyncRead + AsyncWrite + Unpin,
+    T: Read + Write + Unpin,
     B: Body + 'static,
 {
     fn poll_server<S, E>(

--- a/src/rt/bounds.rs
+++ b/src/rt/bounds.rs
@@ -13,8 +13,8 @@ pub use self::h2_client::ExecutorClient;
 #[cfg_attr(docsrs, doc(cfg(all(feature = "server", feature = "http2"))))]
 mod h2_client {
     use std::{error::Error, future::Future};
-    use tokio::io::{AsyncRead, AsyncWrite};
 
+    use crate::rt::{Read, Write};
     use crate::{proto::h2::client::H2ClientFuture, rt::Executor};
 
     /// An executor to spawn http2 futures for the client.
@@ -29,7 +29,7 @@ mod h2_client {
     where
         B: http_body::Body,
         B::Error: Into<Box<dyn Error + Send + Sync>>,
-        T: AsyncRead + AsyncWrite + Unpin,
+        T: Read + Write + Unpin,
     {
         #[doc(hidden)]
         fn execute_h2_future(&mut self, future: H2ClientFuture<B, T>);
@@ -41,7 +41,7 @@ mod h2_client {
         B: http_body::Body + 'static,
         B::Error: Into<Box<dyn Error + Send + Sync>>,
         H2ClientFuture<B, T>: Future<Output = ()>,
-        T: AsyncRead + AsyncWrite + Unpin,
+        T: Read + Write + Unpin,
     {
         fn execute_h2_future(&mut self, future: H2ClientFuture<B, T>) {
             self.execute(future)
@@ -54,7 +54,7 @@ mod h2_client {
         B: http_body::Body + 'static,
         B::Error: Into<Box<dyn Error + Send + Sync>>,
         H2ClientFuture<B, T>: Future<Output = ()>,
-        T: AsyncRead + AsyncWrite + Unpin,
+        T: Read + Write + Unpin,
     {
     }
 

--- a/src/rt/io.rs
+++ b/src/rt/io.rs
@@ -1,0 +1,334 @@
+use std::fmt;
+use std::mem::MaybeUninit;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+// New IO traits? What?! Why, are you bonkers?
+//
+// I mean, yes, probably. But, here's the goals:
+//
+// 1. Supports poll-based IO operations.
+// 2. Opt-in vectored IO.
+// 3. Can use an optional buffer pool.
+// 4. Able to add completion-based (uring) IO eventually.
+//
+// Frankly, the last point is the entire reason we're doing this. We want to
+// have forwards-compatibility with an eventually stable io-uring runtime. We
+// don't need that to work right away. But it must be possible to add in here
+// without breaking hyper 1.0.
+//
+// While in here, if there's small tweaks to poll_read or poll_write that would
+// allow even the "slow" path to be faster, such as if someone didn't remember
+// to forward along an `is_completion` call.
+
+/// Reads bytes from a source.
+///
+/// This trait is similar to `std::io::Read`, but supports asynchronous reads.
+pub trait Read {
+    /// Attempts to read bytes into the `buf`.
+    ///
+    /// On success, returns `Poll::Ready(Ok(()))` and places data in the
+    /// unfilled portion of `buf`. If no data was read (`buf.remaining()` is
+    /// unchanged), it implies that EOF has been reached.
+    ///
+    /// If no data is available for reading, the method returns `Poll::Pending`
+    /// and arranges for the current task (via `cx.waker()`) to receive a
+    /// notification when the object becomes readable or is closed.
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: ReadBufCursor<'_>,
+    ) -> Poll<Result<(), std::io::Error>>;
+}
+
+/// Write bytes asynchronously.
+///
+/// This trait is similar to `std::io::Write`, but for asynchronous writes.
+pub trait Write {
+    /// Attempt to write bytes from `buf` into the destination.
+    ///
+    /// On success, returns `Poll::Ready(Ok(num_bytes_written)))`. If
+    /// successful, it must be guaranteed that `n <= buf.len()`. A return value
+    /// of `0` means that the underlying object is no longer able to accept
+    /// bytes, or that the provided buffer is empty.
+    ///
+    /// If the object is not ready for writing, the method returns
+    /// `Poll::Pending` and arranges for the current task (via `cx.waker()`) to
+    /// receive a notification when the object becomes writable or is closed.
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>>;
+
+    /// Attempts to flush the object.
+    ///
+    /// On success, returns `Poll::Ready(Ok(()))`.
+    ///
+    /// If flushing cannot immediately complete, this method returns
+    /// `Poll::Pending` and arranges for the current task (via `cx.waker()`) to
+    /// receive a notification when the object can make progress.
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>>;
+
+    /// Attempts to shut down this writer.
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>>;
+
+    /// Returns whether this writer has an efficient `poll_write_vectored`
+    /// implementation.
+    ///
+    /// The default implementation returns `false`.
+    fn is_write_vectored(&self) -> bool {
+        false
+    }
+
+    /// Like `poll_write`, except that it writes from a slice of buffers.
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        let buf = bufs
+            .iter()
+            .find(|b| !b.is_empty())
+            .map_or(&[][..], |b| &**b);
+        self.poll_write(cx, buf)
+    }
+}
+
+/// A wrapper around a byte buffer that is incrementally filled and initialized.
+///
+/// This type is a sort of "double cursor". It tracks three regions in the
+/// buffer: a region at the beginning of the buffer that has been logically
+/// filled with data, a region that has been initialized at some point but not
+/// yet logically filled, and a region at the end that may be uninitialized.
+/// The filled region is guaranteed to be a subset of the initialized region.
+///
+/// In summary, the contents of the buffer can be visualized as:
+///
+/// ```not_rust
+/// [             capacity              ]
+/// [ filled |         unfilled         ]
+/// [    initialized    | uninitialized ]
+/// ```
+///
+/// It is undefined behavior to de-initialize any bytes from the uninitialized
+/// region, since it is merely unknown whether this region is uninitialized or
+/// not, and if part of it turns out to be initialized, it must stay initialized.
+pub struct ReadBuf<'a> {
+    raw: &'a mut [MaybeUninit<u8>],
+    filled: usize,
+    init: usize,
+}
+
+/// The cursor part of a [`ReadBuf`].
+///
+/// This is created by calling `ReadBuf::unfilled()`.
+#[derive(Debug)]
+pub struct ReadBufCursor<'a> {
+    buf: &'a mut ReadBuf<'a>,
+}
+
+impl<'data> ReadBuf<'data> {
+    #[inline]
+    #[cfg(test)]
+    pub(crate) fn new(raw: &'data mut [u8]) -> Self {
+        let len = raw.len();
+        Self {
+            // SAFETY: We never de-init the bytes ourselves.
+            raw: unsafe { &mut *(raw as *mut [u8] as *mut [MaybeUninit<u8>]) },
+            filled: 0,
+            init: len,
+        }
+    }
+
+    /// Create a new `ReadBuf` with a slice of uninitialized bytes.
+    #[inline]
+    pub fn uninit(raw: &'data mut [MaybeUninit<u8>]) -> Self {
+        Self {
+            raw,
+            filled: 0,
+            init: 0,
+        }
+    }
+
+    /// Get a slice of the buffer that has been filled in with bytes.
+    #[inline]
+    pub fn filled(&self) -> &[u8] {
+        // SAFETY: We only slice the filled part of the buffer, which is always valid
+        unsafe { &*(&self.raw[0..self.filled] as *const [MaybeUninit<u8>] as *const [u8]) }
+    }
+
+    /// Get a cursor to the unfilled portion of the buffer.
+    #[inline]
+    pub fn unfilled<'cursor>(&'cursor mut self) -> ReadBufCursor<'cursor> {
+        ReadBufCursor {
+            // SAFETY: self.buf is never re-assigned, so its safe to narrow
+            // the lifetime.
+            buf: unsafe {
+                std::mem::transmute::<&'cursor mut ReadBuf<'data>, &'cursor mut ReadBuf<'cursor>>(
+                    self,
+                )
+            },
+        }
+    }
+
+    #[inline]
+    pub(crate) unsafe fn set_init(&mut self, n: usize) {
+        self.init = self.init.max(n);
+    }
+
+    #[inline]
+    pub(crate) unsafe fn set_filled(&mut self, n: usize) {
+        self.filled = self.filled.max(n);
+    }
+
+    #[inline]
+    pub(crate) fn len(&self) -> usize {
+        self.filled
+    }
+
+    #[inline]
+    pub(crate) fn init_len(&self) -> usize {
+        self.init
+    }
+
+    #[inline]
+    fn remaining(&self) -> usize {
+        self.capacity() - self.filled
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.raw.len()
+    }
+}
+
+impl<'data> fmt::Debug for ReadBuf<'data> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReadBuf")
+            .field("filled", &self.filled)
+            .field("init", &self.init)
+            .field("capacity", &self.capacity())
+            .finish()
+    }
+}
+
+impl<'data> ReadBufCursor<'data> {
+    /// Access the unfilled part of the buffer.
+    ///
+    /// # Safety
+    ///
+    /// The caller must not uninitialize any bytes that may have been
+    /// initialized before.
+    #[inline]
+    pub unsafe fn as_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        &mut self.buf.raw[self.buf.filled..]
+    }
+
+    /// Advance the `filled` cursor by `n` bytes.
+    ///
+    /// # Safety
+    ///
+    /// The caller must take care that `n` more bytes have been initialized.
+    #[inline]
+    pub unsafe fn advance(&mut self, n: usize) {
+        self.buf.filled = self.buf.filled.checked_add(n).expect("overflow");
+        self.buf.init = self.buf.filled.max(self.buf.init);
+    }
+
+    #[inline]
+    pub(crate) fn remaining(&self) -> usize {
+        self.buf.remaining()
+    }
+
+    #[inline]
+    pub(crate) fn put_slice(&mut self, buf: &[u8]) {
+        assert!(
+            self.buf.remaining() >= buf.len(),
+            "buf.len() must fit in remaining()"
+        );
+
+        let amt = buf.len();
+        // Cannot overflow, asserted above
+        let end = self.buf.filled + amt;
+
+        // Safety: the length is asserted above
+        unsafe {
+            self.buf.raw[self.buf.filled..end]
+                .as_mut_ptr()
+                .cast::<u8>()
+                .copy_from_nonoverlapping(buf.as_ptr(), amt);
+        }
+
+        if self.buf.init < end {
+            self.buf.init = end;
+        }
+        self.buf.filled = end;
+    }
+}
+
+macro_rules! deref_async_read {
+    () => {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: ReadBufCursor<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut **self).poll_read(cx, buf)
+        }
+    };
+}
+
+impl<T: ?Sized + Read + Unpin> Read for Box<T> {
+    deref_async_read!();
+}
+
+impl<T: ?Sized + Read + Unpin> Read for &mut T {
+    deref_async_read!();
+}
+
+macro_rules! deref_async_write {
+    () => {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Pin::new(&mut **self).poll_write(cx, buf)
+        }
+
+        fn poll_write_vectored(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &[std::io::IoSlice<'_>],
+        ) -> Poll<std::io::Result<usize>> {
+            Pin::new(&mut **self).poll_write_vectored(cx, bufs)
+        }
+
+        fn is_write_vectored(&self) -> bool {
+            (**self).is_write_vectored()
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut **self).poll_flush(cx)
+        }
+
+        fn poll_shutdown(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut **self).poll_shutdown(cx)
+        }
+    };
+}
+
+impl<T: ?Sized + Write + Unpin> Write for Box<T> {
+    deref_async_write!();
+}
+
+impl<T: ?Sized + Write + Unpin> Write for &mut T {
+    deref_async_write!();
+}

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -1,14 +1,18 @@
 //! Runtime components
 //!
-//! By default, hyper includes the [tokio](https://tokio.rs) runtime.
+//! The traits and types within this module are used to allow plugging in
+//! runtime types. These include:
 //!
-//! If the `runtime` feature is disabled, the types in this module can be used
-//! to plug in other runtimes.
+//! - Executors
+//! - Timers
+//! - IO transports
 
 pub mod bounds;
+mod io;
 mod timer;
 
-pub use timer::{Sleep, Timer};
+pub use self::io::{Read, ReadBuf, ReadBufCursor, Write};
+pub use self::timer::{Sleep, Timer};
 
 /// An executor of futures.
 ///

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::rt::{Read, Write};
 use bytes::Bytes;
-use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::body::{Body, Incoming as IncomingBody};
 use crate::common::{task, Future, Pin, Poll, Unpin};
@@ -85,7 +85,7 @@ impl<I, B, S> Connection<I, S>
 where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: AsyncRead + AsyncWrite + Unpin,
+    I: Read + Write + Unpin,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
 {
@@ -172,7 +172,7 @@ impl<I, B, S> Future for Connection<I, S>
 where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: AsyncRead + AsyncWrite + Unpin + 'static,
+    I: Read + Write + Unpin + 'static,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
 {
@@ -333,10 +333,10 @@ impl Builder {
     /// # use hyper::{body::Incoming, Request, Response};
     /// # use hyper::service::Service;
     /// # use hyper::server::conn::http1::Builder;
-    /// # use tokio::io::{AsyncRead, AsyncWrite};
+    /// # use hyper::rt::{Read, Write};
     /// # async fn run<I, S>(some_io: I, some_service: S)
     /// # where
-    /// #     I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    /// #     I: Read + Write + Unpin + Send + 'static,
     /// #     S: Service<hyper::Request<Incoming>, Response=hyper::Response<Incoming>> + Send + 'static,
     /// #     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     /// #     S::Future: Send,
@@ -356,7 +356,7 @@ impl Builder {
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
         S::ResBody: 'static,
         <S::ResBody as Body>::Error: Into<Box<dyn StdError + Send + Sync>>,
-        I: AsyncRead + AsyncWrite + Unpin,
+        I: Read + Write + Unpin,
     {
         let mut conn = proto::Conn::new(io);
         conn.set_timer(self.timer.clone());
@@ -413,7 +413,7 @@ mod upgrades {
     where
         S: HttpService<IncomingBody, ResBody = B>,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
-        I: AsyncRead + AsyncWrite + Unpin,
+        I: Read + Write + Unpin,
         B: Body + 'static,
         B::Error: Into<Box<dyn StdError + Send + Sync>>,
     {
@@ -430,7 +430,7 @@ mod upgrades {
     where
         S: HttpService<IncomingBody, ResBody = B>,
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
-        I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+        I: Read + Write + Unpin + Send + 'static,
         B: Body + 'static,
         B::Error: Into<Box<dyn StdError + Send + Sync>>,
     {

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -5,8 +5,8 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::rt::{Read, Write};
 use pin_project_lite::pin_project;
-use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::body::{Body, Incoming as IncomingBody};
 use crate::common::{task, Future, Pin, Poll, Unpin};
@@ -51,7 +51,7 @@ impl<I, B, S, E> Connection<I, S, E>
 where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: AsyncRead + AsyncWrite + Unpin,
+    I: Read + Write + Unpin,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
     E: Http2ConnExec<S::Future, B>,
@@ -75,7 +75,7 @@ impl<I, B, S, E> Future for Connection<I, S, E>
 where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: AsyncRead + AsyncWrite + Unpin + 'static,
+    I: Read + Write + Unpin + 'static,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
     E: Http2ConnExec<S::Future, B>,
@@ -255,7 +255,7 @@ impl<E> Builder<E> {
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
         Bd: Body + 'static,
         Bd::Error: Into<Box<dyn StdError + Send + Sync>>,
-        I: AsyncRead + AsyncWrite + Unpin,
+        I: Read + Write + Unpin,
         E: Http2ConnExec<S::Future, Bd>,
     {
         let proto = proto::h2::Server::new(

--- a/src/server/conn/mod.rs
+++ b/src/server/conn/mod.rs
@@ -7,43 +7,6 @@
 //!
 //! This module is split by HTTP version. Both work similarly, but do have
 //! specific options on each builder.
-//!
-//! ## Example
-//!
-//! A simple example that prepares an HTTP/1 connection over a Tokio TCP stream.
-//!
-//! ```no_run
-//! # #[cfg(feature = "http1")]
-//! # mod rt {
-//! use http::{Request, Response, StatusCode};
-//! use http_body_util::Full;
-//! use hyper::{server::conn::http1, service::service_fn, body, body::Bytes};
-//! use std::{net::SocketAddr, convert::Infallible};
-//! use tokio::net::TcpListener;
-//!
-//! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-//!     let addr: SocketAddr = ([127, 0, 0, 1], 8080).into();
-//!
-//!     let mut tcp_listener = TcpListener::bind(addr).await?;
-//!     loop {
-//!         let (tcp_stream, _) = tcp_listener.accept().await?;
-//!         tokio::task::spawn(async move {
-//!             if let Err(http_err) = http1::Builder::new()
-//!                     .keep_alive(true)
-//!                     .serve_connection(tcp_stream, service_fn(hello))
-//!                     .await {
-//!                 eprintln!("Error while serving HTTP connection: {}", http_err);
-//!             }
-//!         });
-//!     }
-//! }
-//!
-//! async fn hello(_req: Request<body::Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
-//!    Ok(Response::new(Full::new(Bytes::from("Hello World!"))))
-//! }
-//! # }
-//! ```
 
 #[cfg(feature = "http1")]
 pub mod http1;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -22,6 +22,7 @@ use hyper::{Method, Request, StatusCode, Uri, Version};
 use bytes::Bytes;
 use futures_channel::oneshot;
 use futures_util::future::{self, FutureExt, TryFuture, TryFutureExt};
+use support::TokioIo;
 use tokio::net::TcpStream;
 mod support;
 
@@ -36,8 +37,8 @@ where
     b.collect().await.map(|c| c.to_bytes())
 }
 
-fn tcp_connect(addr: &SocketAddr) -> impl Future<Output = std::io::Result<TcpStream>> {
-    TcpStream::connect(*addr)
+async fn tcp_connect(addr: &SocketAddr) -> std::io::Result<TokioIo<TcpStream>> {
+    TcpStream::connect(*addr).await.map(TokioIo::new)
 }
 
 struct HttpInfo {
@@ -312,7 +313,7 @@ macro_rules! test {
                 req.headers_mut().append("Host", HeaderValue::from_str(&host).unwrap());
             }
 
-            let (mut sender, conn) = builder.handshake(stream).await?;
+            let (mut sender, conn) = builder.handshake(TokioIo::new(stream)).await?;
 
             tokio::task::spawn(async move {
                 if let Err(err) = conn.await {
@@ -1339,7 +1340,7 @@ mod conn {
     use futures_util::future::{self, poll_fn, FutureExt, TryFutureExt};
     use http_body_util::{BodyExt, Empty, StreamBody};
     use hyper::rt::Timer;
-    use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _, ReadBuf};
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
     use tokio::net::{TcpListener as TkTcpListener, TcpStream};
 
     use hyper::body::{Body, Frame};
@@ -1349,7 +1350,7 @@ mod conn {
 
     use super::{concat, s, support, tcp_connect, FutureHyperExt};
 
-    use support::{TokioExecutor, TokioTimer};
+    use support::{TokioExecutor, TokioIo, TokioTimer};
 
     fn setup_logger() {
         let _ = pretty_env_logger::try_init();
@@ -1773,7 +1774,7 @@ mod conn {
         }
 
         let parts = conn.into_parts();
-        let mut io = parts.io;
+        let io = parts.io;
         let buf = parts.read_buf;
 
         assert_eq!(buf, b"foobar=ready"[..]);
@@ -1785,6 +1786,7 @@ mod conn {
         }))
         .unwrap_err();
 
+        let mut io = io.tcp.inner();
         let mut vec = vec![];
         rt.block_on(io.write_all(b"foo=bar")).unwrap();
         rt.block_on(io.read_to_end(&mut vec)).unwrap();
@@ -1861,7 +1863,7 @@ mod conn {
         }
 
         let parts = conn.into_parts();
-        let mut io = parts.io;
+        let io = parts.io;
         let buf = parts.read_buf;
 
         assert_eq!(buf, b"foobar=ready"[..]);
@@ -1874,6 +1876,7 @@ mod conn {
         }))
         .unwrap_err();
 
+        let mut io = io.tcp.inner();
         let mut vec = vec![];
         rt.block_on(io.write_all(b"foo=bar")).unwrap();
         rt.block_on(io.read_to_end(&mut vec)).unwrap();
@@ -1895,6 +1898,7 @@ mod conn {
                 tokio::select! {
                     res = listener.accept() => {
                         let (stream, _) = res.unwrap();
+                        let stream = TokioIo::new(stream);
 
                         let service = service_fn(|_:Request<hyper::body::Incoming>| future::ok::<_, hyper::Error>(Response::new(Empty::<Bytes>::new())));
 
@@ -2077,7 +2081,7 @@ mod conn {
 
         // Spawn an HTTP2 server that reads the whole body and responds
         tokio::spawn(async move {
-            let sock = listener.accept().await.unwrap().0;
+            let sock = TokioIo::new(listener.accept().await.unwrap().0);
             hyper::server::conn::http2::Builder::new(TokioExecutor)
                 .timer(TokioTimer)
                 .serve_connection(
@@ -2166,7 +2170,7 @@ mod conn {
         let res = client.send_request(req).await.expect("send_request");
         assert_eq!(res.status(), StatusCode::OK);
 
-        let mut upgraded = hyper::upgrade::on(res).await.unwrap();
+        let mut upgraded = TokioIo::new(hyper::upgrade::on(res).await.unwrap());
 
         let mut vec = vec![];
         upgraded.read_to_end(&mut vec).await.unwrap();
@@ -2264,7 +2268,7 @@ mod conn {
         );
     }
 
-    async fn drain_til_eof<T: AsyncRead + Unpin>(mut sock: T) -> io::Result<()> {
+    async fn drain_til_eof<T: tokio::io::AsyncRead + Unpin>(mut sock: T) -> io::Result<()> {
         let mut buf = [0u8; 1024];
         loop {
             let n = sock.read(&mut buf).await?;
@@ -2276,11 +2280,11 @@ mod conn {
     }
 
     struct DebugStream {
-        tcp: TcpStream,
+        tcp: TokioIo<TcpStream>,
         shutdown_called: bool,
     }
 
-    impl AsyncWrite for DebugStream {
+    impl hyper::rt::Write for DebugStream {
         fn poll_shutdown(
             mut self: Pin<&mut Self>,
             cx: &mut Context<'_>,
@@ -2305,11 +2309,11 @@ mod conn {
         }
     }
 
-    impl AsyncRead for DebugStream {
+    impl hyper::rt::Read for DebugStream {
         fn poll_read(
             mut self: Pin<&mut Self>,
             cx: &mut Context<'_>,
-            buf: &mut ReadBuf<'_>,
+            buf: hyper::rt::ReadBufCursor<'_>,
         ) -> Poll<io::Result<()>> {
             Pin::new(&mut self.tcp).poll_read(cx, buf)
         }


### PR DESCRIPTION
This replaces the usage of `tokio::io::{AsyncRead, AsyncWrite}` in hyper's public API with new traits in the `hyper::rt` module.

Closes #3110 

## Before merging

- [x] Determine naming (`AsyncRead` vs `Read`; `ReadBuf` and `ReadBufCursor`)
- [x] Determine minimal public methods for `ReadBuf` and `Cursor`
- [x] Document the types and methods
- [ ] Prove that it is forwards-compatible with completion-based IO