### PR TITLE
chore(dependencies): Remove unused num_cpus and tokio-util dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ libc = { version = "0.2", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http-body-util = "=0.1.0-rc.3"
 matches = "0.1"
-num_cpus = "1.0"
 pretty_env_logger = "0.4"
 spmc = "0.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -61,7 +60,6 @@ tokio = { version = "1", features = [
     "test-util",
 ] }
 tokio-test = "0.4"
-tokio-util = { version = "0.7", features = ["codec"] }
 url = "2.2"
 
 [features]


### PR DESCRIPTION
These dependencies seem not to be used.