### PR TITLE
Update http dep to 0.2.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 bytes = "1"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
-http = "0.2"
+http = "0.2.7"
 http-body = "=1.0.0-rc.2"
 pin-project-lite = "0.2.4"
 tokio = { version = "1.13", features = ["sync"] }


### PR DESCRIPTION
This is required to use HeaderName::from_static in a const.

Without this, I was getting the following error:

```
RUSTFLAGS="--cfg hyper_unstable_ffi" cargo rustc --features client,http1,http2,ffi --crate-type cdylib
...
error[E0015]: cannot call non-const fn `http::header::HeaderName::from_static` in constants
  --> src/proto/h2/mod.rs:39:5
   |
39 |     HeaderName::from_static("keep-alive"),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: calls in constants are limited to constant functions, tuple structs and tuple variants

error[E0015]: cannot call non-const fn `http::header::HeaderName::from_static` in constants
  --> src/proto/h2/mod.rs:40:5
   |
40 |     HeaderName::from_static("proxy-connection"),
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: calls in constants are limited to constant functions, tuple structs and tuple variants
```

I suspect part of the reason I was getting this error is that I had a development directory sitting around from months ago, meaning the Cargo.lock was pinning an older version of `http`.

https://github.com/hyperium/http/compare/v0.2.6..v0.2.7