### PR TITLE
fix(client): panic when pool idle timeout set to zero

### DIFF
--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -113,7 +113,7 @@ impl<T> Pool<T> {
                 waiters: HashMap::new(),
                 #[cfg(feature = "runtime")]
                 exec: __exec.clone(),
-                timeout: config.idle_timeout,
+                timeout: config.idle_timeout.filter(|&t| t > Duration::ZERO),
             })))
         } else {
             None


### PR DESCRIPTION
From issue: https://github.com/hyperium/hyper/issues/2997

Test Example:
```rust
#![deny(warnings)]
#![warn(rust_2018_idioms)]

use hyper::body::Buf;
use serde::Deserialize;

// A simple type alias so as to DRY.
type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;

#[tokio::main]
async fn main() -> Result<()> {
    let url = "http://jsonplaceholder.typicode.com/users".parse().unwrap();
    let users = fetch_json(url).await?;
    // print users
    println!("users: {:#?}", users);

    // print the sum of ids
    let sum = users.iter().fold(0, |acc, user| acc + user.id);
    println!("sum of ids: {}", sum);
    Ok(())
}

async fn fetch_json(url: hyper::Uri) -> Result<Vec<User>> {
    let client = hyper::client::Builder::default()
        .pool_idle_timeout(Some(std::time::Duration::ZERO))
        .build_http::<hyper::Body>();

    // Fetch the url...
    let res = client.get(url).await?;

    // asynchronously aggregate the chunks of the body
    let body = hyper::body::aggregate(res).await?;

    // try to parse as json with serde_json
    let users = serde_json::from_reader(body.reader())?;

    Ok(users)
}

#[derive(Deserialize, Debug)]
struct User {
    id: i32,
    #[allow(unused)]
    name: String,
}

```