### PR TITLE
feat(error): change `Display for Error` to only print top error

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2318,10 +2318,6 @@ mod conn {
         let error = client.send_request(req).await.unwrap_err();
 
         assert!(error.is_user());
-        assert_eq!(
-            error.to_string(),
-            "dispatch task is gone: user code panicked"
-        );
     }
 
     async fn drain_til_eof<T: tokio::io::AsyncRead + Unpin>(mut sock: T) -> io::Result<()> {

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -523,6 +523,7 @@ fn post_with_chunked_body() {
 
 #[test]
 fn post_with_chunked_overflow() {
+    use std::error::Error as _;
     let server = serve();
     let mut req = connect(server.addr());
     req.write_all(
@@ -542,7 +543,7 @@ fn post_with_chunked_overflow() {
     .unwrap();
     req.read(&mut [0; 256]).unwrap();
 
-    let err = server.body_err().to_string();
+    let err = server.body_err().source().unwrap().to_string();
     assert!(
         err.contains("overflow"),
         "error should be overflow: {:?}",


### PR DESCRIPTION
hyper's `Error` used to print the error source automatically, preferring to provide a better default for users who do not know about `Report`. But, to fit better with the wider ecosystem, this changes the format to only print the hyper `Error` itself, and not its source.

Closes #2844

BREAKING CHANGE: The format no longer prints the error chain. Be sure to
  check if you are logging errors directly.

  The `Error::message()` method is removed, it is no longer needed.

  The `Error::into_cause()` method is removed.

