### PR TITLE
refactor(ext): replace futures_util::Future with std::future::Future

### DIFF
--- a/benches/support/tokiort.rs
+++ b/benches/support/tokiort.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code)]
 //! Various runtimes for hyper
 use std::{
+    future::Future,
     pin::Pin,
     task::{Context, Poll},
     time::{Duration, Instant},
 };
 
-use futures_util::Future;
 use hyper::rt::{Sleep, Timer};
 use pin_project_lite::pin_project;
 

--- a/src/rt/timer.rs
+++ b/src/rt/timer.rs
@@ -3,12 +3,12 @@
 //! Example using tokio timer:
 //! ```rust
 //! use std::{
+//!     future::Future,
 //!     pin::Pin,
 //!     task::{Context, Poll},
 //!     time::{Duration, Instant},
 //! };
 //!
-//! use futures_util::Future;
 //! use pin_project_lite::pin_project;
 //! use hyper::rt::{Timer, Sleep};
 //!


### PR DESCRIPTION
`std::future::Future` could be used at these places.