### PR TITLE
refactor: resolve unused warning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -146,6 +146,8 @@ jobs:
 
       - name: check --feature-powerset
         run: cargo hack --no-dev-deps check --feature-powerset --depth 2 --skip ffi,tracing
+        env:
+          RUSTFLAGS: "-D dead_code -D unused_imports"
 
   ffi:
     name: Test C API (FFI)

--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -33,7 +33,7 @@ impl DecodedLength {
     /// Should only be called if previously confirmed this isn't
     /// CLOSE_DELIMITED or CHUNKED.
     #[inline]
-    #[cfg(feature = "http1")]
+    #[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
     pub(crate) fn danger_len(self) -> u64 {
         debug_assert!(self.0 < Self::CHUNKED.0);
         self.0
@@ -72,7 +72,7 @@ impl DecodedLength {
     /// This includes 0, which of course is an exact known length.
     ///
     /// It would return false if "chunked" or otherwise size-unknown.
-    #[cfg(feature = "http2")]
+    #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
     pub(crate) fn is_exact(&self) -> bool {
         self.0 <= MAX_LEN
     }

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -26,7 +26,7 @@ pub use http_body::SizeHint;
 
 pub use self::incoming::Incoming;
 
-#[cfg(feature = "http1")]
+#[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
 pub(crate) use self::incoming::Sender;
 pub(crate) use self::length::DecodedLength;
 

--- a/src/common/buf.rs
+++ b/src/common/buf.rs
@@ -21,7 +21,6 @@ impl<T: Buf> BufList<T> {
     }
 
     #[inline]
-    #[cfg(feature = "http1")]
     pub(crate) fn bufs_cnt(&self) -> usize {
         self.bufs.len()
     }

--- a/src/common/io/mod.rs
+++ b/src/common/io/mod.rs
@@ -1,7 +1,7 @@
-#[cfg(any(feature = "http2", test))]
+#[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
 mod compat;
 mod rewind;
 
-#[cfg(any(feature = "http2", test))]
+#[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
 pub(crate) use self::compat::{compat, Compat};
 pub(crate) use self::rewind::Rewind;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -7,6 +7,7 @@ macro_rules! ready {
     };
 }
 
+#[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
 pub(crate) mod buf;
 #[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 pub(crate) mod date;
@@ -14,14 +15,14 @@ pub(crate) mod date;
 pub(crate) mod exec;
 pub(crate) mod io;
 pub(crate) mod task;
-#[cfg(any(feature = "http1", feature = "http2", feature = "server"))]
+#[cfg(any(
+    all(feature = "server", feature = "http1"),
+    all(any(feature = "client", feature = "server"), feature = "http2"),
+))]
 pub(crate) mod time;
 pub(crate) mod watch;
 
 pub(crate) use self::task::Poll;
 
 // group up types normally needed for `Future`
-cfg_proto! {
-    pub(crate) use std::marker::Unpin;
-}
 pub(crate) use std::{future::Future, pin::Pin};

--- a/src/common/task.rs
+++ b/src/common/task.rs
@@ -1,12 +1,10 @@
-#[cfg(feature = "http1")]
-use std::convert::Infallible;
 pub(crate) use std::task::{Context, Poll};
 
 /// A function to help "yield" a future, such that it is re-scheduled immediately.
 ///
 /// Useful for spin counts, so a future doesn't hog too much time.
-#[cfg(feature = "http1")]
-pub(crate) fn yield_now(cx: &mut Context<'_>) -> Poll<Infallible> {
+#[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
+pub(crate) fn yield_now(cx: &mut Context<'_>) -> Poll<std::convert::Infallible> {
     cx.waker().wake_by_ref();
     Poll::Pending
 }

--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -1,8 +1,7 @@
+#[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
+use std::time::Duration;
 use std::{fmt, sync::Arc};
-use std::{
-    pin::Pin,
-    time::{Duration, Instant},
-};
+use std::{pin::Pin, time::Instant};
 
 use crate::rt::Sleep;
 use crate::rt::Timer;
@@ -55,6 +54,7 @@ impl<F> Future for HyperTimeout<F> where F: Future {
 */
 
 impl Time {
+    #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
     pub(crate) fn sleep(&self, duration: Duration) -> Pin<Box<dyn Sleep>> {
         match *self {
             Time::Empty => {
@@ -64,6 +64,7 @@ impl Time {
         }
     }
 
+    #[cfg(feature = "http1")]
     pub(crate) fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Sleep>> {
         match *self {
             Time::Empty => {

--- a/src/ext/h1_reason_phrase.rs
+++ b/src/ext/h1_reason_phrase.rs
@@ -55,6 +55,7 @@ impl ReasonPhrase {
     ///
     /// Use with care; invalid bytes in a reason phrase can cause serious security problems if
     /// emitted in a response.
+    #[cfg(feature = "client")]
     pub(crate) fn from_bytes_unchecked(reason: Bytes) -> Self {
         Self(reason)
     }

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::io;
-use std::marker::PhantomData;
+use std::marker::{PhantomData, Unpin};
 #[cfg(feature = "server")]
 use std::time::Duration;
 
@@ -15,7 +15,7 @@ use super::{Decoder, Encode, EncodedBuf, Encoder, Http1Transaction, ParseContext
 use crate::body::DecodedLength;
 #[cfg(feature = "server")]
 use crate::common::time::Time;
-use crate::common::{task, Pin, Poll, Unpin};
+use crate::common::{task, Pin, Poll};
 use crate::headers::connection_keep_alive;
 use crate::proto::{BodyLength, MessageHead};
 #[cfg(feature = "server")]

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -1,4 +1,4 @@
-use std::error::Error as StdError;
+use std::{error::Error as StdError, marker::Unpin};
 
 use crate::rt::{Read, Write};
 use bytes::{Buf, Bytes};
@@ -6,7 +6,7 @@ use http::Request;
 
 use super::{Http1Transaction, Wants};
 use crate::body::{Body, DecodedLength, Incoming as IncomingBody};
-use crate::common::{task, Future, Pin, Poll, Unpin};
+use crate::common::{task, Future, Pin, Poll};
 use crate::proto::{BodyLength, Conn, Dispatched, MessageHead, RequestHead};
 use crate::upgrade::OnUpgrade;
 

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1,13 +1,17 @@
-use std::fmt::{self, Write};
-use std::mem::MaybeUninit;
+use std::{fmt, mem::MaybeUninit};
+
+#[cfg(feature = "client")]
+use std::fmt::Write;
 #[cfg(feature = "server")]
 use std::time::Instant;
 
 use bytes::Bytes;
 use bytes::BytesMut;
+#[cfg(feature = "client")]
+use http::header::Entry;
 #[cfg(feature = "server")]
 use http::header::ValueIter;
-use http::header::{self, Entry, HeaderName, HeaderValue};
+use http::header::{self, HeaderName, HeaderValue};
 use http::{HeaderMap, Method, StatusCode, Version};
 
 use crate::body::DecodedLength;
@@ -21,7 +25,9 @@ use crate::headers;
 use crate::proto::h1::{
     Encode, Encoder, Http1Transaction, ParseContext, ParseResult, ParsedMessage,
 };
-use crate::proto::{BodyLength, MessageHead, RequestHead, RequestLine};
+#[cfg(feature = "client")]
+use crate::proto::RequestHead;
+use crate::proto::{BodyLength, MessageHead, RequestLine};
 
 const MAX_HEADERS: usize = 100;
 const AVERAGE_HEADER_SIZE: usize = 30; // totally scientific
@@ -1392,6 +1398,7 @@ impl Client {
     }
 }
 
+#[cfg(feature = "client")]
 fn set_content_length(headers: &mut HeaderMap, len: u64) -> Encoder {
     // At this point, there should not be a valid Content-Length
     // header. However, since we'll be indexing in anyways, we can
@@ -1478,6 +1485,7 @@ fn title_case(dst: &mut Vec<u8>, name: &[u8]) {
     }
 }
 
+#[cfg(feature = "client")]
 fn write_headers_title_case(headers: &HeaderMap, dst: &mut Vec<u8>) {
     for (name, value) in headers {
         title_case(dst, name.as_str().as_bytes());
@@ -1487,6 +1495,7 @@ fn write_headers_title_case(headers: &HeaderMap, dst: &mut Vec<u8>) {
     }
 }
 
+#[cfg(feature = "client")]
 fn write_headers(headers: &HeaderMap, dst: &mut Vec<u8>) {
     for (name, value) in headers {
         extend(dst, name.as_str().as_bytes());
@@ -1497,6 +1506,7 @@ fn write_headers(headers: &HeaderMap, dst: &mut Vec<u8>) {
 }
 
 #[cold]
+#[cfg(feature = "client")]
 fn write_headers_original_case(
     headers: &HeaderMap,
     orig_case: &HeaderCaseMap,

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -17,6 +17,7 @@ cfg_feature! {
 pub(crate) mod h2;
 
 /// An Incoming Message head. Includes request/status line, and headers.
+#[cfg(any(feature = "http1"))]
 #[derive(Debug, Default)]
 pub(crate) struct MessageHead<S> {
     /// HTTP version of the message.
@@ -59,6 +60,7 @@ pub(crate) enum Dispatched {
     Upgrade(crate::upgrade::Pending),
 }
 
+#[cfg(all(feature = "client", feature = "http1"))]
 impl MessageHead<http::StatusCode> {
     fn into_response<B>(self, body: B) -> http::Response<B> {
         let mut res = http::Response::new(body);

--- a/src/rt/io.rs
+++ b/src/rt/io.rs
@@ -176,21 +176,25 @@ impl<'data> ReadBuf<'data> {
     }
 
     #[inline]
+    #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
     pub(crate) unsafe fn set_init(&mut self, n: usize) {
         self.init = self.init.max(n);
     }
 
     #[inline]
+    #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
     pub(crate) unsafe fn set_filled(&mut self, n: usize) {
         self.filled = self.filled.max(n);
     }
 
     #[inline]
+    #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
     pub(crate) fn len(&self) -> usize {
         self.filled
     }
 
     #[inline]
+    #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
     pub(crate) fn init_len(&self) -> usize {
         self.init
     }

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -2,6 +2,7 @@
 
 use std::error::Error as StdError;
 use std::fmt;
+use std::marker::Unpin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -9,7 +10,7 @@ use crate::rt::{Read, Write};
 use bytes::Bytes;
 
 use crate::body::{Body, Incoming as IncomingBody};
-use crate::common::{task, Future, Pin, Poll, Unpin};
+use crate::common::{task, Future, Pin, Poll};
 use crate::proto;
 use crate::service::HttpService;
 use crate::{common::time::Time, rt::Timer};

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -2,6 +2,7 @@
 
 use std::error::Error as StdError;
 use std::fmt;
+use std::marker::Unpin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -9,7 +10,7 @@ use crate::rt::{Read, Write};
 use pin_project_lite::pin_project;
 
 use crate::body::{Body, Incoming as IncomingBody};
-use crate::common::{task, Future, Pin, Poll, Unpin};
+use crate::common::{task, Future, Pin, Poll};
 use crate::proto;
 use crate::rt::bounds::Http2ConnExec;
 use crate::service::HttpService;

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -103,12 +103,18 @@ pub fn on<T: sealed::CanUpgrade>(msg: T) -> OnUpgrade {
     msg.on_upgrade()
 }
 
-#[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(all(
+    any(feature = "client", feature = "server"),
+    any(feature = "http1", feature = "http2"),
+))]
 pub(super) struct Pending {
     tx: oneshot::Sender<crate::Result<Upgraded>>,
 }
 
-#[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(all(
+    any(feature = "client", feature = "server"),
+    any(feature = "http1", feature = "http2"),
+))]
 pub(super) fn pending() -> (Pending, OnUpgrade) {
     let (tx, rx) = oneshot::channel();
     (Pending { tx }, OnUpgrade { rx: Some(rx) })
@@ -117,7 +123,10 @@ pub(super) fn pending() -> (Pending, OnUpgrade) {
 // ===== impl Upgraded =====
 
 impl Upgraded {
-    #[cfg(any(feature = "http1", feature = "http2", test))]
+    #[cfg(all(
+        any(feature = "client", feature = "server"),
+        any(feature = "http1", feature = "http2")
+    ))]
     pub(super) fn new<T>(io: T, read_buf: Bytes) -> Self
     where
         T: Read + Write + Unpin + Send + 'static,
@@ -199,7 +208,7 @@ impl OnUpgrade {
         OnUpgrade { rx: None }
     }
 
-    #[cfg(feature = "http1")]
+    #[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
     pub(super) fn is_none(&self) -> bool {
         self.rx.is_none()
     }
@@ -228,7 +237,10 @@ impl fmt::Debug for OnUpgrade {
 
 // ===== impl Pending =====
 
-#[cfg(any(feature = "http1", feature = "http2"))]
+#[cfg(all(
+    any(feature = "client", feature = "server"),
+    any(feature = "http1", feature = "http2")
+))]
 impl Pending {
     pub(super) fn fulfill(self, upgraded: Upgraded) {
         trace!("pending upgrade fulfill");


### PR DESCRIPTION
Adds `cfg` feature attributes to resolve unused warnings, which occur in each features and the combinations, and ci config to check `unused_imports` and `dead_code`.