### PR TITLE
chore(ci): cache rust dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,6 +83,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Test
         run: cargo test ${{ matrix.features }}
 
@@ -109,6 +111,8 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Check
         run: cargo check --features full
 
@@ -125,6 +129,8 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Test
         # Can't enable tcp feature since Miri does not support the tokio runtime
@@ -144,6 +150,8 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: check --feature-powerset
         run: cargo hack --no-dev-deps check --feature-powerset --depth 2 --skip ffi,tracing
         env:
@@ -159,6 +167,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Build FFI
         env:
@@ -193,6 +203,8 @@ jobs:
         with:
           tool: cargo-expand
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Build FFI
         env:
           RUSTFLAGS: --cfg hyper_unstable_ffi
@@ -211,6 +223,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@nightly
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: cargo doc
         run: cargo rustdoc --features full,ffi -- --cfg docsrs --cfg hyper_unstable_ffi -D broken-intra-doc-links
@@ -233,6 +247,8 @@ jobs:
         with:
           tool: cargo-check-external-types@0.1.7
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: check-external-types
         run: cargo check-external-types --config .github/workflows/external-types.toml
 
@@ -248,6 +264,8 @@ jobs:
 
       - name: Install cargo-udeps
         uses: taiki-e/install-action@cargo-udeps
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: Check unused dependencies on default features
         run: cargo udeps


### PR DESCRIPTION
Adds `Swatinem/rust-cache` to cache rust dependencies to improve the CI efficiency.