### PR TITLE
ReasonPhrase Polish

### DIFF
--- a/src/ext/h1_reason_phrase.rs
+++ b/src/ext/h1_reason_phrase.rs
@@ -42,7 +42,7 @@ impl ReasonPhrase {
     }
 
     /// Converts a static byte slice to a reason phrase.
-    pub fn from_static(reason: &'static [u8]) -> Self {
+    pub const fn from_static(reason: &'static [u8]) -> Self {
         // TODO: this can be made const once MSRV is >= 1.57.0
         if find_invalid_byte(reason).is_some() {
             panic!("invalid byte in static reason phrase");

--- a/src/ext/h1_reason_phrase.rs
+++ b/src/ext/h1_reason_phrase.rs
@@ -50,11 +50,12 @@ impl ReasonPhrase {
         Self(Bytes::from_static(reason))
     }
 
+    // Not public on purpose.
     /// Converts a `Bytes` directly into a `ReasonPhrase` without validating.
     ///
     /// Use with care; invalid bytes in a reason phrase can cause serious security problems if
     /// emitted in a response.
-    pub unsafe fn from_bytes_unchecked(reason: Bytes) -> Self {
+    pub(crate) fn from_bytes_unchecked(reason: Bytes) -> Self {
         Self(reason)
     }
 }

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1059,7 +1059,7 @@ impl Http1Transaction for Client {
             if let Some(reason) = reason {
                 // Safety: httparse ensures that only valid reason phrase bytes are present in this
                 // field.
-                let reason = unsafe { crate::ext::ReasonPhrase::from_bytes_unchecked(reason) };
+                let reason = crate::ext::ReasonPhrase::from_bytes_unchecked(reason);
                 extensions.insert(reason);
             }
 


### PR DESCRIPTION
This removes the `from_bytes_unchecked()` method, since it's utility seems dubious (we can always add back if it's badly needed). It also makes `from_static` a const fn.