### PR TITLE
fix(client): early server response shouldn't propagate NO_ERROR

### DIFF
--- a/src/body/incoming.rs
+++ b/src/body/incoming.rs
@@ -201,7 +201,16 @@ impl Body for Incoming {
                             ping.record_data(bytes.len());
                             return Poll::Ready(Some(Ok(Frame::data(bytes))));
                         }
-                        Some(Err(e)) => return Poll::Ready(Some(Err(crate::Error::new_body(e)))),
+                        Some(Err(e)) => {
+                            return match e.reason() {
+                                // These reasons should cause stop of body reading, but don't fail it.
+                                // The same logic as for `Read for H2Upgraded` is applied here.
+                                Some(h2::Reason::NO_ERROR) | Some(h2::Reason::CANCEL) => {
+                                    Poll::Ready(None)
+                                }
+                                _ => Poll::Ready(Some(Err(crate::Error::new_body(e)))),
+                            }
+                        }
                         None => {
                             *data_done = true;
                             // fall through to trailers

--- a/src/body/incoming.rs
+++ b/src/body/incoming.rs
@@ -203,13 +203,13 @@ impl Body for Incoming {
                         }
                         Some(Err(e)) => {
                             return match e.reason() {
-                                // These reasons should cause stop of body reading, but don't fail it.
+                                // These reasons should cause the body reading to stop, but not fail it.
                                 // The same logic as for `Read for H2Upgraded` is applied here.
                                 Some(h2::Reason::NO_ERROR) | Some(h2::Reason::CANCEL) => {
                                     Poll::Ready(None)
                                 }
                                 _ => Poll::Ready(Some(Err(crate::Error::new_body(e)))),
-                            }
+                            };
                         }
                         None => {
                             *data_done = true;

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -50,7 +50,7 @@ pub(crate) enum BodyLength {
     Unknown,
 }
 
-/// Status of when a Disaptcher future completes.
+/// Status of when a Dispatcher future completes.
 pub(crate) enum Dispatched {
     /// Dispatcher completely shutdown connection.
     Shutdown,


### PR DESCRIPTION
Closes #2872

Added test is failing against the current version (before this fix)

Backport for `0.14.x`: https://github.com/hyperium/hyper/pull/3274
