### PR TITLE
fix(examples): add backports feature requirement to tower_client example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ required-features = ["full"]
 [[example]]
 name = "tower_client"
 path = "examples/tower_client.rs"
-required-features = ["full"]
+required-features = ["full", "backports"]
 
 [[example]]
 name = "tower_server"


### PR DESCRIPTION
tower_client example seems to require backports feature.