### PR TITLE
fix(docs): update guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A **fast** and **correct** HTTP implementation for Rust.
 - Extensive production use
 - Client and Server APIs
 
-**Get started** by looking over the [guides](https://hyper.rs/guides).
+**Get started** by looking over the [guides](https://hyper.rs/guides/1/).
 
 ## "Low-level"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! - Extensive production use
 //! - [Client](client/index.html) and [Server](server/index.html) APIs
 //!
-//! If just starting out, **check out the [Guides](https://hyper.rs/guides)
+//! If just starting out, **check out the [Guides](https://hyper.rs/guides/1/)
 //! first.**
 //!
 //! ## "Low-level"


### PR DESCRIPTION
Updated all remaining incorrect guide links that I was able to find with ctrl+shift+f 👀.

At some point it will be appropriate to update the site to forward `/guide` to 1.0 instead of 0.14.

https://github.com/hyperium/hyperium.github.io/blob/c94a621c2b95a4a824194e20da031d8cf7f1ce05/_legacy/index.md?plain=1#L1-L7

... perhaps when 1.0 lands 🤔 

# Criticism Welcome 😄

Always