### PR TITLE
refactor(common): remove common re-export

### DIFF
--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -61,9 +61,13 @@ pub mod http2;
 
 use std::error::Error as StdError;
 use std::fmt;
+use std::future::Future;
 #[cfg(not(all(feature = "http1", feature = "http2")))]
 use std::marker::PhantomData;
+use std::marker::Unpin;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 #[cfg(all(feature = "runtime", feature = "http2"))]
 use std::time::Duration;
 
@@ -77,12 +81,9 @@ use tracing::{debug, trace};
 
 use super::dispatch;
 use crate::body::HttpBody;
+use crate::common::exec::{BoxSendFuture, Exec};
 #[cfg(not(all(feature = "http1", feature = "http2")))]
 use crate::common::Never;
-use crate::common::{
-    exec::{BoxSendFuture, Exec},
-    task, Future, Pin, Poll,
-};
 use crate::proto;
 use crate::rt::Executor;
 #[cfg(feature = "http1")]
@@ -257,7 +258,7 @@ impl<B> SendRequest<B> {
     /// Polls to determine whether this sender can be used yet for a request.
     ///
     /// If the associated connection is closed, this returns an Error.
-    pub fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<crate::Result<()>> {
+    pub fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
         self.dispatch.poll_ready(cx)
     }
 
@@ -381,7 +382,7 @@ where
     type Error = crate::Error;
     type Future = ResponseFuture;
 
-    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.poll_ready(cx)
     }
 
@@ -502,7 +503,7 @@ where
     /// Use [`poll_fn`](https://docs.rs/futures/0.1.25/futures/future/fn.poll_fn.html)
     /// and [`try_ready!`](https://docs.rs/futures/0.1.25/futures/macro.try_ready.html)
     /// to work with this function; or use the `without_shutdown` wrapper.
-    pub fn poll_without_shutdown(&mut self, cx: &mut task::Context<'_>) -> Poll<crate::Result<()>> {
+    pub fn poll_without_shutdown(&mut self, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
         match *self.inner.as_mut().expect("already upgraded") {
             #[cfg(feature = "http1")]
             ProtoClient::H1 { ref mut h1 } => h1.poll_without_shutdown(cx),
@@ -554,7 +555,7 @@ where
 {
     type Output = crate::Result<()>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match ready!(Pin::new(self.inner.as_mut().unwrap()).poll(cx))? {
             proto::Dispatched::Shutdown => Poll::Ready(Ok(())),
             #[cfg(feature = "http1")]
@@ -1067,7 +1068,7 @@ impl Builder {
 impl Future for ResponseFuture {
     type Output = crate::Result<Response<Body>>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.inner {
             ResponseFutureState::Waiting(ref mut rx) => {
                 Pin::new(rx).poll(cx).map(|res| match res {
@@ -1101,7 +1102,7 @@ where
 {
     type Output = crate::Result<proto::Dispatched>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project() {
             #[cfg(feature = "http1")]
             ProtoClientProj::H1 { h1 } => h1.poll(cx),

--- a/src/client/connect/dns.rs
+++ b/src/client/connect/dns.rs
@@ -26,7 +26,7 @@ use std::future::Future;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs};
 use std::pin::Pin;
 use std::str::FromStr;
-use std::task::{self, Poll};
+use std::task::{Context, Poll};
 use std::{fmt, io, vec};
 
 use tokio::task::JoinHandle;
@@ -113,7 +113,7 @@ impl Service<Name> for GaiResolver {
     type Error = io::Error;
     type Future = GaiFuture;
 
-    fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         Poll::Ready(Ok(()))
     }
 
@@ -138,7 +138,7 @@ impl fmt::Debug for GaiResolver {
 impl Future for GaiFuture {
     type Output = Result<GaiAddrs, io::Error>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Pin::new(&mut self.inner).poll(cx).map(|res| match res {
             Ok(Ok(addrs)) => Ok(GaiAddrs { inner: addrs }),
             Ok(Err(err)) => Err(err),
@@ -286,7 +286,7 @@ impl Service<Name> for TokioThreadpoolGaiResolver {
     type Error = io::Error;
     type Future = TokioThreadpoolGaiFuture;
 
-    fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         Poll::Ready(Ok(()))
     }
 
@@ -299,7 +299,7 @@ impl Service<Name> for TokioThreadpoolGaiResolver {
 impl Future for TokioThreadpoolGaiFuture {
     type Output = Result<GaiAddrs, io::Error>;
 
-    fn poll(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
         match ready!(tokio_executor::threadpool::blocking(|| (
             self.name.as_str(),
             0
@@ -318,8 +318,10 @@ impl Future for TokioThreadpoolGaiFuture {
 */
 
 mod sealed {
+    use std::future::Future;
+    use std::task::{Context, Poll};
+
     use super::{Name, SocketAddr};
-    use crate::common::{task, Future, Poll};
     use tower_service::Service;
 
     // "Trait alias" for `Service<Name, Response = Addrs>`
@@ -328,7 +330,7 @@ mod sealed {
         type Error: Into<Box<dyn std::error::Error + Send + Sync>>;
         type Future: Future<Output = Result<Self::Addrs, Self::Error>>;
 
-        fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>>;
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
         fn resolve(&mut self, name: Name) -> Self::Future;
     }
 
@@ -342,7 +344,7 @@ mod sealed {
         type Error = S::Error;
         type Future = S::Future;
 
-        fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             Service::poll_ready(self, cx)
         }
 

--- a/src/client/connect/mod.rs
+++ b/src/client/connect/mod.rs
@@ -427,12 +427,13 @@ where
 #[cfg(any(feature = "http1", feature = "http2"))]
 pub(super) mod sealed {
     use std::error::Error as StdError;
+    use std::future::Future;
+    use std::marker::Unpin;
 
     use ::http::Uri;
     use tokio::io::{AsyncRead, AsyncWrite};
 
     use super::Connection;
-    use crate::common::{Future, Unpin};
 
     /// Connect to a destination, returning an IO transport.
     ///

--- a/src/client/pool.rs
+++ b/src/client/pool.rs
@@ -1,8 +1,12 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::error::Error as StdError;
 use std::fmt;
+use std::future::Future;
+use std::marker::Unpin;
 use std::ops::{Deref, DerefMut};
+use std::pin::Pin;
 use std::sync::{Arc, Mutex, Weak};
+use std::task::{Context, Poll};
 
 #[cfg(not(feature = "runtime"))]
 use std::time::{Duration, Instant};
@@ -13,7 +17,7 @@ use tokio::time::{Duration, Instant, Interval};
 use tracing::{debug, trace};
 
 use super::client::Ver;
-use crate::common::{exec::Exec, task, Future, Pin, Poll, Unpin};
+use crate::common::exec::Exec;
 
 // FIXME: allow() required due to `impl Trait` leaking types to this lint
 #[allow(missing_debug_implementations)]
@@ -576,10 +580,7 @@ impl fmt::Display for CheckoutIsClosedError {
 }
 
 impl<T: Poolable> Checkout<T> {
-    fn poll_waiter(
-        &mut self,
-        cx: &mut task::Context<'_>,
-    ) -> Poll<Option<crate::Result<Pooled<T>>>> {
+    fn poll_waiter(&mut self, cx: &mut Context<'_>) -> Poll<Option<crate::Result<Pooled<T>>>> {
         if let Some(mut rx) = self.waiter.take() {
             match Pin::new(&mut rx).poll(cx) {
                 Poll::Ready(Ok(value)) => {
@@ -604,7 +605,7 @@ impl<T: Poolable> Checkout<T> {
         }
     }
 
-    fn checkout(&mut self, cx: &mut task::Context<'_>) -> Option<Pooled<T>> {
+    fn checkout(&mut self, cx: &mut Context<'_>) -> Option<Pooled<T>> {
         let entry = {
             let mut inner = self.pool.inner.as_ref()?.lock().unwrap();
             let expiration = Expiration::new(inner.timeout);
@@ -657,7 +658,7 @@ impl<T: Poolable> Checkout<T> {
 impl<T: Poolable> Future for Checkout<T> {
     type Output = crate::Result<Pooled<T>>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if let Some(pooled) = ready!(self.poll_waiter(cx)?) {
             return Poll::Ready(Ok(pooled));
         }
@@ -748,7 +749,7 @@ pin_project_lite::pin_project! {
 impl<T: Poolable + 'static> Future for IdleTask<T> {
     type Output = ();
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
         loop {
             match this.pool_drop_notifier.as_mut().poll(cx) {
@@ -790,11 +791,14 @@ impl<T> WeakOpt<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::Context;
     use std::task::Poll;
     use std::time::Duration;
 
     use super::{Connecting, Key, Pool, Poolable, Reservation, WeakOpt};
-    use crate::common::{exec::Exec, task, Future, Pin};
+    use crate::common::exec::Exec;
 
     /// Test unique reservations.
     #[derive(Debug, PartialEq, Eq)]
@@ -864,7 +868,7 @@ mod tests {
     {
         type Output = Option<()>;
 
-        fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             match Pin::new(&mut self.0).poll(cx) {
                 Poll::Ready(Ok(_)) => Poll::Ready(Some(())),
                 Poll::Ready(Err(_)) => Poll::Ready(Some(())),

--- a/src/client/service.rs
+++ b/src/client/service.rs
@@ -5,6 +5,8 @@
 use std::error::Error as StdError;
 use std::future::Future;
 use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use tracing::debug;
 
@@ -12,7 +14,6 @@ use tracing::debug;
 use super::conn::{Builder, SendRequest};
 use crate::{
     body::HttpBody,
-    common::{task, Pin, Poll},
     service::{MakeConnection, Service},
 };
 
@@ -58,7 +59,7 @@ where
     type Future =
         Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
-    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner
             .poll_ready(cx)
             .map_err(|e| crate::Error::new(crate::error::Kind::Connect).with(e.into()))

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -1,10 +1,10 @@
 use std::marker::Unpin;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::{cmp, io};
 
 use bytes::{Buf, Bytes};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-
-use crate::common::{task, Pin, Poll};
 
 /// Combine a buffer with an IO, rewinding reads to use the buffer.
 #[derive(Debug)]
@@ -50,7 +50,7 @@ where
 {
     fn poll_read(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
+        cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         if let Some(mut prefix) = self.pre.take() {
@@ -78,7 +78,7 @@ where
 {
     fn poll_write(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
+        cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut self.inner).poll_write(cx, buf)
@@ -86,17 +86,17 @@ where
 
     fn poll_write_vectored(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
+        cx: &mut Context<'_>,
         bufs: &[io::IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut self.inner).poll_write_vectored(cx, bufs)
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.inner).poll_flush(cx)
     }
 
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Pin::new(&mut self.inner).poll_shutdown(cx)
     }
 

--- a/src/common/lazy.rs
+++ b/src/common/lazy.rs
@@ -1,6 +1,9 @@
-use pin_project_lite::pin_project;
+use std::future::Future;
+use std::marker::Unpin;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
-use super::{task, Future, Pin, Poll};
+use pin_project_lite::pin_project;
 
 pub(crate) trait Started: Future {
     fn started(&self) -> bool;
@@ -55,7 +58,7 @@ where
 {
     type Output = R::Output;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
 
         if let InnerProj::Fut { fut } = this.inner.as_mut().project() {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -23,6 +23,7 @@ mod never;
     all(feature = "client", any(feature = "http1", feature = "http2"))
 ))]
 pub(crate) mod sync_wrapper;
+#[cfg(feature = "http1")]
 pub(crate) mod task;
 pub(crate) mod watch;
 
@@ -30,10 +31,3 @@ pub(crate) mod watch;
 pub(crate) use self::lazy::{lazy, Started as Lazy};
 #[cfg(any(feature = "http1", feature = "http2", feature = "runtime"))]
 pub(crate) use self::never::Never;
-pub(crate) use self::task::Poll;
-
-// group up types normally needed for `Future`
-cfg_proto! {
-    pub(crate) use std::marker::Unpin;
-}
-pub(crate) use std::{future::Future, pin::Pin};

--- a/src/common/task.rs
+++ b/src/common/task.rs
@@ -1,11 +1,10 @@
-#[cfg(feature = "http1")]
+use std::task::{Context, Poll};
+
 use super::Never;
-pub(crate) use std::task::{Context, Poll};
 
 /// A function to help "yield" a future, such that it is re-scheduled immediately.
 ///
 /// Useful for spin counts, so a future doesn't hog too much time.
-#[cfg(feature = "http1")]
 pub(crate) fn yield_now(cx: &mut Context<'_>) -> Poll<Never> {
     cx.waker().wake_by_ref();
     Poll::Pending

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -1,6 +1,9 @@
 use std::fmt;
 use std::io;
 use std::marker::PhantomData;
+use std::marker::Unpin;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 #[cfg(all(feature = "server", feature = "runtime"))]
 use std::time::Duration;
 
@@ -16,7 +19,6 @@ use tracing::{debug, error, trace};
 use super::io::Buffered;
 use super::{Decoder, Encode, EncodedBuf, Encoder, Http1Transaction, ParseContext, Wants};
 use crate::body::DecodedLength;
-use crate::common::{task, Pin, Poll, Unpin};
 use crate::headers::connection_keep_alive;
 use crate::proto::{BodyLength, MessageHead};
 
@@ -185,7 +187,7 @@ where
 
     pub(super) fn poll_read_head(
         &mut self,
-        cx: &mut task::Context<'_>,
+        cx: &mut Context<'_>,
     ) -> Poll<Option<crate::Result<(MessageHead<T::Incoming>, DecodedLength, Wants)>>> {
         debug_assert!(self.can_read_head());
         trace!("Conn::read_head");
@@ -286,7 +288,7 @@ where
 
     pub(crate) fn poll_read_body(
         &mut self,
-        cx: &mut task::Context<'_>,
+        cx: &mut Context<'_>,
     ) -> Poll<Option<io::Result<Bytes>>> {
         debug_assert!(self.can_read_body());
 
@@ -347,10 +349,7 @@ where
         ret
     }
 
-    pub(crate) fn poll_read_keep_alive(
-        &mut self,
-        cx: &mut task::Context<'_>,
-    ) -> Poll<crate::Result<()>> {
+    pub(crate) fn poll_read_keep_alive(&mut self, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
         debug_assert!(!self.can_read_head() && !self.can_read_body());
 
         if self.is_read_closed() {
@@ -373,7 +372,7 @@ where
     //
     // This should only be called for Clients wanting to enter the idle
     // state.
-    fn require_empty_read(&mut self, cx: &mut task::Context<'_>) -> Poll<crate::Result<()>> {
+    fn require_empty_read(&mut self, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
         debug_assert!(!self.can_read_head() && !self.can_read_body() && !self.is_read_closed());
         debug_assert!(!self.is_mid_message());
         debug_assert!(T::is_client());
@@ -406,7 +405,7 @@ where
         Poll::Ready(Err(crate::Error::new_unexpected_message()))
     }
 
-    fn mid_message_detect_eof(&mut self, cx: &mut task::Context<'_>) -> Poll<crate::Result<()>> {
+    fn mid_message_detect_eof(&mut self, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
         debug_assert!(!self.can_read_head() && !self.can_read_body() && !self.is_read_closed());
         debug_assert!(self.is_mid_message());
 
@@ -425,7 +424,7 @@ where
         }
     }
 
-    fn force_io_read(&mut self, cx: &mut task::Context<'_>) -> Poll<io::Result<usize>> {
+    fn force_io_read(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         debug_assert!(!self.state.is_read_closed());
 
         let result = ready!(self.io.poll_read_from_io(cx));
@@ -436,7 +435,7 @@ where
         }))
     }
 
-    fn maybe_notify(&mut self, cx: &mut task::Context<'_>) {
+    fn maybe_notify(&mut self, cx: &mut Context<'_>) {
         // its possible that we returned NotReady from poll() without having
         // exhausted the underlying Io. We would have done this when we
         // determined we couldn't keep reading until we knew how writing
@@ -483,7 +482,7 @@ where
         }
     }
 
-    fn try_keep_alive(&mut self, cx: &mut task::Context<'_>) {
+    fn try_keep_alive(&mut self, cx: &mut Context<'_>) {
         self.state.try_keep_alive::<T>();
         self.maybe_notify(cx);
     }
@@ -726,14 +725,14 @@ where
         Err(err)
     }
 
-    pub(crate) fn poll_flush(&mut self, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+    pub(crate) fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         ready!(Pin::new(&mut self.io).poll_flush(cx))?;
         self.try_keep_alive(cx);
         trace!("flushed({}): {:?}", T::LOG, self.state);
         Poll::Ready(Ok(()))
     }
 
-    pub(crate) fn poll_shutdown(&mut self, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+    pub(crate) fn poll_shutdown(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match ready!(Pin::new(self.io.io_mut()).poll_shutdown(cx)) {
             Ok(()) => {
                 trace!("shut down IO complete");
@@ -747,7 +746,7 @@ where
     }
 
     /// If the read side can be cheaply drained, do so. Otherwise, close.
-    pub(super) fn poll_drain_or_close_read(&mut self, cx: &mut task::Context<'_>) {
+    pub(super) fn poll_drain_or_close_read(&mut self, cx: &mut Context<'_>) {
         if let Reading::Continue(ref decoder) = self.state.reading {
             // skip sending the 100-continue
             // just move forward to a read, in case a tiny body was included

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -5,6 +5,8 @@ use std::future::Future;
 use std::io::{self, IoSlice};
 use std::marker::Unpin;
 use std::mem::MaybeUninit;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 #[cfg(all(feature = "server", feature = "runtime"))]
 use std::time::Duration;
 
@@ -16,7 +18,6 @@ use tracing::{debug, trace};
 
 use super::{Http1Transaction, ParseContext, ParsedMessage};
 use crate::common::buf::BufList;
-use crate::common::{task, Pin, Poll};
 
 /// The initial buffer size allocated before trying to read from IO.
 pub(crate) const INIT_BUFFER_SIZE: usize = 8192;
@@ -174,7 +175,7 @@ where
 
     pub(super) fn parse<S>(
         &mut self,
-        cx: &mut task::Context<'_>,
+        cx: &mut Context<'_>,
         parse_ctx: ParseContext<'_>,
     ) -> Poll<crate::Result<ParsedMessage<S::Incoming>>>
     where
@@ -250,10 +251,7 @@ where
         }
     }
 
-    pub(crate) fn poll_read_from_io(
-        &mut self,
-        cx: &mut task::Context<'_>,
-    ) -> Poll<io::Result<usize>> {
+    pub(crate) fn poll_read_from_io(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         self.read_blocked = false;
         let next = self.read_buf_strategy.next();
         if self.read_buf_remaining_mut() < next {
@@ -296,7 +294,7 @@ where
         self.read_blocked
     }
 
-    pub(crate) fn poll_flush(&mut self, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+    pub(crate) fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         if self.flush_pipeline && !self.read_buf.is_empty() {
             Poll::Ready(Ok(()))
         } else if self.write_buf.remaining() == 0 {
@@ -336,7 +334,7 @@ where
     ///
     /// Since all buffered bytes are flattened into the single headers buffer,
     /// that skips some bookkeeping around using multiple buffers.
-    fn poll_flush_flattened(&mut self, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_flush_flattened(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         loop {
             let n = ready!(Pin::new(&mut self.io).poll_write(cx, self.write_buf.headers.chunk()))?;
             debug!("flushed {} bytes", n);
@@ -366,7 +364,7 @@ impl<T: Unpin, B> Unpin for Buffered<T, B> {}
 
 // TODO: This trait is old... at least rename to PollBytes or something...
 pub(crate) trait MemRead {
-    fn read_mem(&mut self, cx: &mut task::Context<'_>, len: usize) -> Poll<io::Result<Bytes>>;
+    fn read_mem(&mut self, cx: &mut Context<'_>, len: usize) -> Poll<io::Result<Bytes>>;
 }
 
 impl<T, B> MemRead for Buffered<T, B>
@@ -374,7 +372,7 @@ where
     T: AsyncRead + AsyncWrite + Unpin,
     B: Buf,
 {
-    fn read_mem(&mut self, cx: &mut task::Context<'_>, len: usize) -> Poll<io::Result<Bytes>> {
+    fn read_mem(&mut self, cx: &mut Context<'_>, len: usize) -> Poll<io::Result<Bytes>> {
         if !self.read_buf.is_empty() {
             let n = std::cmp::min(len, self.read_buf.len());
             Poll::Ready(Ok(self.read_buf.split_to(n).freeze()))

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -1,4 +1,8 @@
 use std::error::Error as StdError;
+use std::future::Future;
+use std::marker::Unpin;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 #[cfg(feature = "runtime")]
 use std::time::Duration;
 
@@ -15,7 +19,7 @@ use tracing::{debug, trace, warn};
 use super::{ping, H2Upgraded, PipeToSendStream, SendBuf};
 use crate::body::HttpBody;
 use crate::client::dispatch::Callback;
-use crate::common::{exec::Exec, task, Future, Never, Pin, Poll};
+use crate::common::{exec::Exec, Never};
 use crate::ext::Protocol;
 use crate::headers;
 use crate::proto::h2::UpgradedSendStream;
@@ -239,7 +243,7 @@ where
     B::Data: Send,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
 {
-    fn poll_pipe(&mut self, f: FutCtx<B>, cx: &mut task::Context<'_>) {
+    fn poll_pipe(&mut self, f: FutCtx<B>, cx: &mut Context<'_>) {
         let ping = self.ping.clone();
         let send_stream = if !f.is_connect {
             if !f.eos {
@@ -334,7 +338,7 @@ where
 {
     type Output = crate::Result<Dispatched>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
             match ready!(self.h2_tx.poll_ready(cx)) {
                 Ok(()) => (),

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -4,14 +4,15 @@ use http::header::{HeaderName, CONNECTION, TE, TRAILER, TRANSFER_ENCODING, UPGRA
 use http::HeaderMap;
 use pin_project_lite::pin_project;
 use std::error::Error as StdError;
+use std::future::Future;
 use std::io::{self, Cursor, IoSlice};
 use std::mem;
-use std::task::Context;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tracing::{debug, trace, warn};
 
 use crate::body::HttpBody;
-use crate::common::{task, Future, Pin, Poll};
 use crate::proto::h2::ping::Recorder;
 
 pub(crate) mod ping;
@@ -116,7 +117,7 @@ where
 {
     type Output = crate::Result<()>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut me = self.project();
         loop {
             if !*me.data_done {

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -2,6 +2,10 @@
 
 use std::error::Error as StdError;
 use std::fmt;
+use std::future::Future;
+use std::marker::Unpin;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use pin_project_lite::pin_project;
@@ -9,7 +13,6 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::body::{Body as IncomingBody, HttpBody as Body};
 use crate::common::exec::ConnStreamExec;
-use crate::common::{task, Future, Pin, Poll, Unpin};
 use crate::proto;
 use crate::service::HttpService;
 
@@ -79,7 +82,7 @@ where
 {
     type Output = crate::Result<()>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match ready!(Pin::new(&mut self.conn).poll(cx)) {
             Ok(_done) => {
                 //TODO: the proto::h2::Server no longer needs to return

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -1,8 +1,11 @@
 use std::error::Error as StdError;
 use std::fmt;
+use std::future::Future;
+use std::marker::Unpin;
 #[cfg(feature = "tcp")]
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
-
+use std::pin::Pin;
+use std::task::{Context, Poll};
 #[cfg(feature = "tcp")]
 use std::time::Duration;
 
@@ -17,7 +20,6 @@ use super::tcp::AddrIncoming;
 use crate::body::{Body, HttpBody};
 use crate::common::exec::Exec;
 use crate::common::exec::{ConnStreamExec, NewSvcExec};
-use crate::common::{task, Future, Pin, Poll, Unpin};
 // Renamed `Http` as `Http_` for now so that people upgrading don't see an
 // error that `hyper::server::Http` is private...
 use super::conn::{Connection, Http as Http_, UpgradeableConnection};
@@ -162,7 +164,7 @@ where
 
     fn poll_next_(
         self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
+        cx: &mut Context<'_>,
     ) -> Poll<Option<crate::Result<Connecting<IO, S::Future, E>>>> {
         let me = self.project();
         match ready!(me.make_service.poll_ready_ref(cx)) {
@@ -188,7 +190,7 @@ where
 
     pub(super) fn poll_watch<W>(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
+        cx: &mut Context<'_>,
         watcher: &W,
     ) -> Poll<crate::Result<()>>
     where
@@ -221,7 +223,7 @@ where
 {
     type Output = crate::Result<()>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.poll_watch(cx, &NoopWatcher)
     }
 }
@@ -675,13 +677,17 @@ where
 // used by exec.rs
 pub(crate) mod new_svc {
     use std::error::Error as StdError;
+    use std::future::Future;
+    use std::marker::Unpin;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
     use tokio::io::{AsyncRead, AsyncWrite};
     use tracing::debug;
 
     use super::{Connecting, Watcher};
     use crate::body::{Body, HttpBody};
     use crate::common::exec::ConnStreamExec;
-    use crate::common::{task, Future, Pin, Poll, Unpin};
     use crate::service::HttpService;
     use pin_project_lite::pin_project;
 
@@ -742,7 +748,7 @@ pub(crate) mod new_svc {
     {
         type Output = ();
 
-        fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             // If it weren't for needing to name this type so the `Send` bounds
             // could be projected to the `Serve` executor, this could just be
             // an `async fn`, and much safer. Woe is me.
@@ -810,7 +816,7 @@ where
 {
     type Output = Result<Connection<I, S, E>, FE>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut me = self.project();
         let service = ready!(me.future.poll(cx))?;
         let io = Option::take(&mut me.io).expect("polled after complete");

--- a/src/server/shutdown.rs
+++ b/src/server/shutdown.rs
@@ -1,4 +1,8 @@
 use std::error::Error as StdError;
+use std::future::Future;
+use std::marker::Unpin;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use pin_project_lite::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -10,7 +14,6 @@ use super::server::{Server, Watcher};
 use crate::body::{Body, HttpBody};
 use crate::common::drain::{self, Draining, Signal, Watch, Watching};
 use crate::common::exec::{ConnStreamExec, NewSvcExec};
-use crate::common::{task, Future, Pin, Poll, Unpin};
 use crate::service::{HttpService, MakeServiceRef};
 
 pin_project! {
@@ -63,7 +66,7 @@ where
 {
     type Output = crate::Result<()>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut me = self.project();
         loop {
             let next = {

--- a/src/server/tcp.rs
+++ b/src/server/tcp.rs
@@ -1,14 +1,15 @@
 use socket2::TcpKeepalive;
 use std::fmt;
+use std::future::Future;
 use std::io;
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use tokio::net::TcpListener;
 use tokio::time::Sleep;
 use tracing::{debug, error, trace};
-
-use crate::common::{task, Future, Pin, Poll};
 
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::addr_stream::AddrStream;
@@ -200,7 +201,7 @@ impl AddrIncoming {
         self.sleep_on_errors = val;
     }
 
-    fn poll_next_(&mut self, cx: &mut task::Context<'_>) -> Poll<io::Result<AddrStream>> {
+    fn poll_next_(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<AddrStream>> {
         // Check if a previous timeout is active that was set by IO errors.
         if let Some(ref mut to) = self.timeout {
             ready!(Pin::new(to).poll(cx));
@@ -261,7 +262,7 @@ impl Accept for AddrIncoming {
 
     fn poll_accept(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context<'_>,
+        cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
         let result = ready!(self.poll_next_(cx));
         Poll::Ready(Some(result))
@@ -300,10 +301,10 @@ mod addr_stream {
     use std::net::SocketAddr;
     #[cfg(unix)]
     use std::os::unix::io::{AsRawFd, RawFd};
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
     use tokio::net::TcpStream;
-
-    use crate::common::{task, Pin, Poll};
 
     pin_project_lite::pin_project! {
         /// A transport returned yieled by `AddrIncoming`.
@@ -352,7 +353,7 @@ mod addr_stream {
         /// not yet available.
         pub fn poll_peek(
             &mut self,
-            cx: &mut task::Context<'_>,
+            cx: &mut Context<'_>,
             buf: &mut tokio::io::ReadBuf<'_>,
         ) -> Poll<io::Result<usize>> {
             self.inner.poll_peek(cx, buf)
@@ -363,7 +364,7 @@ mod addr_stream {
         #[inline]
         fn poll_read(
             self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
+            cx: &mut Context<'_>,
             buf: &mut ReadBuf<'_>,
         ) -> Poll<io::Result<()>> {
             self.project().inner.poll_read(cx, buf)
@@ -374,7 +375,7 @@ mod addr_stream {
         #[inline]
         fn poll_write(
             self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
+            cx: &mut Context<'_>,
             buf: &[u8],
         ) -> Poll<io::Result<usize>> {
             self.project().inner.poll_write(cx, buf)
@@ -383,20 +384,20 @@ mod addr_stream {
         #[inline]
         fn poll_write_vectored(
             self: Pin<&mut Self>,
-            cx: &mut task::Context<'_>,
+            cx: &mut Context<'_>,
             bufs: &[io::IoSlice<'_>],
         ) -> Poll<io::Result<usize>> {
             self.project().inner.poll_write_vectored(cx, bufs)
         }
 
         #[inline]
-        fn poll_flush(self: Pin<&mut Self>, _cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
             // TCP flush is a noop
             Poll::Ready(Ok(()))
         }
 
         #[inline]
-        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
             self.project().inner.poll_shutdown(cx)
         }
 

--- a/src/service/http.rs
+++ b/src/service/http.rs
@@ -1,7 +1,8 @@
 use std::error::Error as StdError;
+use std::future::Future;
+use std::task::{Context, Poll};
 
 use crate::body::HttpBody;
-use crate::common::{task, Future, Poll};
 use crate::{Request, Response};
 
 /// An asynchronous function from `Request` to `Response`.
@@ -20,7 +21,7 @@ pub trait HttpService<ReqBody>: sealed::Sealed<ReqBody> {
     type Future: Future<Output = Result<Response<Self::ResBody>, Self::Error>>;
 
     #[doc(hidden)]
-    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>>;
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
 
     #[doc(hidden)]
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future;
@@ -37,7 +38,7 @@ where
     type Error = T::Error;
     type Future = T::Future;
 
-    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         tower_service::Service::poll_ready(self, cx)
     }
 

--- a/src/service/oneshot.rs
+++ b/src/service/oneshot.rs
@@ -1,9 +1,11 @@
 // TODO: Eventually to be replaced with tower_util::Oneshot.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
 use pin_project_lite::pin_project;
 use tower_service::Service;
-
-use crate::common::{task, Future, Pin, Poll};
 
 pub(crate) fn oneshot<S, Req>(svc: S, req: Req) -> Oneshot<S, Req>
 where
@@ -47,7 +49,7 @@ where
 {
     type Output = Result<S::Response, S::Error>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut me = self.project();
 
         loop {

--- a/src/service/util.rs
+++ b/src/service/util.rs
@@ -1,9 +1,10 @@
 use std::error::Error as StdError;
 use std::fmt;
+use std::future::Future;
 use std::marker::PhantomData;
+use std::task::{Context, Poll};
 
 use crate::body::HttpBody;
-use crate::common::{task, Future, Poll};
 use crate::{Request, Response};
 
 /// Create a `Service` from a function.
@@ -54,7 +55,7 @@ where
     type Error = E;
     type Future = Ret;
 
-    fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 


### PR DESCRIPTION
Backports #3346. This might allow developers to compare with 0.14 more a little easily.