### PR TITLE
chore: Replace matches crate with std assert and matches macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ libc = { version = "0.2", optional = true }
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http-body-util = "=0.1.0-rc.3"
-matches = "0.1"
 pretty_env_logger = "0.4"
 spmc = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1,9 +1,6 @@
 #![deny(warnings)]
 #![warn(rust_2018_idioms)]
 
-#[macro_use]
-extern crate matches;
-
 use std::convert::Infallible;
 use std::fmt;
 use std::future::Future;
@@ -1781,7 +1778,7 @@ mod conn {
         assert!(!io.shutdown_called, "upgrade shouldn't shutdown AsyncWrite");
         rt.block_on(poll_fn(|ctx| {
             let ready = client.poll_ready(ctx);
-            assert_matches!(ready, Poll::Ready(Err(_)));
+            assert!(matches!(ready, Poll::Ready(Err(_))));
             ready
         }))
         .unwrap_err();
@@ -1871,7 +1868,7 @@ mod conn {
 
         rt.block_on(poll_fn(|ctx| {
             let ready = client.poll_ready(ctx);
-            assert_matches!(ready, Poll::Ready(Err(_)));
+            assert!(matches!(ready, Poll::Ready(Err(_))));
             ready
         }))
         .unwrap_err();


### PR DESCRIPTION
Replaces `matches` crate with std `assert` and `matches` macro. 