### PR TITLE
chore(dependencies): reduce default dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,18 +26,18 @@ futures-util = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "=1.0.0-rc.2"
 http-body-util = { version = "=0.1.0-rc.3", optional = true }
-httpdate = "1.0"
 httparse = "1.8"
 h2 = { version = "0.3.9", optional = true }
 itoa = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 pin-project-lite = "0.2.4"
 tokio = { version = "1", features = ["sync"] }
-want = "0.3"
 
 # Optional
 
+httpdate = { version = "1.0", optional = true }
 libc = { version = "0.2", optional = true }
+want = { version = "0.3", optional = true }
 
 [dev-dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
@@ -78,8 +78,8 @@ http1 = []
 http2 = ["dep:h2"]
 
 # Client/Server
-client = []
-server = []
+client = ["dep:want"]
+server = ["dep:httpdate"]
 
 # C-API support (currently unstable (no semver))
 ffi = ["dep:libc", "dep:http-body-util"]


### PR DESCRIPTION
`httpdate` and `want` are used in some combinations of features. Although Cargo does not provide such a combined features configuration, the scopes could be reduced.