### PR TITLE
chore(ci): update ci config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -226,11 +226,9 @@ jobs:
           toolchain: nightly-2023-05-31  # Compatible version for cargo-check-external-types
 
       - name: Install cargo-check-external-types
-        uses: actions-rs/install@v0.1
+        uses: taiki-e/cache-cargo-install-action@v1
         with:
-          crate: cargo-check-external-types
-          version: 0.1.7
-          use-tool-cache: true
+          tool: cargo-check-external-types@0.1.7
 
       - name: check-external-types
         run: cargo check-external-types --config .github/workflows/external-types.toml


### PR DESCRIPTION
- Updates to `actions/checkout@v4` from version 3.
- Replaces `actions-rs/install` with `taiki-e/cache-cargo-install-action` as the former is not maintained and throws warnings.