### PR TITLE
feat(upgrade): introduce tracing as an optional unstable feature

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -144,7 +144,7 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
 
       - name: check --feature-powerset
-        run: cargo hack check --feature-powerset --depth 2 --skip ffi -Z avoid-dev-deps
+        run: cargo hack check --feature-powerset --depth 2 --skip ffi,tracing -Z avoid-dev-deps
 
   ffi:
     name: Test C API (FFI)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,8 +91,8 @@ tracing = ["dep:tracing"]
 nightly = []
 
 [package.metadata.docs.rs]
-features = ["ffi", "full"]
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "hyper_unstable_ffi"]
+features = ["ffi", "full", "tracing"]
+rustdoc-args = ["--cfg", "docsrs", "--cfg", "hyper_unstable_ffi", "--cfg", "hyper_unstable_tracing"]
 
 [package.metadata.playground]
 features = ["full"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ httpdate = "1.0"
 httparse = "1.8"
 h2 = { version = "0.3.9", optional = true }
 itoa = "1"
-tracing = { version = "0.1", default-features = false, features = ["std"] }
 pin-project-lite = "0.2.4"
 tokio = { version = "1", features = ["sync"] }
 want = "0.3"
@@ -38,6 +37,7 @@ want = "0.3"
 # Optional
 
 libc = { version = "0.2", optional = true }
+tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
@@ -83,6 +83,9 @@ server = []
 
 # C-API support (currently unstable (no semver))
 ffi = ["dep:libc", "dep:http-body-util"]
+
+# Utilize tracing (currently unstable)
+tracing = ["dep:tracing"]
 
 # internal features used in CI
 nightly = []

--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -50,13 +50,9 @@ impl DecodedLength {
     /// Checks the `u64` is within the maximum allowed for content-length.
     #[cfg(any(feature = "http1", feature = "http2"))]
     pub(crate) fn checked_new(len: u64) -> Result<Self, crate::error::Parse> {
-        #[cfg(feature = "tracing")]
-        use tracing::warn;
-
         if len <= MAX_LEN {
             Ok(DecodedLength(len))
         } else {
-            #[cfg(feature = "tracing")]
             warn!("content-length bigger than maximum: {} > {}", len, MAX_LEN);
             Err(crate::error::Parse::TooLarge)
         }

--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -50,11 +50,13 @@ impl DecodedLength {
     /// Checks the `u64` is within the maximum allowed for content-length.
     #[cfg(any(feature = "http1", feature = "http2"))]
     pub(crate) fn checked_new(len: u64) -> Result<Self, crate::error::Parse> {
+        #[cfg(feature = "tracing")]
         use tracing::warn;
 
         if len <= MAX_LEN {
             Ok(DecodedLength(len))
         } else {
+            #[cfg(feature = "tracing")]
             warn!("content-length bigger than maximum: {} > {}", len, MAX_LEN);
             Err(crate::error::Parse::TooLarge)
         }

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -191,9 +191,7 @@ where
                     Err(_canceled) => panic!("dispatch dropped without returning error"),
                 },
                 Err(_req) => {
-                    #[cfg(feature = "tracing")]
-                    tracing::debug!("connection was not ready");
-
+                    debug!("connection was not ready");
                     Err(crate::Error::new_canceled().with("connection was not ready"))
                 }
             }
@@ -220,8 +218,7 @@ where
                 }))
             }
             Err(req) => {
-                #[cfg(feature = "tracing")]
-                tracing::debug!("connection was not ready");
+                debug!("connection was not ready");
                 let err = crate::Error::new_canceled().with("connection was not ready");
                 Either::Right(future::err((err, Some(req))))
             }
@@ -480,8 +477,7 @@ impl Builder {
         let opts = self.clone();
 
         async move {
-            #[cfg(feature = "tracing")]
-            tracing::trace!("client handshake HTTP/1");
+            trace!("client handshake HTTP/1");
 
             let (tx, rx) = dispatch::channel();
             let mut conn = proto::Conn::new(io);

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -191,6 +191,7 @@ where
                     Err(_canceled) => panic!("dispatch dropped without returning error"),
                 },
                 Err(_req) => {
+                    #[cfg(feature = "tracing")]
                     tracing::debug!("connection was not ready");
 
                     Err(crate::Error::new_canceled().with("connection was not ready"))
@@ -219,6 +220,7 @@ where
                 }))
             }
             Err(req) => {
+                #[cfg(feature = "tracing")]
                 tracing::debug!("connection was not ready");
                 let err = crate::Error::new_canceled().with("connection was not ready");
                 Either::Right(future::err((err, Some(req))))
@@ -478,6 +480,7 @@ impl Builder {
         let opts = self.clone();
 
         async move {
+            #[cfg(feature = "tracing")]
             tracing::trace!("client handshake HTTP/1");
 
             let (tx, rx) = dispatch::channel();

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -146,8 +146,7 @@ where
                     Err(_canceled) => panic!("dispatch dropped without returning error"),
                 },
                 Err(_req) => {
-                    #[cfg(feature = "tracing")]
-                    tracing::debug!("connection was not ready");
+                    debug!("connection was not ready");
 
                     Err(crate::Error::new_canceled().with("connection was not ready"))
                 }
@@ -175,8 +174,7 @@ where
                 }))
             }
             Err(req) => {
-                #[cfg(feature = "tracing")]
-                tracing::debug!("connection was not ready");
+                debug!("connection was not ready");
                 let err = crate::Error::new_canceled().with("connection was not ready");
                 Either::Right(future::err((err, Some(req))))
             }
@@ -409,8 +407,7 @@ where
         let opts = self.clone();
 
         async move {
-            #[cfg(feature = "tracing")]
-            tracing::trace!("client handshake HTTP/1");
+            trace!("client handshake HTTP/1");
 
             let (tx, rx) = dispatch::channel();
             let h2 = proto::h2::client::handshake(io, rx, &opts.h2_builder, opts.exec, opts.timer)

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -146,6 +146,7 @@ where
                     Err(_canceled) => panic!("dispatch dropped without returning error"),
                 },
                 Err(_req) => {
+                    #[cfg(feature = "tracing")]
                     tracing::debug!("connection was not ready");
 
                     Err(crate::Error::new_canceled().with("connection was not ready"))
@@ -174,6 +175,7 @@ where
                 }))
             }
             Err(req) => {
+                #[cfg(feature = "tracing")]
                 tracing::debug!("connection was not ready");
                 let err = crate::Error::new_canceled().with("connection was not ready");
                 Either::Right(future::err((err, Some(req))))
@@ -407,6 +409,7 @@ where
         let opts = self.clone();
 
         async move {
+            #[cfg(feature = "tracing")]
             tracing::trace!("client handshake HTTP/1");
 
             let (tx, rx) = dispatch::channel();

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -5,6 +5,7 @@ use http::{Request, Response};
 use http_body::Body;
 use pin_project_lite::pin_project;
 use tokio::sync::{mpsc, oneshot};
+#[cfg(feature = "tracing")]
 use tracing::trace;
 
 use crate::{
@@ -316,6 +317,7 @@ where
                         return std::task::Poll::Pending;
                     }
                 };
+                #[cfg(feature = "tracing")]
                 trace!("send_when canceled");
                 Poll::Ready(())
             }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -5,8 +5,6 @@ use http::{Request, Response};
 use http_body::Body;
 use pin_project_lite::pin_project;
 use tokio::sync::{mpsc, oneshot};
-#[cfg(feature = "tracing")]
-use tracing::trace;
 
 use crate::{
     body::Incoming,
@@ -317,7 +315,6 @@ where
                         return std::task::Poll::Pending;
                     }
                 };
-                #[cfg(feature = "tracing")]
                 trace!("send_when canceled");
                 Poll::Ready(())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,8 @@ pub use crate::error::{Error, Result};
 #[macro_use]
 mod cfg;
 #[macro_use]
+mod trace;
+#[macro_use]
 mod common;
 pub mod body;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,6 @@ pub use crate::error::{Error, Result};
 mod cfg;
 
 #[macro_use]
-#[cfg_attr(docsrs, doc(all(feature = "tracing"), hyper_unstable_tracing))]
 mod trace;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,20 @@
 //! - `server`: Enables the HTTP `server`.
 //!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
-
+//!
+//! # Unstable Features
+//! hyper includes a set of unstable optional features that can be enabled through the use of a
+//! feature flag and a [configuration flag].
+//!
+//! The following is a list of feature flags and their corresponding `RUSTFLAG`:
+//! - `ffi`: Enables C API for hyper `hyper_unstable_ffi`.
+//! - `tracing`: Enables debug logging with `hyper_unstable_tracing`.
+//!
+//! Enabling an unstable feature is possible with the following `cargo` command, as of version `1.64.0`:
+//! ```notrust
+//! RUSTFLAGS="--cfg hyper_unstable_tracing" cargo rustc --features client,http1,http2,tracing --crate-type cdylib
+//!```
+//! [configuration flag]: https://doc.rust-lang.org/reference/conditional-compilation.html
 #[doc(hidden)]
 pub use http;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,8 +67,11 @@ pub use crate::error::{Error, Result};
 
 #[macro_use]
 mod cfg;
+
 #[macro_use]
+#[cfg_attr(docsrs, doc(all(feature = "tracing"), hyper_unstable_tracing))]
 mod trace;
+
 #[macro_use]
 mod common;
 pub mod body;

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -438,7 +438,7 @@ where
 
         let result = ready!(self.io.poll_read_from_io(cx));
         Poll::Ready(result.map_err(|e| {
-            trace!("force_io_read; io error = {:?}", e);
+            trace!(error = %e, "force_io_read; io error");
             self.state.close();
             e
         }))

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -4,8 +4,6 @@ use std::io;
 use std::usize;
 
 use bytes::Bytes;
-#[cfg(feature = "tracing")]
-use tracing::{debug, trace};
 
 use crate::common::{task, Poll};
 
@@ -107,7 +105,6 @@ impl Decoder {
         cx: &mut task::Context<'_>,
         body: &mut R,
     ) -> Poll<Result<Bytes, io::Error>> {
-        #[cfg(feature = "tracing")]
         trace!("decode; state={:?}", self.kind);
         match self.kind {
             Length(ref mut remaining) => {
@@ -136,7 +133,6 @@ impl Decoder {
                     // advances the chunked state
                     *state = ready!(state.step(cx, body, size, &mut buf))?;
                     if *state == ChunkedState::End {
-                        #[cfg(feature = "tracing")]
                         trace!("end of chunked");
                         return Poll::Ready(Ok(Bytes::new()));
                     }
@@ -214,7 +210,6 @@ impl ChunkedState {
         rdr: &mut R,
         size: &mut u64,
     ) -> Poll<Result<ChunkedState, io::Error>> {
-        #[cfg(feature = "tracing")]
         trace!("Read chunk hex size");
 
         macro_rules! or_overflow {
@@ -259,7 +254,6 @@ impl ChunkedState {
         cx: &mut task::Context<'_>,
         rdr: &mut R,
     ) -> Poll<Result<ChunkedState, io::Error>> {
-        #[cfg(feature = "tracing")]
         trace!("read_size_lws");
         match byte!(rdr, cx) {
             // LWS can follow the chunk size, but no more digits can come
@@ -276,7 +270,6 @@ impl ChunkedState {
         cx: &mut task::Context<'_>,
         rdr: &mut R,
     ) -> Poll<Result<ChunkedState, io::Error>> {
-        #[cfg(feature = "tracing")]
         trace!("read_extension");
         // We don't care about extensions really at all. Just ignore them.
         // They "end" at the next CRLF.
@@ -298,14 +291,12 @@ impl ChunkedState {
         rdr: &mut R,
         size: u64,
     ) -> Poll<Result<ChunkedState, io::Error>> {
-        #[cfg(feature = "tracing")]
         trace!("Chunk size is {:?}", size);
         match byte!(rdr, cx) {
             b'\n' => {
                 if size == 0 {
                     Poll::Ready(Ok(ChunkedState::EndCr))
                 } else {
-                    #[cfg(feature = "tracing")]
                     debug!("incoming chunked header: {0:#X} ({0} bytes)", size);
                     Poll::Ready(Ok(ChunkedState::Body))
                 }
@@ -323,7 +314,6 @@ impl ChunkedState {
         rem: &mut u64,
         buf: &mut Option<Bytes>,
     ) -> Poll<Result<ChunkedState, io::Error>> {
-        #[cfg(feature = "tracing")]
         trace!("Chunked read, remaining={:?}", rem);
 
         // cap remaining bytes at the max capacity of usize
@@ -381,7 +371,6 @@ impl ChunkedState {
         cx: &mut task::Context<'_>,
         rdr: &mut R,
     ) -> Poll<Result<ChunkedState, io::Error>> {
-        #[cfg(feature = "tracing")]
         trace!("read_trailer");
         match byte!(rdr, cx) {
             b'\r' => Poll::Ready(Ok(ChunkedState::TrailerLf)),

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -3,8 +3,6 @@ use std::error::Error as StdError;
 use crate::rt::{Read, Write};
 use bytes::{Buf, Bytes};
 use http::Request;
-#[cfg(feature = "tracing")]
-use tracing::{debug, trace};
 
 use super::{Http1Transaction, Wants};
 use crate::body::{Body, DecodedLength, Incoming as IncomingBody};
@@ -183,7 +181,6 @@ where
             }
         }
 
-        #[cfg(feature = "tracing")]
         trace!("poll_loop yielding (self = {:p})", self);
 
         task::yield_now(cx).map(|never| match never {})
@@ -206,7 +203,6 @@ where
                         Poll::Ready(Err(_canceled)) => {
                             // user doesn't care about the body
                             // so we should stop reading
-                            #[cfg(feature = "tracing")]
                             trace!("body receiver dropped before eof, draining or closing");
                             self.conn.poll_drain_or_close_read(cx);
                             continue;
@@ -219,7 +215,6 @@ where
                             }
                             Err(_canceled) => {
                                 if self.conn.can_read_body() {
-                                    #[cfg(feature = "tracing")]
                                     trace!("body receiver dropped before eof, closing");
                                     self.conn.close_read();
                                 }
@@ -250,7 +245,6 @@ where
         match ready!(self.dispatch.poll_ready(cx)) {
             Ok(()) => (),
             Err(()) => {
-                #[cfg(feature = "tracing")]
                 trace!("dispatch no longer receiving messages");
                 self.close();
                 return Poll::Ready(Ok(()));
@@ -282,7 +276,6 @@ where
                 Poll::Ready(Ok(()))
             }
             Some(Err(err)) => {
-                #[cfg(feature = "tracing")]
                 debug!("read_head error: {}", err);
                 self.dispatch.recv_msg(Err(err))?;
                 // if here, the dispatcher gave the user the error
@@ -341,7 +334,6 @@ where
                 {
                     debug_assert!(!*clear_body, "opt guard defaults to keeping body");
                     if !self.conn.can_write_body() {
-                        #[cfg(feature = "tracing")]
                         trace!(
                             "no more write body allowed, user body is_end_stream = {}",
                             body.is_end_stream(),
@@ -359,7 +351,6 @@ where
                         let chunk = if let Ok(data) = frame.into_data() {
                             data
                         } else {
-                            #[cfg(feature = "tracing")]
                             trace!("discarding non-data frame");
                             continue;
                         };
@@ -367,7 +358,6 @@ where
                         if eos {
                             *clear_body = true;
                             if chunk.remaining() == 0 {
-                                #[cfg(feature = "tracing")]
                                 trace!("discarding empty chunk");
                                 self.conn.end_body()?;
                             } else {
@@ -375,7 +365,6 @@ where
                             }
                         } else {
                             if chunk.remaining() == 0 {
-                                #[cfg(feature = "tracing")]
                                 trace!("discarding empty chunk");
                                 continue;
                             }
@@ -399,7 +388,6 @@ where
 
     fn poll_flush(&mut self, cx: &mut task::Context<'_>) -> Poll<crate::Result<()>> {
         self.conn.poll_flush(cx).map_err(|err| {
-            #[cfg(feature = "tracing")]
             debug!("error writing: {}", err);
             crate::Error::new_body_write(err)
         })
@@ -591,7 +579,6 @@ cfg_client! {
                     // check that future hasn't been canceled already
                     match cb.poll_canceled(cx) {
                         Poll::Ready(()) => {
-                            #[cfg(feature = "tracing")]
                             trace!("request canceled");
                             Poll::Ready(None)
                         }
@@ -610,7 +597,6 @@ cfg_client! {
                 }
                 Poll::Ready(None) => {
                     // user has dropped sender handle
-                    #[cfg(feature = "tracing")]
                     trace!("client tx closed");
                     this.rx_closed = true;
                     Poll::Ready(None)
@@ -640,7 +626,6 @@ cfg_client! {
                     } else if !self.rx_closed {
                         self.rx.close();
                         if let Some((req, cb)) = self.rx.try_recv() {
-                            #[cfg(feature = "tracing")]
                             trace!("canceling queued request with connection error: {}", err);
                             // in this case, the message was never even started, so it's safe to tell
                             // the user that the request was completely canceled
@@ -660,7 +645,6 @@ cfg_client! {
             match self.callback {
                 Some(ref mut cb) => match cb.poll_canceled(cx) {
                     Poll::Ready(()) => {
-                        #[cfg(feature = "tracing")]
                         trace!("callback receiver has dropped");
                         Poll::Ready(Err(()))
                     }

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -3,8 +3,6 @@ use std::io::IoSlice;
 
 use bytes::buf::{Chain, Take};
 use bytes::Buf;
-#[cfg(feature = "tracing")]
-use tracing::trace;
 
 use super::io::WriteBuf;
 
@@ -112,7 +110,6 @@ impl Encoder {
 
         let kind = match self.kind {
             Kind::Chunked => {
-                #[cfg(feature = "tracing")]
                 trace!("encoding chunked {}B", len);
                 let buf = ChunkSize::new(len)
                     .chain(msg)
@@ -120,7 +117,6 @@ impl Encoder {
                 BufKind::Chunked(buf)
             }
             Kind::Length(ref mut remaining) => {
-                #[cfg(feature = "tracing")]
                 trace!("sized write, len = {}", len);
                 if len as u64 > *remaining {
                     let limit = *remaining as usize;
@@ -133,7 +129,6 @@ impl Encoder {
             }
             #[cfg(feature = "server")]
             Kind::CloseDelimited => {
-                #[cfg(feature = "tracing")]
                 trace!("close delimited write {}B", len);
                 BufKind::Exact(msg)
             }
@@ -150,7 +145,6 @@ impl Encoder {
 
         match self.kind {
             Kind::Chunked => {
-                #[cfg(feature = "tracing")]
                 trace!("encoding chunked {}B", len);
                 let buf = ChunkSize::new(len)
                     .chain(msg)
@@ -161,7 +155,6 @@ impl Encoder {
             Kind::Length(remaining) => {
                 use std::cmp::Ordering;
 
-                #[cfg(feature = "tracing")]
                 trace!("sized write, len = {}", len);
                 match (len as u64).cmp(&remaining) {
                     Ordering::Equal => {
@@ -180,7 +173,6 @@ impl Encoder {
             }
             #[cfg(feature = "server")]
             Kind::CloseDelimited => {
-                #[cfg(feature = "tracing")]
                 trace!("close delimited write {}B", len);
                 dst.buffer(msg);
                 false

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -3,6 +3,7 @@ use std::io::IoSlice;
 
 use bytes::buf::{Chain, Take};
 use bytes::Buf;
+#[cfg(feature = "tracing")]
 use tracing::trace;
 
 use super::io::WriteBuf;
@@ -111,6 +112,7 @@ impl Encoder {
 
         let kind = match self.kind {
             Kind::Chunked => {
+                #[cfg(feature = "tracing")]
                 trace!("encoding chunked {}B", len);
                 let buf = ChunkSize::new(len)
                     .chain(msg)
@@ -118,6 +120,7 @@ impl Encoder {
                 BufKind::Chunked(buf)
             }
             Kind::Length(ref mut remaining) => {
+                #[cfg(feature = "tracing")]
                 trace!("sized write, len = {}", len);
                 if len as u64 > *remaining {
                     let limit = *remaining as usize;
@@ -130,6 +133,7 @@ impl Encoder {
             }
             #[cfg(feature = "server")]
             Kind::CloseDelimited => {
+                #[cfg(feature = "tracing")]
                 trace!("close delimited write {}B", len);
                 BufKind::Exact(msg)
             }
@@ -146,6 +150,7 @@ impl Encoder {
 
         match self.kind {
             Kind::Chunked => {
+                #[cfg(feature = "tracing")]
                 trace!("encoding chunked {}B", len);
                 let buf = ChunkSize::new(len)
                     .chain(msg)
@@ -156,6 +161,7 @@ impl Encoder {
             Kind::Length(remaining) => {
                 use std::cmp::Ordering;
 
+                #[cfg(feature = "tracing")]
                 trace!("sized write, len = {}", len);
                 match (len as u64).cmp(&remaining) {
                     Ordering::Equal => {
@@ -174,6 +180,7 @@ impl Encoder {
             }
             #[cfg(feature = "server")]
             Kind::CloseDelimited => {
+                #[cfg(feature = "tracing")]
                 trace!("close delimited write {}B", len);
                 dst.buffer(msg);
                 false

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -70,7 +70,7 @@ where
     if bytes.is_empty() {
         return Ok(None);
     }
-    
+
     trace_span!("parse_headers");
 
     #[cfg(feature = "server")]

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -71,7 +71,7 @@ where
         return Ok(None);
     }
 
-    trace_span!("parse_headers");
+    let _entered = trace_span!("parse_headers");
 
     #[cfg(feature = "server")]
     if !*ctx.h1_header_read_timeout_running {
@@ -101,7 +101,7 @@ pub(super) fn encode_headers<T>(
 where
     T: Http1Transaction,
 {
-    trace_span!("encode_headers");
+    let _entered = trace_span!("encode_headers");
     T::encode(enc, dst)
 }
 

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -9,8 +9,6 @@ use bytes::BytesMut;
 use http::header::ValueIter;
 use http::header::{self, Entry, HeaderName, HeaderValue};
 use http::{HeaderMap, Method, StatusCode, Version};
-#[cfg(feature = "tracing")]
-use tracing::{debug, error, trace, trace_span, warn};
 
 use crate::body::DecodedLength;
 #[cfg(feature = "server")]
@@ -55,7 +53,6 @@ macro_rules! maybe_panic {
         if cfg!(debug_assertions) {
             panic!("{:?}", _err);
         } else {
-            #[cfg(feature = "tracing")]
             error!("Internal Hyper error, please report {:?}", _err);
             return Err(Parse::Internal)
         }
@@ -73,12 +70,8 @@ where
     if bytes.is_empty() {
         return Ok(None);
     }
-
-    #[cfg(feature = "tracing")]
-    {
-        let span = trace_span!("parse_headers");
-        let _s = span.enter();
-    }
+    
+    trace_span!("parse_headers");
 
     #[cfg(feature = "server")]
     if !*ctx.h1_header_read_timeout_running {
@@ -87,12 +80,10 @@ where
             *ctx.h1_header_read_timeout_running = true;
             match ctx.h1_header_read_timeout_fut {
                 Some(h1_header_read_timeout_fut) => {
-                    #[cfg(feature = "tracing")]
                     debug!("resetting h1 header read timeout timer");
                     ctx.timer.reset(h1_header_read_timeout_fut, deadline);
                 }
                 None => {
-                    #[cfg(feature = "tracing")]
                     debug!("setting h1 header read timeout timer");
                     *ctx.h1_header_read_timeout_fut = Some(ctx.timer.sleep_until(deadline));
                 }
@@ -110,11 +101,7 @@ pub(super) fn encode_headers<T>(
 where
     T: Http1Transaction,
 {
-    #[cfg(feature = "tracing")]
-    {
-        let span = trace_span!("encode_headers");
-        let _s = span.enter();
-    }
+    trace_span!("encode_headers");
     T::encode(enc, dst)
 }
 
@@ -154,13 +141,11 @@ impl Http1Transaction for Server {
             /* SAFETY: it is safe to go from MaybeUninit array to array of MaybeUninit */
             let mut headers: [MaybeUninit<httparse::Header<'_>>; MAX_HEADERS] =
                 unsafe { MaybeUninit::uninit().assume_init() };
-            #[cfg(feature = "tracing")]
             trace!(bytes = buf.len(), "Request.parse");
             let mut req = httparse::Request::new(&mut []);
             let bytes = buf.as_ref();
             match req.parse_with_uninit_headers(bytes, &mut headers) {
                 Ok(httparse::Status::Complete(parsed_len)) => {
-                    #[cfg(feature = "tracing")]
                     trace!("Request.parse Complete({})", parsed_len);
                     len = parsed_len;
                     let uri = req.path.unwrap();
@@ -250,7 +235,6 @@ impl Http1Transaction for Server {
                     // not the final encoding, and this is a Request, then it is
                     // malformed. A server should respond with 400 Bad Request.
                     if !is_http_11 {
-                        #[cfg(feature = "tracing")]
                         debug!("HTTP/1.0 cannot have Transfer-Encoding header");
                         return Err(Parse::transfer_encoding_unexpected());
                     }
@@ -270,7 +254,6 @@ impl Http1Transaction for Server {
                         .ok_or_else(Parse::content_length_invalid)?;
                     if let Some(prev) = con_len {
                         if prev != len {
-                            #[cfg(feature = "tracing")]
                             debug!(
                                 "multiple Content-Length headers with different values: [{}, {}]",
                                 prev, len,
@@ -320,7 +303,6 @@ impl Http1Transaction for Server {
         }
 
         if is_te && !is_te_chunked {
-            #[cfg(feature = "tracing")]
             debug!("request with transfer-encoding header, but not chunked, bad request");
             return Err(Parse::transfer_encoding_invalid());
         }
@@ -353,7 +335,6 @@ impl Http1Transaction for Server {
     }
 
     fn encode(mut msg: Encode<'_, Self::Outgoing>, dst: &mut Vec<u8>) -> crate::Result<Encoder> {
-        #[cfg(feature = "tracing")]
         trace!(
             "Server::encode status={:?}, body={:?}, req_method={:?}",
             msg.head.subject,
@@ -375,7 +356,6 @@ impl Http1Transaction for Server {
             wrote_len = true;
             (Ok(()), true)
         } else if msg.head.subject.is_informational() {
-            #[cfg(feature = "tracing")]
             warn!("response with 1xx status code not supported");
             *msg.head = MessageHead::default();
             msg.head.subject = StatusCode::INTERNAL_SERVER_ERROR;
@@ -405,7 +385,6 @@ impl Http1Transaction for Server {
                 Version::HTTP_10 => extend(dst, b"HTTP/1.0 "),
                 Version::HTTP_11 => extend(dst, b"HTTP/1.1 "),
                 Version::HTTP_2 => {
-                    #[cfg(feature = "tracing")]
                     debug!("response with HTTP2 version coerced to HTTP/1.1");
                     extend(dst, b"HTTP/1.1 ");
                 }
@@ -469,7 +448,6 @@ impl Http1Transaction for Server {
             _ => return None,
         };
 
-        #[cfg(feature = "tracing")]
         debug!("sending automatic response ({}) for parse error", status);
         let mut msg = MessageHead::default();
         msg.subject = status;
@@ -685,7 +663,6 @@ impl Server {
             match *name {
                 header::CONTENT_LENGTH => {
                     if wrote_len && !is_name_written {
-                        #[cfg(feature = "tracing")]
                         warn!("unexpected content-length found, canceling");
                         rewind(dst);
                         return Err(crate::Error::new_user_header());
@@ -733,7 +710,6 @@ impl Server {
                             if let Some(len) = headers::content_length_parse(&value) {
                                 if let Some(prev) = prev_con_len {
                                     if prev != len {
-                                        #[cfg(feature = "tracing")]
                                         warn!(
                                             "multiple Content-Length values found: [{}, {}]",
                                             prev, len
@@ -758,7 +734,6 @@ impl Server {
                                     continue 'headers;
                                 }
                             } else {
-                                #[cfg(feature = "tracing")]
                                 warn!("illegal Content-Length value: {:?}", value);
                                 rewind(dst);
                                 return Err(crate::Error::new_user_header());
@@ -775,7 +750,6 @@ impl Server {
                                 debug_assert_eq!(encoder, Encoder::length(0));
                             } else {
                                 if value.as_bytes() != b"0" {
-                                    #[cfg(feature = "tracing")]
                                     warn!(
                                         "content-length value found, but empty body provided: {:?}",
                                         value
@@ -789,7 +763,6 @@ impl Server {
                 }
                 header::TRANSFER_ENCODING => {
                     if wrote_len && !is_name_written {
-                        #[cfg(feature = "tracing")]
                         warn!("unexpected transfer-encoding found, canceling");
                         rewind(dst);
                         return Err(crate::Error::new_user_header());
@@ -907,7 +880,6 @@ impl Server {
         }
 
         if !Server::can_have_body(msg.req_method, msg.head.subject) {
-            #[cfg(feature = "tracing")]
             trace!(
                 "server body forced to 0; method={:?}, status={:?}",
                 msg.req_method,
@@ -967,7 +939,6 @@ impl Http1Transaction for Client {
                 // SAFETY: We can go safely from MaybeUninit array to array of MaybeUninit
                 let mut headers: [MaybeUninit<httparse::Header<'_>>; MAX_HEADERS] =
                     unsafe { MaybeUninit::uninit().assume_init() };
-                #[cfg(feature = "tracing")]
                 trace!(bytes = buf.len(), "Response.parse");
                 let mut res = httparse::Response::new(&mut []);
                 let bytes = buf.as_ref();
@@ -977,7 +948,6 @@ impl Http1Transaction for Client {
                     &mut headers,
                 ) {
                     Ok(httparse::Status::Complete(len)) => {
-                        #[cfg(feature = "tracing")]
                         trace!("Response.parse Complete({})", len);
                         let status = StatusCode::from_u16(res.code.unwrap())?;
 
@@ -1002,7 +972,6 @@ impl Http1Transaction for Client {
                     }
                     Ok(httparse::Status::Partial) => return Ok(None),
                     Err(httparse::Error::Version) if ctx.h09_responses => {
-                        #[cfg(feature = "tracing")]
                         trace!("Response.parse accepted HTTP/0.9 response");
 
                         (0, StatusCode::OK, None, Version::HTTP_09, 0)
@@ -1125,7 +1094,6 @@ impl Http1Transaction for Client {
     }
 
     fn encode(msg: Encode<'_, Self::Outgoing>, dst: &mut Vec<u8>) -> crate::Result<Encoder> {
-        #[cfg(feature = "tracing")]
         trace!(
             "Client::encode method={:?}, body={:?}",
             msg.head.subject.0,
@@ -1148,7 +1116,6 @@ impl Http1Transaction for Client {
             Version::HTTP_10 => extend(dst, b"HTTP/1.0"),
             Version::HTTP_11 => extend(dst, b"HTTP/1.1"),
             Version::HTTP_2 => {
-                #[cfg(feature = "tracing")]
                 debug!("request with HTTP2 version coerced to HTTP/1.1");
                 extend(dst, b"HTTP/1.1");
             }
@@ -1208,7 +1175,6 @@ impl Client {
                 return Ok(Some((DecodedLength::ZERO, true)));
             }
             100 | 102..=199 => {
-                #[cfg(feature = "tracing")]
                 trace!("ignoring informational response: {}", inc.subject.as_u16());
                 return Ok(None);
             }
@@ -1226,7 +1192,6 @@ impl Client {
             }
             Some(_) => {}
             None => {
-                #[cfg(feature = "tracing")]
                 trace!("Client::decoder is missing the Method");
             }
         }
@@ -1237,24 +1202,20 @@ impl Client {
             // not the final encoding, and this is a Request, then it is
             // malformed. A server should respond with 400 Bad Request.
             if inc.version == Version::HTTP_10 {
-                #[cfg(feature = "tracing")]
                 debug!("HTTP/1.0 cannot have Transfer-Encoding header");
                 Err(Parse::transfer_encoding_unexpected())
             } else if headers::transfer_encoding_is_chunked(&inc.headers) {
                 Ok(Some((DecodedLength::CHUNKED, false)))
             } else {
-                #[cfg(feature = "tracing")]
                 trace!("not chunked, read till eof");
                 Ok(Some((DecodedLength::CLOSE_DELIMITED, false)))
             }
         } else if let Some(len) = headers::content_length_parse_all(&inc.headers) {
             Ok(Some((DecodedLength::checked_new(len)?, false)))
         } else if inc.headers.contains_key(header::CONTENT_LENGTH) {
-            #[cfg(feature = "tracing")]
             debug!("illegal Content-Length header");
             Err(Parse::content_length_invalid())
         } else {
-            #[cfg(feature = "tracing")]
             trace!("neither Transfer-Encoding nor Content-Length");
             Ok(Some((DecodedLength::CLOSE_DELIMITED, false)))
         }
@@ -1284,7 +1245,6 @@ impl Client {
         if !can_chunked {
             // Chunked isn't legal, so if it is set, we need to remove it.
             if headers.remove(header::TRANSFER_ENCODING).is_some() {
-                #[cfg(feature = "tracing")]
                 trace!("removing illegal transfer-encoding header");
             }
 
@@ -1307,7 +1267,6 @@ impl Client {
                 if headers::is_chunked(te.iter()) {
                     Some(Encoder::chunked())
                 } else {
-                    #[cfg(feature = "tracing")]
                     warn!("user provided transfer-encoding does not end in 'chunked'");
 
                     // There's a Transfer-Encoding, but it doesn't end in 'chunked'!
@@ -1450,7 +1409,6 @@ fn set_content_length(headers: &mut HeaderMap, len: u64) -> Encoder {
                 // Uh oh, the user set `Content-Length` headers, but set bad ones.
                 // This would be an illegal message anyways, so let's try to repair
                 // with our known good length.
-                #[cfg(feature = "tracing")]
                 error!("user provided content-length header was invalid");
 
                 cl.insert(HeaderValue::from(len));
@@ -1482,7 +1440,6 @@ fn record_header_indices(
 
     for (header, indices) in headers.iter().zip(indices.iter_mut()) {
         if header.name.len() >= (1 << 16) {
-            #[cfg(feature = "tracing")]
             debug!("header name larger than 64kb: {:?}", header.name);
             return Err(crate::error::Parse::TooLarge);
         }

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -243,7 +243,7 @@ where
             *this.is_terminated = true;
         }
         polled.map_err(|_e| {
-            debug!("connection error: {}", _e)
+            debug!("connection error: {}", _e);
         })
     }
 }

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -12,8 +12,6 @@ use h2::client::{Builder, Connection, SendRequest};
 use h2::SendStream;
 use http::{Method, StatusCode};
 use pin_project_lite::pin_project;
-#[cfg(feature = "tracing")]
-use tracing::{debug, trace, warn};
 
 use super::ping::{Ponger, Recorder};
 use super::{ping, H2Upgraded, PipeToSendStream, SendBuf};
@@ -202,7 +200,6 @@ where
                 this.conn.set_initial_window_size(wnd)?;
             }
             Poll::Ready(ping::Ponged::KeepAliveTimedOut) => {
-                #[cfg(feature = "tracing")]
                 debug!("connection keep-alive timed out");
                 return Poll::Ready(Ok(()));
             }
@@ -245,8 +242,7 @@ where
         if polled.is_ready() {
             *this.is_terminated = true;
         }
-        polled.map_err(|e| {
-            #[cfg(feature = "tracing")]
+        polled.map_err(|e| { 
             debug!("connection error: {}", e)
         })
     }
@@ -319,7 +315,6 @@ where
                 // mpsc has been dropped, hopefully polling
                 // the connection some more should start shutdown
                 // and then close.
-                #[cfg(feature = "tracing")]
                 trace!("send_request dropped, starting conn shutdown");
                 drop(this.cancel_tx.take().expect("ConnTask Future polled twice"));
             }
@@ -448,7 +443,6 @@ where
         match this.pipe.poll_unpin(cx) {
             Poll::Ready(result) => {
                 if let Err(e) = result {
-                    #[cfg(feature = "tracing")]
                     debug!("client request body error: {}", e);
                 }
                 drop(this.conn_drop_ref.take().expect("Future polled twice"));
@@ -554,7 +548,6 @@ where
                 let content_length = headers::content_length_parse_all(res.headers());
                 if let (Some(mut send_stream), StatusCode::OK) = (send_stream, res.status()) {
                     if content_length.map_or(false, |len| len != 0) {
-                        #[cfg(feature = "tracing")]
                         warn!("h2 connect response with non-zero body not supported");
 
                         send_stream.send_reset(h2::Reason::INTERNAL_ERROR);
@@ -590,7 +583,6 @@ where
             Err(err) => {
                 ping.ensure_not_timed_out().map_err(|e| (e, None))?;
 
-                #[cfg(feature = "tracing")]
                 debug!("client response error: {}", err);
                 Poll::Ready(Err((crate::Error::new_h2(err), None::<Request<B>>)))
             }
@@ -615,7 +607,6 @@ where
                 Err(err) => {
                     self.ping.ensure_not_timed_out()?;
                     return if err.reason() == Some(::h2::Reason::NO_ERROR) {
-                        #[cfg(feature = "tracing")]
                         trace!("connection gracefully shutdown");
                         Poll::Ready(Ok(Dispatched::Shutdown))
                     } else {
@@ -638,7 +629,6 @@ where
                 Poll::Ready(Some((req, cb))) => {
                     // check that future hasn't been canceled already
                     if cb.is_canceled() {
-                        #[cfg(feature = "tracing")]
                         trace!("request callback is canceled");
                         continue;
                     }
@@ -658,7 +648,6 @@ where
                         if headers::content_length_parse_all(req.headers())
                             .map_or(false, |len| len != 0)
                         {
-                            #[cfg(feature = "tracing")]
                             warn!("h2 connect request with non-zero body not supported");
                             cb.send(Err((
                                 crate::Error::new_h2(h2::Reason::INTERNAL_ERROR.into()),
@@ -675,7 +664,6 @@ where
                     let (fut, body_tx) = match self.h2_tx.send_request(req, !is_connect && eos) {
                         Ok(ok) => ok,
                         Err(err) => {
-                            #[cfg(feature = "tracing")]
                             debug!("client send request error: {}", err);
                             cb.send(Err((crate::Error::new_h2(err), None)));
                             continue;
@@ -711,7 +699,6 @@ where
                 }
 
                 Poll::Ready(None) => {
-                    #[cfg(feature = "tracing")]
                     trace!("client::dispatch::Sender dropped");
                     return Poll::Ready(Ok(Dispatched::Shutdown));
                 }
@@ -719,7 +706,6 @@ where
                 Poll::Pending => match ready!(Pin::new(&mut self.conn_eof).poll(cx)) {
                     Ok(never) => match never {},
                     Err(_conn_is_eof) => {
-                        #[cfg(feature = "tracing")]
                         trace!("connection task is closed, closing dispatch task");
                         return Poll::Ready(Ok(Dispatched::Shutdown));
                     }

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -242,8 +242,8 @@ where
         if polled.is_ready() {
             *this.is_terminated = true;
         }
-        polled.map_err(|e| { 
-            debug!("connection error: {}", e)
+        polled.map_err(|_e| {
+            debug!("connection error: {}", _e)
         })
     }
 }
@@ -442,8 +442,8 @@ where
 
         match this.pipe.poll_unpin(cx) {
             Poll::Ready(result) => {
-                if let Err(e) = result {
-                    debug!("client request body error: {}", e);
+                if let Err(_e) = result {
+                    debug!("client request body error: {}", _e);
                 }
                 drop(this.conn_drop_ref.take().expect("Future polled twice"));
                 drop(this.ping.take().expect("Future polled twice"));

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -243,7 +243,7 @@ where
             *this.is_terminated = true;
         }
         polled.map_err(|_e| {
-            debug!("connection error: {}", _e);
+            debug!(error = %_e, "connection error");
         })
     }
 }

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -8,6 +8,7 @@ use std::error::Error as StdError;
 use std::io::{Cursor, IoSlice};
 use std::mem;
 use std::task::Context;
+#[cfg(feature = "tracing")]
 use tracing::{debug, trace, warn};
 
 use crate::body::Body;
@@ -45,6 +46,7 @@ const CONNECTION_HEADERS: [HeaderName; 5] = [
 fn strip_connection_headers(headers: &mut HeaderMap, is_request: bool) {
     for header in &CONNECTION_HEADERS {
         if headers.remove(header).is_some() {
+            #[cfg(feature = "tracing")]
             warn!("Connection header illegal in HTTP/2: {}", header.as_str());
         }
     }
@@ -55,14 +57,17 @@ fn strip_connection_headers(headers: &mut HeaderMap, is_request: bool) {
             .map(|te_header| te_header != "trailers")
             .unwrap_or(false)
         {
+            #[cfg(feature = "tracing")]
             warn!("TE headers not set to \"trailers\" are illegal in HTTP/2 requests");
             headers.remove(TE);
         }
     } else if headers.remove(TE).is_some() {
+        #[cfg(feature = "tracing")]
         warn!("TE headers illegal in HTTP/2 responses");
     }
 
     if let Some(header) = headers.remove(CONNECTION) {
+        #[cfg(feature = "tracing")]
         warn!(
             "Connection header illegal in HTTP/2: {}",
             CONNECTION.as_str()
@@ -145,6 +150,7 @@ where
                 .poll_reset(cx)
                 .map_err(crate::Error::new_body_write)?
             {
+                #[cfg(feature = "tracing")]
                 debug!("stream received RST_STREAM: {:?}", reason);
                 return Poll::Ready(Err(crate::Error::new_body_write(::h2::Error::from(reason))));
             }
@@ -154,6 +160,7 @@ where
                     if frame.is_data() {
                         let chunk = frame.into_data().unwrap_or_else(|_| unreachable!());
                         let is_eos = me.stream.is_end_stream();
+                        #[cfg(feature = "tracing")]
                         trace!(
                             "send body chunk: {} bytes, eos={}",
                             chunk.remaining(),
@@ -176,6 +183,7 @@ where
                             .map_err(crate::Error::new_body_write)?;
                         return Poll::Ready(Ok(()));
                     } else {
+                        #[cfg(feature = "tracing")]
                         trace!("discarding unknown frame");
                         // loop again
                     }
@@ -205,12 +213,14 @@ impl<B: Buf> SendStreamExt for SendStream<SendBuf<B>> {
         E: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
         let err = crate::Error::new_user_body(err);
+        #[cfg(feature = "tracing")]
         debug!("send body user stream error: {}", err);
         self.send_reset(err.h2_reason());
         err
     }
 
     fn send_eos_frame(&mut self) -> crate::Result<()> {
+        #[cfg(feature = "tracing")]
         trace!("send body eos");
         self.send_data(SendBuf::None, true)
             .map_err(crate::Error::new_body_write)

--- a/src/proto/h2/ping.rs
+++ b/src/proto/h2/ping.rs
@@ -299,8 +299,8 @@ impl Ponger {
                     }
                 }
             }
-            Poll::Ready(Err(e)) => {
-                debug!("pong error: {}", e);
+            Poll::Ready(Err(_e)) => {
+                debug!("pong error: {}", _e);
             }
             Poll::Pending => {
                 if let Some(ref mut ka) = self.keep_alive {
@@ -331,8 +331,8 @@ impl Shared {
                 self.ping_sent_at = Some(Instant::now());
                 trace!("sent ping");
             }
-            Err(err) => {
-                debug!("error sending ping: {}", err);
+            Err(_err) => {
+                debug!("error sending ping: {}", _err);
             }
         }
     }

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -9,6 +9,7 @@ use h2::server::{Connection, Handshake, SendResponse};
 use h2::{Reason, RecvStream};
 use http::{Method, Request};
 use pin_project_lite::pin_project;
+#[cfg(feature = "tracing")]
 use tracing::{debug, trace, warn};
 
 use super::{ping, PipeToSendStream, SendBuf};
@@ -161,6 +162,7 @@ where
     }
 
     pub(crate) fn graceful_shutdown(&mut self) {
+        #[cfg(feature = "tracing")]
         trace!("graceful_shutdown");
         match self.state {
             State::Handshaking { .. } => {
@@ -248,6 +250,7 @@ where
 
                 match ready!(self.conn.poll_accept(cx)) {
                     Some(Ok((req, mut respond))) => {
+                        #[cfg(feature = "tracing")]
                         trace!("incoming request");
                         let content_length = headers::content_length_parse_all(req.headers());
                         let ping = self
@@ -271,6 +274,7 @@ where
                             )
                         } else {
                             if content_length.map_or(false, |len| len != 0) {
+                                #[cfg(feature = "tracing")]
                                 warn!("h2 connect request with non-zero body not supported");
                                 respond.send_reset(h2::Reason::INTERNAL_ERROR);
                                 return Poll::Ready(Ok(()));
@@ -304,6 +308,7 @@ where
                             ping.ensure_not_timed_out()?;
                         }
 
+                        #[cfg(feature = "tracing")]
                         trace!("incoming connection complete");
                         return Poll::Ready(Ok(()));
                     }
@@ -329,6 +334,7 @@ where
                     let _ = self.conn.set_initial_window_size(wnd);
                 }
                 Poll::Ready(ping::Ponged::KeepAliveTimedOut) => {
+                    #[cfg(feature = "tracing")]
                     debug!("keep-alive timed out, closing connection");
                     self.conn.abrupt_shutdown(h2::Reason::NO_ERROR);
                 }
@@ -395,6 +401,7 @@ macro_rules! reply {
         match $me.reply.send_response($res, $eos) {
             Ok(tx) => tx,
             Err(e) => {
+                #[cfg(feature = "tracing")]
                 debug!("send response error: {}", e);
                 $me.reply.send_reset(Reason::INTERNAL_ERROR);
                 return Poll::Ready(Err(crate::Error::new_h2(e)));
@@ -427,6 +434,7 @@ where
                             if let Poll::Ready(reason) =
                                 me.reply.poll_reset(cx).map_err(crate::Error::new_h2)?
                             {
+                                #[cfg(feature = "tracing")]
                                 debug!("stream received RST_STREAM: {:?}", reason);
                                 return Poll::Ready(Err(crate::Error::new_h2(reason.into())));
                             }
@@ -434,6 +442,7 @@ where
                         }
                         Poll::Ready(Err(e)) => {
                             let err = crate::Error::new_user_service(e);
+                            #[cfg(feature = "tracing")]
                             warn!("http2 service errored: {}", err);
                             me.reply.send_reset(err.h2_reason());
                             return Poll::Ready(Err(err));
@@ -454,6 +463,7 @@ where
                             if headers::content_length_parse_all(res.headers())
                                 .map_or(false, |len| len != 0)
                             {
+                                #[cfg(feature = "tracing")]
                                 warn!("h2 successful response to CONNECT request with body not supported");
                                 me.reply.send_reset(h2::Reason::INTERNAL_ERROR);
                                 return Poll::Ready(Err(crate::Error::new_user_header()));
@@ -509,6 +519,7 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         self.poll2(cx).map(|res| {
             if let Err(e) = res {
+                #[cfg(feature = "tracing")]
                 debug!("stream error: {}", e);
             }
         })

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -507,8 +507,8 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         self.poll2(cx).map(|res| {
-            if let Err(e) = res {
-                debug!("stream error: {}", e);
+            if let Err(_e) = res {
+                debug!("stream error: {}", _e);
             }
         })
     }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,0 +1,107 @@
+#![allow(unused_macros)]
+
+macro_rules! debug {
+    ($($arg:tt)+) => {
+        #[cfg(feature = "tracing")]
+        {
+            println!($($arg)+);
+            tracing::debug!($($arg)+);
+        }
+    }
+}
+
+macro_rules! debug_span {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        {
+            let span = tracing::debug_span!($($arg)+);
+            let _ = span.enter();
+        }
+    }
+}
+
+macro_rules! error {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        {
+            tracing::error!($($arg)+);
+        }
+    }
+}
+
+macro_rules! error_span {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        {
+            let span = tracing::error_span!($($arg)+);
+            let _ = span.enter();
+        }
+    }
+}
+
+macro_rules! info {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        {
+            tracing::info!($($arg)+);
+        }
+    }
+}
+
+macro_rules! info_span {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        {
+            let span = tracing::info_span!($($arg)+);
+            let _ = span.enter();
+        }
+    }
+}
+
+macro_rules! trace {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        {
+            tracing::trace!($($arg)+);
+        }
+    }
+}
+
+macro_rules! trace_span {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        {
+            let span = tracing::trace_span!($($arg)+);
+            let _ = span.enter();
+        }
+    }
+}
+
+macro_rules! span {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        {
+            let span = tracing::span!($($arg)+);
+            let _ = span.enter();
+        }
+    }
+}
+
+macro_rules! warn {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        {
+            tracing::warn!($($arg)+);
+        }
+    }
+}
+
+macro_rules! warn_span {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        {
+            let span = tracing::warn_span!($($arg)+);
+            let _ = span.enter();
+        }
+    }
+}

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,19 +1,21 @@
-// For completeness, wrappers around all of tracing's public logging and span macros are provided, 
+// For completeness, wrappers around all of tracing's public logging and span macros are provided,
 // even if they are not used at the present time.
 #![allow(unused_macros)]
 
-#[cfg(not(hyper_unstable_tracing))]
+#[cfg(all(not(hyper_unstable_tracing), feature = "tracing"))]
 compile_error!(
     "\
     The `tracing` feature is unstable, and requires the \
     `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-    "
-    );
+"
+);
 
 macro_rules! debug {
     ($($arg:tt)+) => {
         #[cfg(feature = "tracing")]
-        tracing::debug!($($arg)+);
+        {
+            tracing::debug!($($arg)+);
+        }
     }
 }
 
@@ -23,7 +25,7 @@ macro_rules! debug_span {
             #[cfg(feature = "tracing")]
             {
                 let _span = tracing::debug_span!($($arg)+);
-                _span.entered();
+                _span.entered()
             }
         }
     }
@@ -32,7 +34,9 @@ macro_rules! debug_span {
 macro_rules! error {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
-        tracing::error!($($arg)+);
+        {
+            tracing::error!($($arg)+);
+        }
     }
 }
 
@@ -42,7 +46,7 @@ macro_rules! error_span {
             #[cfg(feature = "tracing")]
             {
                 let _span = tracing::error_span!($($arg)+);
-                _span.entered();
+                _span.entered()
             }
         }
     }
@@ -51,7 +55,9 @@ macro_rules! error_span {
 macro_rules! info {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
-        tracing::info!($($arg)+);
+        {
+            tracing::info!($($arg)+);
+        }
     }
 }
 
@@ -61,7 +67,7 @@ macro_rules! info_span {
             #[cfg(feature = "tracing")]
             {
                 let _span = tracing::info_span!($($arg)+);
-                _span.entered();
+                _span.entered()
             }
         }
     }
@@ -70,7 +76,9 @@ macro_rules! info_span {
 macro_rules! trace {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
-        tracing::trace!($($arg)+);
+        {
+            tracing::trace!($($arg)+);
+        }
     }
 }
 
@@ -80,7 +88,7 @@ macro_rules! trace_span {
             #[cfg(feature = "tracing")]
             {
                 let _span = tracing::trace_span!($($arg)+);
-                _span.entered();
+                _span.entered()
             }
         }
     }
@@ -92,7 +100,7 @@ macro_rules! span {
             #[cfg(feature = "tracing")]
             {
                 let _span = tracing::span!($($arg)+);
-                _span.entered();
+                _span.entered()
             }
         }
     }
@@ -101,7 +109,9 @@ macro_rules! span {
 macro_rules! warn {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
-        tracing::warn!($($arg)+);
+        {
+            tracing::warn!($($arg)+);
+        }
     }
 }
 
@@ -111,7 +121,7 @@ macro_rules! warn_span {
             #[cfg(feature = "tracing")]
             {
                 let _span = tracing::warn_span!($($arg)+);
-                _span.entered();
+                _span.entered()
             }
         }
     }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -2,33 +2,6 @@
 // even if they are not used at the present time.
 #![allow(unused_macros)]
 
-//! Internal Tracing macro module
-//!
-//! The [`trace`][crate::trace] module is an internal module that contains wrapper macros encapsulating
-//! [`tracing`][tracing]'s macros. These macros allow for conditional expansion of
-//! [`tracing`][tracing] macros during compilation when the `tracing` feature is enabled, or trimming
-//! them when the feature is disabled, all in a concise manner.
-//!
-//! The macros from the [`trace`][crate::trace] module are declared by default and can be used throughout the
-//! crate. However, as the contents of these macros are conditionally compiled, they are effectively trimmed
-//! during inline expansion when the `tracing` feature is disabled.
-//!
-//! # Unstable
-//!
-//! The [`tracing`][tracing] module is currenty **unstable**, hence the existence of this module. As a
-//! result, hyper's [`tracing`][tracing] logs are only accessibe if `--cfg hyper_unstable_tracing` is
-//! passed to `rustc` when compiling. The easiest way to do that is through setting the `RUSTFLAGS`
-//! enviornment variable.
-//!
-//! # Building
-//!  
-//! Enabling [`trace`][crate::trace] logs, can be done with the following `cargo` command, as of
-//! version `1.64.0`:
-//!
-//! ```notrust
-//! RUSTFLAGS="--cfg hyper_unstable_tracing" cargo rustc --features client,http1,http2,tracing --crate-type cdylib
-//! ```
-
 #[cfg(not(hyper_unstable_tracing))]
 compile_error!(
     "\

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,4 +1,33 @@
+// For completeness, wrappers around all of tracing's public macros are provided, even if they are
+// not used at the present time.
 #![allow(unused_macros)]
+
+//! Internal Tracing macro module
+//!
+//! The [`trace`][crate::trace] module is an internal module that contains wrapper macros encapsulating
+//! [`tracing`][tracing]'s macros. These macros allow for conditional expansion of
+//! [`tracing`][tracing] macros during compilation when the `tracing` feature is enabled, or trimming
+//! them when the feature is disabled, all in a concise manner.
+//!
+//! The macros from the [`trace`][crate::trace] module are declared by default and can be used throughout the
+//! crate. However, as the contents of these macros are conditionally compiled, they are effectively trimmed
+//! during inline expansion when the `tracing` feature is disabled.
+//!
+//! # Unstable
+//!
+//! The [`tracing`][tracing] module is currenty **unstable**, hence the existence of this module. As a
+//! result, hyper's [`tracing`][tracing] logs are only accessibe if `--cfg hyper_unstable_tracing` is
+//! passed to `rustc` when compiling. The easiest way to do that is through setting the `RUSTFLAGS`
+//! enviornment variable.
+//!
+//! # Building
+//!  
+//! Enabling [`trace`][crate::trace] logs, can be done with the following `cargo` command, as of
+//! version `1.64.0`:
+//!
+//! ```notrust
+//! RUSTFLAGS="--cfg hyper_unstable_tracing" cargo rustc --features client,http1,http2,tracing --crate-type cdylib
+//! ```
 
 macro_rules! debug {
     ($($arg:tt)+) => {

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,5 +1,5 @@
-// For completeness, wrappers around all of tracing's public macros are provided, even if they are
-// not used at the present time.
+// For completeness, wrappers around all of tracing's public logging and span macros are provided, 
+// even if they are not used at the present time.
 #![allow(unused_macros)]
 
 //! Internal Tracing macro module
@@ -29,35 +29,29 @@
 //! RUSTFLAGS="--cfg hyper_unstable_tracing" cargo rustc --features client,http1,http2,tracing --crate-type cdylib
 //! ```
 
+#[cfg(not(hyper_unstable_tracing))]
+compile_error!(
+    "\
+    The `tracing` feature is unstable, and requires the \
+    `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+    "
+    );
+
 macro_rules! debug {
     ($($arg:tt)+) => {
         #[cfg(feature = "tracing")]
-        {
-            #[cfg(not(hyper_unstable_tracing))]
-            compile_error!(
-                "\
-                The `tracing` feature is unstable, and requires the \
-                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-            "
-            );
-            tracing::debug!($($arg)+);
-        }
+        tracing::debug!($($arg)+);
     }
 }
 
 macro_rules! debug_span {
     ($($arg:tt)*) => {
-        #[cfg(feature = "tracing")]
         {
-            #[cfg(not(hyper_unstable_tracing))]
-            compile_error!(
-                "\
-                The `tracing` feature is unstable, and requires the \
-                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-            "
-            );
-            let span = tracing::debug_span!($($arg)+);
-            let _ = span.enter();
+            #[cfg(feature = "tracing")]
+            {
+                let _span = tracing::debug_span!($($arg)+);
+                _span.entered();
+            }
         }
     }
 }
@@ -65,32 +59,18 @@ macro_rules! debug_span {
 macro_rules! error {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
-        {
-            #[cfg(not(hyper_unstable_tracing))]
-            compile_error!(
-                "\
-                The `tracing` feature is unstable, and requires the \
-                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-            "
-            );
-            tracing::error!($($arg)+);
-        }
+        tracing::error!($($arg)+);
     }
 }
 
 macro_rules! error_span {
     ($($arg:tt)*) => {
-        #[cfg(feature = "tracing")]
         {
-            #[cfg(not(hyper_unstable_tracing))]
-            compile_error!(
-                "\
-                The `tracing` feature is unstable, and requires the \
-                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-            "
-            );
-            let span = tracing::error_span!($($arg)+);
-            let _ = span.enter();
+            #[cfg(feature = "tracing")]
+            {
+                let _span = tracing::error_span!($($arg)+);
+                _span.entered();
+            }
         }
     }
 }
@@ -98,32 +78,18 @@ macro_rules! error_span {
 macro_rules! info {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
-        {
-            #[cfg(not(hyper_unstable_tracing))]
-            compile_error!(
-                "\
-                The `tracing` feature is unstable, and requires the \
-                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-            "
-            );
-            tracing::info!($($arg)+);
-        }
+        tracing::info!($($arg)+);
     }
 }
 
 macro_rules! info_span {
     ($($arg:tt)*) => {
-        #[cfg(feature = "tracing")]
         {
-            #[cfg(not(hyper_unstable_tracing))]
-            compile_error!(
-                "\
-                The `tracing` feature is unstable, and requires the \
-                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-            "
-            );
-            let span = tracing::info_span!($($arg)+);
-            let _ = span.enter();
+            #[cfg(feature = "tracing")]
+            {
+                let _span = tracing::info_span!($($arg)+);
+                _span.entered();
+            }
         }
     }
 }
@@ -131,49 +97,30 @@ macro_rules! info_span {
 macro_rules! trace {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
-        {
-            #[cfg(not(hyper_unstable_tracing))]
-            compile_error!(
-                "\
-                The `tracing` feature is unstable, and requires the \
-                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-            "
-            );
-            tracing::trace!($($arg)+);
-        }
+        tracing::trace!($($arg)+);
     }
 }
 
 macro_rules! trace_span {
     ($($arg:tt)*) => {
-        #[cfg(feature = "tracing")]
         {
-            #[cfg(not(hyper_unstable_tracing))]
-            compile_error!(
-                "\
-                The `tracing` feature is unstable, and requires the \
-                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-            "
-            );
-            let span = tracing::trace_span!($($arg)+);
-            let _ = span.enter();
+            #[cfg(feature = "tracing")]
+            {
+                let _span = tracing::trace_span!($($arg)+);
+                _span.entered();
+            }
         }
     }
 }
 
 macro_rules! span {
     ($($arg:tt)*) => {
-        #[cfg(feature = "tracing")]
         {
-            #[cfg(not(hyper_unstable_tracing))]
-            compile_error!(
-                "\
-                The `tracing` feature is unstable, and requires the \
-                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-            "
-            );
-            let span = tracing::span!($($arg)+);
-            let _ = span.enter();
+            #[cfg(feature = "tracing")]
+            {
+                let _span = tracing::span!($($arg)+);
+                _span.entered();
+            }
         }
     }
 }
@@ -181,32 +128,18 @@ macro_rules! span {
 macro_rules! warn {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
-        {
-            #[cfg(not(hyper_unstable_tracing))]
-            compile_error!(
-                "\
-                The `tracing` feature is unstable, and requires the \
-                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-            "
-            );
-            tracing::warn!($($arg)+);
-        }
+        tracing::warn!($($arg)+);
     }
 }
 
 macro_rules! warn_span {
     ($($arg:tt)*) => {
-        #[cfg(feature = "tracing")]
         {
-            #[cfg(not(hyper_unstable_tracing))]
-            compile_error!(
-                "\
-                The `tracing` feature is unstable, and requires the \
-                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
-            "
-            );
-            let span = tracing::warn_span!($($arg)+);
-            let _ = span.enter();
+            #[cfg(feature = "tracing")]
+            {
+                let _span = tracing::warn_span!($($arg)+);
+                _span.entered();
+            }
         }
     }
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -4,7 +4,13 @@ macro_rules! debug {
     ($($arg:tt)+) => {
         #[cfg(feature = "tracing")]
         {
-            println!($($arg)+);
+            #[cfg(not(hyper_unstable_tracing))]
+            compile_error!(
+                "\
+                The `tracing` feature is unstable, and requires the \
+                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+            "
+            );
             tracing::debug!($($arg)+);
         }
     }
@@ -14,6 +20,13 @@ macro_rules! debug_span {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
         {
+            #[cfg(not(hyper_unstable_tracing))]
+            compile_error!(
+                "\
+                The `tracing` feature is unstable, and requires the \
+                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+            "
+            );
             let span = tracing::debug_span!($($arg)+);
             let _ = span.enter();
         }
@@ -24,6 +37,13 @@ macro_rules! error {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
         {
+            #[cfg(not(hyper_unstable_tracing))]
+            compile_error!(
+                "\
+                The `tracing` feature is unstable, and requires the \
+                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+            "
+            );
             tracing::error!($($arg)+);
         }
     }
@@ -33,6 +53,13 @@ macro_rules! error_span {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
         {
+            #[cfg(not(hyper_unstable_tracing))]
+            compile_error!(
+                "\
+                The `tracing` feature is unstable, and requires the \
+                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+            "
+            );
             let span = tracing::error_span!($($arg)+);
             let _ = span.enter();
         }
@@ -43,6 +70,13 @@ macro_rules! info {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
         {
+            #[cfg(not(hyper_unstable_tracing))]
+            compile_error!(
+                "\
+                The `tracing` feature is unstable, and requires the \
+                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+            "
+            );
             tracing::info!($($arg)+);
         }
     }
@@ -52,6 +86,13 @@ macro_rules! info_span {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
         {
+            #[cfg(not(hyper_unstable_tracing))]
+            compile_error!(
+                "\
+                The `tracing` feature is unstable, and requires the \
+                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+            "
+            );
             let span = tracing::info_span!($($arg)+);
             let _ = span.enter();
         }
@@ -62,6 +103,13 @@ macro_rules! trace {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
         {
+            #[cfg(not(hyper_unstable_tracing))]
+            compile_error!(
+                "\
+                The `tracing` feature is unstable, and requires the \
+                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+            "
+            );
             tracing::trace!($($arg)+);
         }
     }
@@ -71,6 +119,13 @@ macro_rules! trace_span {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
         {
+            #[cfg(not(hyper_unstable_tracing))]
+            compile_error!(
+                "\
+                The `tracing` feature is unstable, and requires the \
+                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+            "
+            );
             let span = tracing::trace_span!($($arg)+);
             let _ = span.enter();
         }
@@ -81,6 +136,13 @@ macro_rules! span {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
         {
+            #[cfg(not(hyper_unstable_tracing))]
+            compile_error!(
+                "\
+                The `tracing` feature is unstable, and requires the \
+                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+            "
+            );
             let span = tracing::span!($($arg)+);
             let _ = span.enter();
         }
@@ -91,6 +153,13 @@ macro_rules! warn {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
         {
+            #[cfg(not(hyper_unstable_tracing))]
+            compile_error!(
+                "\
+                The `tracing` feature is unstable, and requires the \
+                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+            "
+            );
             tracing::warn!($($arg)+);
         }
     }
@@ -100,6 +169,13 @@ macro_rules! warn_span {
     ($($arg:tt)*) => {
         #[cfg(feature = "tracing")]
         {
+            #[cfg(not(hyper_unstable_tracing))]
+            compile_error!(
+                "\
+                The `tracing` feature is unstable, and requires the \
+                `RUSTFLAGS='--cfg hyper_unstable_tracing'` environment variable to be set.\
+            "
+            );
             let span = tracing::warn_span!($($arg)+);
             let _ = span.enter();
         }

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -48,7 +48,7 @@ use std::marker::Unpin;
 use crate::rt::{Read, ReadBufCursor, Write};
 use bytes::Bytes;
 use tokio::sync::oneshot;
-#[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(all(any(feature = "http1", feature = "http2"), feature = "tracing"))]
 use tracing::trace;
 
 use crate::common::io::Rewind;
@@ -233,6 +233,7 @@ impl fmt::Debug for OnUpgrade {
 #[cfg(any(feature = "http1", feature = "http2"))]
 impl Pending {
     pub(super) fn fulfill(self, upgraded: Upgraded) {
+        #[cfg(feature = "tracing")]
         trace!("pending upgrade fulfill");
         let _ = self.tx.send(Ok(upgraded));
     }
@@ -241,6 +242,7 @@ impl Pending {
     /// Don't fulfill the pending Upgrade, but instead signal that
     /// upgrades are handled manually.
     pub(super) fn manual(self) {
+        #[cfg(feature = "tracing")]
         trace!("pending upgrade handled manually");
         let _ = self.tx.send(Err(crate::Error::new_user_manual_upgrade()));
     }

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -231,7 +231,6 @@ impl fmt::Debug for OnUpgrade {
 #[cfg(any(feature = "http1", feature = "http2"))]
 impl Pending {
     pub(super) fn fulfill(self, upgraded: Upgraded) {
-        #[cfg(any(feature = "http1", feature = "http2"))]
         trace!("pending upgrade fulfill");
         let _ = self.tx.send(Ok(upgraded));
     }

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -48,8 +48,6 @@ use std::marker::Unpin;
 use crate::rt::{Read, ReadBufCursor, Write};
 use bytes::Bytes;
 use tokio::sync::oneshot;
-#[cfg(all(any(feature = "http1", feature = "http2"), feature = "tracing"))]
-use tracing::trace;
 
 use crate::common::io::Rewind;
 use crate::common::{task, Future, Pin, Poll};
@@ -233,7 +231,7 @@ impl fmt::Debug for OnUpgrade {
 #[cfg(any(feature = "http1", feature = "http2"))]
 impl Pending {
     pub(super) fn fulfill(self, upgraded: Upgraded) {
-        #[cfg(feature = "tracing")]
+        #[cfg(any(feature = "http1", feature = "http2"))]
         trace!("pending upgrade fulfill");
         let _ = self.tx.send(Ok(upgraded));
     }
@@ -242,7 +240,7 @@ impl Pending {
     /// Don't fulfill the pending Upgrade, but instead signal that
     /// upgrades are handled manually.
     pub(super) fn manual(self) {
-        #[cfg(feature = "tracing")]
+        #[cfg(any(feature = "http1", feature = "http2"))]
         trace!("pending upgrade handled manually");
         let _ = self.tx.send(Err(crate::Error::new_user_manual_upgrade()));
     }


### PR DESCRIPTION
This change allow users to opt out of tracing via the `tracing` crate by adding tracing as an optional feature. This change is part of the effort, outlined in #2874, to reach hyper 1.0.

Closes #3319
BREAKING CHANGES: tracing is disabled by default and requires users to opt in to revert to previous behavior.

