### PR TITLE
chore(ci): use cargo-hack --no-dev-deps option to check without dev-dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -139,13 +139,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
       - name: check --feature-powerset
-        run: cargo hack check --feature-powerset --depth 2 --skip ffi,tracing -Z avoid-dev-deps
+        run: cargo hack --no-dev-deps check --feature-powerset --depth 2 --skip ffi,tracing
 
   ffi:
     name: Test C API (FFI)


### PR DESCRIPTION
`cargo-hack` has `--no-dev-deps` option to check without dev-dependencies. As this does not require nightly Rust version, the features checks are allowed to be performed with stable Rust by using this instead of `-Z avoid-dev-deps`.