### PR TITLE
fix(server): Respect Expect header only when http proto > 1.0

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -257,7 +257,7 @@ where
             if !T::should_read_first() {
                 self.try_keep_alive(cx);
             }
-        } else if msg.expect_continue {
+        } else if msg.expect_continue && msg.head.version.gt(&Version::HTTP_10) {
             self.state.reading = Reading::Continue(Decoder::new(msg.decode));
             wants = wants.add(Wants::EXPECT);
         } else {


### PR DESCRIPTION
1. fix server Expect handling(from the perspective of server correctness)
    Refer to: https://www.rfc-editor.org/rfc/rfc9110.html#name-expect
    > A server that receives a 100-continue expectation in an HTTP/1.0 request MUST ignore that expectation
3. adds HTTP/1.0 Expect 100-continue test