### PR TITLE
refactor(common): replace hyper::common::ready with futures_util::ready

### DIFF
--- a/src/body/incoming.rs
+++ b/src/body/incoming.rs
@@ -7,6 +7,11 @@ use std::task::{Context, Poll};
 use bytes::Bytes;
 #[cfg(all(feature = "http1", any(feature = "client", feature = "server")))]
 use futures_channel::{mpsc, oneshot};
+#[cfg(all(
+    any(feature = "http1", feature = "http2"),
+    any(feature = "client", feature = "server")
+))]
+use futures_util::ready;
 #[cfg(all(feature = "http1", any(feature = "client", feature = "server")))]
 use futures_util::{stream::FusedStream, Stream}; // for mpsc::Receiver
 #[cfg(all(feature = "http1", any(feature = "client", feature = "server")))]

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -8,6 +8,7 @@ use std::task::{Context, Poll};
 
 use crate::rt::{Read, Write};
 use bytes::Bytes;
+use futures_util::ready;
 use http::{Request, Response};
 use httparse::ParserConfig;
 

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -10,6 +10,7 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use crate::rt::{Read, Write};
+use futures_util::ready;
 use http::{Request, Response};
 
 use super::super::dispatch;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,16 +1,3 @@
-#[cfg(all(
-    any(feature = "client", feature = "server"),
-    any(feature = "http1", feature = "http2")
-))]
-macro_rules! ready {
-    ($e:expr) => {
-        match $e {
-            std::task::Poll::Ready(v) => v,
-            std::task::Poll::Pending => return std::task::Poll::Pending,
-        }
-    };
-}
-
 #[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
 pub(crate) mod buf;
 #[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,8 @@ mod cfg;
 #[macro_use]
 mod trace;
 
-#[macro_use]
-mod common;
 pub mod body;
+mod common;
 mod error;
 pub mod ext;
 #[cfg(test)]

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 use crate::rt::{Read, Write};
 use bytes::{Buf, Bytes};
+use futures_util::ready;
 use http::header::{HeaderValue, CONNECTION, TE};
 use http::{HeaderMap, Method, Version};
 use httparse::ParserConfig;

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -5,6 +5,7 @@ use std::task::{Context, Poll};
 use std::usize;
 
 use bytes::Bytes;
+use futures_util::ready;
 
 use super::io::MemRead;
 use super::DecodedLength;

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -8,6 +8,7 @@ use std::{
 
 use crate::rt::{Read, Write};
 use bytes::{Buf, Bytes};
+use futures_util::ready;
 use http::Request;
 
 use super::{Http1Transaction, Wants};

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -10,6 +10,7 @@ use std::task::{Context, Poll};
 
 use crate::rt::{Read, ReadBuf, Write};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+use futures_util::ready;
 
 use super::{Http1Transaction, ParseContext, ParsedMessage};
 use crate::common::buf::BufList;

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -12,6 +12,7 @@ use bytes::Bytes;
 use futures_channel::mpsc::{Receiver, Sender};
 use futures_channel::{mpsc, oneshot};
 use futures_util::future::{Either, FusedFuture, FutureExt as _};
+use futures_util::ready;
 use futures_util::stream::{StreamExt as _, StreamFuture};
 use h2::client::{Builder, Connection, SendRequest};
 use h2::SendStream;

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use bytes::{Buf, Bytes};
+use futures_util::ready;
 use h2::{Reason, RecvStream, SendStream};
 use http::header::{HeaderName, CONNECTION, TE, TRAILER, TRANSFER_ENCODING, UPGRADE};
 use http::HeaderMap;

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -6,6 +6,7 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use bytes::Bytes;
+use futures_util::ready;
 use h2::server::{Connection, Handshake, SendResponse};
 use h2::{Reason, RecvStream};
 use http::{Method, Request};

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use crate::rt::{Read, Write};
 use crate::upgrade::Upgraded;
 use bytes::Bytes;
+use futures_util::ready;
 
 use crate::body::{Body, Incoming as IncomingBody};
 use crate::proto;

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -10,6 +10,7 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use crate::rt::{Read, Write};
+use futures_util::ready;
 use pin_project_lite::pin_project;
 
 use crate::body::{Body, Incoming as IncomingBody};


### PR DESCRIPTION
`hyper` seems to be able to use `futures_util::ready`, instead of defining `hyper`'s own `ready` macro.