### PR TITLE
chore(dependencies): remove libc crate from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ http-body-util = { version = "0.1", optional = true }
 httparse = { version = "1.8", optional = true }
 httpdate = { version = "1.0", optional = true }
 itoa = { version = "1", optional = true }
-libc = { version = "0.2", optional = true }
 pin-project-lite = { version = "0.2.4", optional = true }
 smallvec = { version = "1.12", features = ["const_generics", "const_new"], optional = true }
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
@@ -85,7 +84,7 @@ client = ["dep:want", "dep:pin-project-lite", "dep:smallvec"]
 server = ["dep:httpdate", "dep:pin-project-lite", "dep:smallvec"]
 
 # C-API support (currently unstable (no semver))
-ffi = ["dep:libc", "dep:http-body-util", "futures-util?/alloc"]
+ffi = ["dep:http-body-util", "futures-util?/alloc"]
 
 # Utilize tracing (currently unstable)
 tracing = ["dep:tracing"]

--- a/src/ffi/body.rs
+++ b/src/ffi/body.rs
@@ -1,14 +1,14 @@
-use std::ffi::c_void;
+use std::ffi::{c_int, c_void};
 use std::mem::ManuallyDrop;
 use std::ptr;
 use std::task::{Context, Poll};
 
 use http_body_util::BodyExt as _;
-use libc::{c_int, size_t};
 
 use super::task::{hyper_context, hyper_task, hyper_task_return_type, AsTaskType};
 use super::{UserDataPointer, HYPER_ITER_CONTINUE};
 use crate::body::{Bytes, Frame, Incoming as IncomingBody};
+use crate::ffi::size_t;
 
 /// A streaming HTTP body.
 ///

--- a/src/ffi/client.rs
+++ b/src/ffi/client.rs
@@ -1,7 +1,6 @@
+use std::ffi::c_int;
 use std::ptr;
 use std::sync::Arc;
-
-use libc::c_int;
 
 use crate::client::conn;
 use crate::rt::Executor as _;

--- a/src/ffi/error.rs
+++ b/src/ffi/error.rs
@@ -1,4 +1,4 @@
-use libc::size_t;
+use crate::ffi::size_t;
 
 /// A more detailed error object returned by some hyper functions.
 ///

--- a/src/ffi/http_types.rs
+++ b/src/ffi/http_types.rs
@@ -1,6 +1,6 @@
+use std::ffi::{c_int, c_void};
+
 use bytes::Bytes;
-use libc::{c_int, size_t};
-use std::ffi::c_void;
 
 use super::body::hyper_body;
 use super::error::hyper_code;
@@ -8,6 +8,7 @@ use super::task::{hyper_task_return_type, AsTaskType};
 use super::{UserDataPointer, HYPER_ITER_CONTINUE};
 use crate::body::Incoming as IncomingBody;
 use crate::ext::{HeaderCaseMap, OriginalHeaderOrder, ReasonPhrase};
+use crate::ffi::size_t;
 use crate::header::{HeaderName, HeaderValue};
 use crate::{HeaderMap, Method, Request, Response, Uri};
 

--- a/src/ffi/io.rs
+++ b/src/ffi/io.rs
@@ -2,10 +2,9 @@ use std::ffi::c_void;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::rt::{Read, Write};
-use libc::size_t;
-
 use super::task::hyper_context;
+use crate::ffi::size_t;
+use crate::rt::{Read, Write};
 
 /// Sentinel value to return from a read or write callback that the operation
 /// is pending.

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -62,19 +62,19 @@ pub use self::io::*;
 pub use self::task::*;
 
 /// Return in iter functions to continue iterating.
-pub const HYPER_ITER_CONTINUE: libc::c_int = 0;
+pub const HYPER_ITER_CONTINUE: std::ffi::c_int = 0;
 /// Return in iter functions to stop iterating.
 #[allow(unused)]
-pub const HYPER_ITER_BREAK: libc::c_int = 1;
+pub const HYPER_ITER_BREAK: std::ffi::c_int = 1;
 
 /// An HTTP Version that is unspecified.
-pub const HYPER_HTTP_VERSION_NONE: libc::c_int = 0;
+pub const HYPER_HTTP_VERSION_NONE: std::ffi::c_int = 0;
 /// The HTTP/1.0 version.
-pub const HYPER_HTTP_VERSION_1_0: libc::c_int = 10;
+pub const HYPER_HTTP_VERSION_1_0: std::ffi::c_int = 10;
 /// The HTTP/1.1 version.
-pub const HYPER_HTTP_VERSION_1_1: libc::c_int = 11;
+pub const HYPER_HTTP_VERSION_1_1: std::ffi::c_int = 11;
 /// The HTTP/2 version.
-pub const HYPER_HTTP_VERSION_2: libc::c_int = 20;
+pub const HYPER_HTTP_VERSION_2: std::ffi::c_int = 20;
 
 #[derive(Clone)]
 struct UserDataPointer(*mut std::ffi::c_void);
@@ -87,9 +87,13 @@ unsafe impl Sync for UserDataPointer {}
 /// cbindgen:ignore
 static VERSION_CSTR: &str = concat!(env!("CARGO_PKG_VERSION"), "\0");
 
+// `core::ffi::c_size_t` is a nightly-only experimental API.
+// https://github.com/rust-lang/rust/issues/88345
+type size_t = usize;
+
 ffi_fn! {
     /// Returns a static ASCII (null terminated) string of the hyper version.
-    fn hyper_version() -> *const libc::c_char {
+    fn hyper_version() -> *const std::ffi::c_char {
         VERSION_CSTR.as_ptr() as _
     } ?= std::ptr::null()
 }

--- a/src/ffi/task.rs
+++ b/src/ffi/task.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_void;
+use std::ffi::{c_int, c_void};
 use std::future::Future;
 use std::pin::Pin;
 use std::ptr;
@@ -9,7 +9,6 @@ use std::sync::{
 use std::task::{Context, Poll};
 
 use futures_util::stream::{FuturesUnordered, Stream};
-use libc::c_int;
 
 use super::error::hyper_code;
 use super::UserDataPointer;


### PR DESCRIPTION
`hyper` uses `libc` in `ffi` feature for the C language's type aliases. As `hyper`'s `ffi` feature is an unstable feature, `hyper` could use these types via `std::ffi` which require Rust 1.64, except for `c_size_t` which is a nightly only API. As `libc::size_t` and `core::ffi::c_size_t` are both defined as `usize`, this type might be able to be defined as type alias in `hyper` until it stabilizes.