### PR TITLE
Run cargo-audit in CI to check for known vulnerabilities in dependencies.

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,17 @@
+name: cargo-audit
+on:
+  push:
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  schedule:
+    - cron: '0 16 * * Mon'
+
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ futures-util = { version = "0.3", default-features = false, features = ["alloc"]
 http-body-util = "=0.1.0-rc.2"
 matches = "0.1"
 num_cpus = "1.0"
-pretty_env_logger = "0.4"
+pretty_env_logger = "0.5"
 spmc = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
`cargo audit` checks for dependencies with known issues. This PR adds a github workflow that runs `cargo audit` on a weekly basis on `HEAD` and whenever a dependency changes.

Bumped the `pretty_env_logger` dependency to get rid of the `atty` crate with a known [informational advisory](https://rustsec.org/advisories/RUSTSEC-2021-0145).

