### PR TITLE
chore(dependencies): relax minimum tokio version to 1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,6 +26,7 @@ jobs:
       - doc
       - check-external-types
       - udeps
+      - minimal-versions
     steps:
       - run: exit 0
 
@@ -272,3 +273,16 @@ jobs:
 
       - name: Check unused dependencies on full features
         run: cargo udeps --features full
+
+  minimal-versions:
+    runs-on: ubuntu-latest
+    needs: [style]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo minimal-versions check
+      - run: cargo minimal-versions check --features full

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = { version = "0.3", default-features = false }
 http = "1"
 http-body = "1"
 pin-project-lite = "0.2.4"
-tokio = { version = "1.13", features = ["sync"] }
+tokio = { version = "1", features = ["sync"] }
 
 # Optional
 


### PR DESCRIPTION
This pull request reverts #3345. #3195 is about 0.14.25 and `tokio::sync::watch::Sender::send_replace` seems not to be used in this branch.