### PR TITLE
refactor(lib): resolve FIXME messages

### DIFF
--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -107,8 +107,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    // FIXME: re-implement tests with `async/await`, this import should
-    // trigger a warning to remind us
     use super::super::compat;
     use super::Rewind;
     use bytes::Bytes;


### PR DESCRIPTION
Remove outdated FIXME comments, and resolve FIXME regarding usage of `MaybeUninit`.

Since hyper's MSRV is higher now, we can use some new stabilized apis. I also removed some `unsafe` blocks related to `MaybeUninit` usage.