### PR TITLE
fix(0.14.x): early server response shouldn't propagate NO_ERROR

### DIFF
--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -50,7 +50,7 @@ pub(crate) enum BodyLength {
     Unknown,
 }
 
-/// Status of when a Disaptcher future completes.
+/// Status of when a Dispatcher future completes.
 pub(crate) enum Dispatched {
     /// Dispatcher completely shutdown connection.
     Shutdown,


### PR DESCRIPTION
Closes #2872 for `0.14.x` version: **this is backport, see** #3275

Added test is failing against the current version (before the fix).

