### PR TITLE
chore(dependencies): use form_urlencoded crate directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tracing = { version = "0.1", default-features = false, features = ["std"], optio
 want = { version = "0.3", optional = true }
 
 [dev-dependencies]
+form_urlencoded = "1"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 http-body-util = "=0.1.0-rc.3"
 pretty_env_logger = "0.5"
@@ -59,7 +60,6 @@ tokio = { version = "1", features = [
     "test-util",
 ] }
 tokio-test = "0.4"
-url = "2.2"
 
 [features]
 # Nothing by default

--- a/examples/params.rs
+++ b/examples/params.rs
@@ -11,7 +11,6 @@ use tokio::net::TcpListener;
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::SocketAddr;
-use url::form_urlencoded;
 
 #[path = "../benches/support/mod.rs"]
 mod support;


### PR DESCRIPTION
As `hyper`'s example uses `url` crate just for the re-exported `form_urlencoded`, seems to be able to use it directly.