### PR TITLE
Cargo fmt workaround

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,7 +104,12 @@ jobs:
           toolchain: ${{ steps.msrv.outputs.version }}
 
       - name: Check
-        run: cargo check --features full
+        # Workaround for rust-lang/cargo#7732
+        run: |
+          if ! rustfmt --check --edition 2018 $(git ls-files '*.rs'); then
+            printf "Please run \`rustfmt --edition 2018 \$(git ls-files '*.rs')\` to fix rustfmt errors.\nSee CONTRIBUTING.md for more details.\n" >&2
+            exit 1
+          fi
 
   miri:
     name: Test with Miri

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,13 @@ You want to contribute? You're awesome! Don't know where to start? Check the [li
 
 - [Submitting a Pull Request](./docs/PULL_REQUESTS.md#submitting-a-pull-request)
 - [Commit Guidelines](./docs/COMMITS.md)
+
+## Cargo fmt
+`cargo fmt --all` does not work in hyper. Please use the following commands:
+```txt
+# Mac or Linux
+rustfmt --check --edition 2018 $(git ls-files '*.rs')
+
+# Powershell
+Get-ChildItem . -Filter "*.rs" -Recurse | foreach { rustfmt --check --edition 2018 $_.FullName }
+```

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -10,9 +10,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use super::super::dispatch;
 use crate::body::{Body, Incoming as IncomingBody};
-use crate::common::{
-    task, Future, Pin, Poll,
-};
+use crate::common::{task, Future, Pin, Poll};
 use crate::proto;
 use crate::upgrade::Upgraded;
 
@@ -319,10 +317,7 @@ impl Builder {
     /// Default is false.
     ///
     /// [RFC 7230 Section 3.2.4.]: https://tools.ietf.org/html/rfc7230#section-3.2.4
-    pub fn allow_spaces_after_header_name_in_responses(
-        &mut self,
-        enabled: bool,
-    ) -> &mut Builder {
+    pub fn allow_spaces_after_header_name_in_responses(&mut self, enabled: bool) -> &mut Builder {
         self.h1_parser_config
             .allow_spaces_after_header_name_in_responses(enabled);
         self
@@ -360,10 +355,7 @@ impl Builder {
     /// Default is false.
     ///
     /// [RFC 7230 Section 3.2.4.]: https://tools.ietf.org/html/rfc7230#section-3.2.4
-    pub fn allow_obsolete_multiline_headers_in_responses(
-        &mut self,
-        enabled: bool,
-    ) -> &mut Builder {
+    pub fn allow_obsolete_multiline_headers_in_responses(&mut self, enabled: bool) -> &mut Builder {
         self.h1_parser_config
             .allow_obsolete_multiline_headers_in_responses(enabled);
         self

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -26,7 +26,9 @@ pub struct SendRequest<B> {
 
 impl<B> Clone for SendRequest<B> {
     fn clone(&self) -> SendRequest<B> {
-        SendRequest { dispatch: self.dispatch.clone() }
+        SendRequest {
+            dispatch: self.dispatch.clone(),
+        }
     }
 }
 
@@ -57,10 +59,7 @@ pub struct Builder {
 ///
 /// This is a shortcut for `Builder::new().handshake(io)`.
 /// See [`client::conn`](crate::client::conn) for more.
-pub async fn handshake<E, T, B>(
-    exec: E,
-    io: T,
-) -> crate::Result<(SendRequest<B>, Connection<T, B>)>
+pub async fn handshake<E, T, B>(exec: E, io: T) -> crate::Result<(SendRequest<B>, Connection<T, B>)>
 where
     E: Executor<BoxSendFuture> + Send + Sync + 'static,
     T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
@@ -243,7 +242,7 @@ where
 impl Builder {
     /// Creates a new connection builder.
     #[inline]
-    pub fn new<E>(exec: E) -> Builder 
+    pub fn new<E>(exec: E) -> Builder
     where
         E: Executor<BoxSendFuture> + Send + Sync + 'static,
     {
@@ -284,10 +283,7 @@ impl Builder {
     /// Passing `None` will do nothing.
     ///
     /// If not set, hyper will use a default.
-    pub fn initial_connection_window_size(
-        &mut self,
-        sz: impl Into<Option<u32>>,
-    ) -> &mut Self {
+    pub fn initial_connection_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         if let Some(sz) = sz.into() {
             self.h2_builder.adaptive_window = false;
             self.h2_builder.initial_conn_window_size = sz;
@@ -329,10 +325,7 @@ impl Builder {
     /// Pass `None` to disable HTTP2 keep-alive.
     ///
     /// Default is currently disabled.
-    pub fn keep_alive_interval(
-        &mut self,
-        interval: impl Into<Option<Duration>>,
-    ) -> &mut Self {
+    pub fn keep_alive_interval(&mut self, interval: impl Into<Option<Duration>>) -> &mut Self {
         self.h2_builder.keep_alive_interval = interval.into();
         self
     }

--- a/src/client/conn/mod.rs
+++ b/src/client/conn/mod.rs
@@ -56,4 +56,3 @@
 pub mod http1;
 #[cfg(feature = "http2")]
 pub mod http2;
-

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -53,15 +53,15 @@ pub(super) fn content_length_parse_all_values(values: ValueIter<'_, HeaderValue>
                         return None;
                     }
                 } else {
-                    return None
+                    return None;
                 }
             }
         } else {
-            return None
+            return None;
         }
     }
 
-    return content_length
+    return content_length;
 }
 
 fn from_digits(bytes: &[u8]) -> Option<u64> {
@@ -80,7 +80,7 @@ fn from_digits(bytes: &[u8]) -> Option<u64> {
             b'0'..=b'9' => {
                 result = result.checked_mul(RADIX)?;
                 result = result.checked_add((b - b'0') as u64)?;
-            },
+            }
             _ => {
                 // not a DIGIT, get outta here!
                 return None;

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -28,7 +28,8 @@ pub(crate) trait Dispatch {
         self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
     ) -> Poll<Option<Result<(Self::PollItem, Self::PollBody), Self::PollError>>>;
-    fn recv_msg(&mut self, msg: crate::Result<(Self::RecvItem, IncomingBody)>) -> crate::Result<()>;
+    fn recv_msg(&mut self, msg: crate::Result<(Self::RecvItem, IncomingBody)>)
+        -> crate::Result<()>;
     fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), ()>>;
     fn should_poll(&self) -> bool;
 }
@@ -249,7 +250,8 @@ where
                 let body = match body_len {
                     DecodedLength::ZERO => IncomingBody::empty(),
                     other => {
-                        let (tx, rx) = IncomingBody::new_channel(other, wants.contains(Wants::EXPECT));
+                        let (tx, rx) =
+                            IncomingBody::new_channel(other, wants.contains(Wants::EXPECT));
                         self.body_tx = Some(tx);
                         rx
                     }

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -13,8 +13,8 @@ use tracing::{debug, trace, warn};
 
 use super::{ping, H2Upgraded, PipeToSendStream, SendBuf};
 use crate::body::{Body, Incoming as IncomingBody};
-use crate::common::time::Time;
 use crate::client::dispatch::Callback;
+use crate::common::time::Time;
 use crate::common::{exec::Exec, task, Future, Never, Pin, Poll};
 use crate::ext::Protocol;
 use crate::headers;

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -129,9 +129,7 @@ where
                     match ready!(me.body_tx.poll_capacity(cx)) {
                         Some(Ok(0)) => {}
                         Some(Ok(_)) => break,
-                        Some(Err(e)) => {
-                            return Poll::Ready(Err(crate::Error::new_body_write(e)))
-                        }
+                        Some(Err(e)) => return Poll::Ready(Err(crate::Error::new_body_write(e))),
                         None => {
                             // None means the stream is no longer in a
                             // streaming state, we either finished it
@@ -148,9 +146,7 @@ where
                 .map_err(crate::Error::new_body_write)?
             {
                 debug!("stream received RST_STREAM: {:?}", reason);
-                return Poll::Ready(Err(crate::Error::new_body_write(::h2::Error::from(
-                    reason,
-                ))));
+                return Poll::Ready(Err(crate::Error::new_body_write(::h2::Error::from(reason))));
             }
 
             match ready!(me.stream.as_mut().poll_frame(cx)) {
@@ -365,14 +361,12 @@ where
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), io::Error>> {
         if self.send_stream.write(&[], true).is_ok() {
-            return Poll::Ready(Ok(()))
+            return Poll::Ready(Ok(()));
         }
 
         Poll::Ready(Err(h2_to_io_error(
             match ready!(self.send_stream.poll_reset(cx)) {
-                Ok(Reason::NO_ERROR) => {
-                    return Poll::Ready(Ok(()))
-                }
+                Ok(Reason::NO_ERROR) => return Poll::Ready(Ok(())),
                 Ok(Reason::CANCEL) | Ok(Reason::STREAM_CLOSED) => {
                     return Poll::Ready(Err(io::ErrorKind::BrokenPipe.into()))
                 }

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -13,7 +13,6 @@ use tracing::{debug, trace, warn};
 
 use super::{ping, PipeToSendStream, SendBuf};
 use crate::body::{Body, Incoming as IncomingBody};
-use crate::rt::bounds::Http2ConnExec;
 use crate::common::time::Time;
 use crate::common::{date, task, Future, Pin, Poll};
 use crate::ext::Protocol;
@@ -21,10 +20,11 @@ use crate::headers;
 use crate::proto::h2::ping::Recorder;
 use crate::proto::h2::{H2Upgraded, UpgradedSendStream};
 use crate::proto::Dispatched;
+use crate::rt::bounds::Http2ConnExec;
 use crate::service::HttpService;
 
 use crate::upgrade::{OnUpgrade, Pending, Upgraded};
-use crate::{Response};
+use crate::Response;
 
 // Our defaults are chosen for the "majority" case, which usually are not
 // resource constrained, and so the spec default of 64kb can be too limiting

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -10,13 +10,16 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::body::{Body, Incoming as IncomingBody};
 use crate::common::{task, Future, Pin, Poll, Unpin};
-use crate::{common::time::Time, rt::Timer};
 use crate::proto;
 use crate::service::HttpService;
+use crate::{common::time::Time, rt::Timer};
 
-type Http1Dispatcher<T, B, S> =
-    proto::h1::Dispatcher<proto::h1::dispatch::Server<S, IncomingBody>, B, T, proto::ServerTransaction>;
-
+type Http1Dispatcher<T, B, S> = proto::h1::Dispatcher<
+    proto::h1::dispatch::Server<S, IncomingBody>,
+    B,
+    T,
+    proto::ServerTransaction,
+>;
 
 pin_project_lite::pin_project! {
     /// A future binding an http1 connection with a Service.
@@ -30,7 +33,6 @@ pin_project_lite::pin_project! {
         conn: Http1Dispatcher<T, S::ResBody, S>,
     }
 }
-
 
 /// A configuration builder for HTTP/1 server connections.
 #[derive(Clone, Debug)]
@@ -151,9 +153,7 @@ where
         let mut zelf = Some(self);
         futures_util::future::poll_fn(move |cx| {
             ready!(zelf.as_mut().unwrap().conn.poll_without_shutdown(cx))?;
-            Poll::Ready(
-                Ok(zelf.take().unwrap().into_parts())
-            )
+            Poll::Ready(Ok(zelf.take().unwrap().into_parts()))
         })
     }
 
@@ -167,7 +167,6 @@ where
         upgrades::UpgradeableConnection { inner: Some(self) }
     }
 }
-
 
 impl<I, B, S> Future for Connection<I, S>
 where
@@ -194,7 +193,7 @@ where
                 };
                 return Poll::Ready(Ok(()));
             }
-            Err(e) =>  Poll::Ready(Err(e)),
+            Err(e) => Poll::Ready(Err(e)),
         }
     }
 }
@@ -389,9 +388,7 @@ impl Builder {
         }
         let sd = proto::h1::dispatch::Server::new(service);
         let proto = proto::h1::Dispatcher::new(sd, conn);
-        Connection {
-            conn: proto,
-        }
+        Connection { conn: proto }
     }
 }
 

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -132,10 +132,7 @@ impl<E> Builder<E> {
     /// Passing `None` will do nothing.
     ///
     /// If not set, hyper will use a default.
-    pub fn initial_connection_window_size(
-        &mut self,
-        sz: impl Into<Option<u32>>,
-    ) -> &mut Self {
+    pub fn initial_connection_window_size(&mut self, sz: impl Into<Option<u32>>) -> &mut Self {
         if let Some(sz) = sz.into() {
             self.h2_builder.adaptive_window = false;
             self.h2_builder.initial_conn_window_size = sz;
@@ -191,10 +188,7 @@ impl<E> Builder<E> {
     ///
     /// # Cargo Feature
     ///
-    pub fn keep_alive_interval(
-        &mut self,
-        interval: impl Into<Option<Duration>>,
-    ) -> &mut Self {
+    pub fn keep_alive_interval(&mut self, interval: impl Into<Option<Duration>>) -> &mut Self {
         self.h2_builder.keep_alive_interval = interval.into();
         self
     }

--- a/src/server/conn/mod.rs
+++ b/src/server/conn/mod.rs
@@ -49,4 +49,3 @@
 pub mod http1;
 #[cfg(feature = "http2")]
 pub mod http2;
-

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,4 +7,3 @@
 //! concerns itself with. After you have a connection, you can handle HTTP over
 //! it with the types in the [`conn`](conn) module.
 pub mod conn;
-


### PR DESCRIPTION
`cargo fmt` does not work for all files. This adds the same workaround as in [tokio](https://github.com/tokio-rs/tokio/blob/master/.github/workflows/ci.yml#L498)