### PR TITLE
fix(http): divide by zero error when dividing duration by scalar

### DIFF
--- a/src/client/connect/http.rs
+++ b/src/client/connect/http.rs
@@ -521,7 +521,7 @@ struct ConnectingTcpRemote {
 
 impl ConnectingTcpRemote {
     fn new(addrs: dns::SocketAddrs, connect_timeout: Option<Duration>) -> Self {
-        let connect_timeout = connect_timeout.map(|t| t / (addrs.len() as u32));
+        let connect_timeout = connect_timeout.map(|t| t.checked_div(addrs.len() as f32))
 
         Self {
             addrs,


### PR DESCRIPTION
Consider addrs length is 0.

From issue: https://github.com/seanmonstar/reqwest/issues/2003