### PR TITLE
Upgrade minimum tokio to 1.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "=1.0.0-rc.2"
 pin-project-lite = "0.2.4"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1.13", features = ["sync"] }
 
 # Optional
 


### PR DESCRIPTION
This is for `tokio::sync::watch::Sender::send_replace` as introduced in https://github.com/tokio-rs/tokio/commit/dee3236c97b5502290046b9d677e108089188a9e and fixes https://github.com/hyperium/hyper/issues/3195