### PR TITLE
chore(ci): update features job to skip `tracing` feature

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -144,7 +144,7 @@ jobs:
         uses: taiki-e/install-action@cargo-hack
 
       - name: check --feature-powerset
-        run: cargo hack check --feature-powerset --depth 2 --skip ffi -Z avoid-dev-deps
+        run: cargo hack check --feature-powerset --depth 2 --skip ffi,tracing -Z avoid-dev-deps
 
   ffi:
     name: Test C API (FFI)


### PR DESCRIPTION
Similar to ffi, the feature job will skip tracing as it is unstable and requires a cfg flag to compile without an error. Once #3326 is merged, subsequent PRs will fail the feature CI job without this change.

This PR should be merged before #3326 or directly after.

