### PR TITLE
chore(dependencies): Allow socket2 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ want = "0.3"
 # Optional
 
 libc = { version = "0.2", optional = true }
-socket2 = { version = "0.4.7", optional = true, features = ["all"] }
+socket2 = { version = ">=0.4.7, <0.6.0", optional = true, features = ["all"] }
 
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Allows users to use `socket2` 0.5 version. When users want to use `tokio` which version is larger than 1.30, as it starts to use `socket2` 0.5, users depend on multiple versions of `socket2`, 0.4 and 0.5. According to the [changelog](https://github.com/rust-lang/socket2/blob/v0.5/CHANGELOG.md#050), as `hyper` 0.14 seems not to be affected by the `socket2`'s breaking changes, `hyper` might be able to allow users to use `socket2` 0.5.