### PR TITLE
chore(lib): fix lint error

### DIFF
--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -448,6 +448,7 @@ pub(super) mod sealed {
         fn connect(self, internal_only: Internal, dst: Uri) -> <Self::_Svc as ConnectSvc>::Future;
     }
 
+    #[allow(unreachable_pub)]
     pub trait ConnectSvc {
         type Connection: AsyncRead + AsyncWrite + Connection + Unpin + Send + 'static;
         type Error: Into<Box<dyn StdError + Send + Sync>>;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -13,7 +13,9 @@ use hyper::{Body, Client, Request, Response, Server, Version};
 pub use futures_util::{
     future, FutureExt as _, StreamExt as _, TryFutureExt as _, TryStreamExt as _,
 };
-pub use hyper::{ext::Protocol, http::Extensions, HeaderMap, StatusCode};
+pub use hyper::{ext::Protocol, HeaderMap};
+#[allow(unused_imports)]
+pub use hyper::{http::Extensions, StatusCode};
 pub use std::net::SocketAddr;
 
 #[allow(unused_macros)]


### PR DESCRIPTION
Fixes the lint errors for the nightly Rust, which occurred in #3384.