### PR TITLE
feat(lib): update to `http` 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,15 @@ include = [
 bytes = "1"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
-http = "0.2.7"
-http-body = "=1.0.0-rc.2"
+http = "1"
+http-body = "1"
 pin-project-lite = "0.2.4"
 tokio = { version = "1.13", features = ["sync"] }
 
 # Optional
 
-h2 = { version = "0.3.9", optional = true }
-http-body-util = { version = "=0.1.0-rc.3", optional = true }
+h2 = { version = "0.4", optional = true }
+http-body-util = { version = "0.1", optional = true }
 httparse = { version = "1.8", optional = true }
 httpdate = { version = "1.0", optional = true }
 itoa = { version = "1", optional = true }
@@ -41,7 +41,7 @@ want = { version = "0.3", optional = true }
 
 [dev-dependencies]
 form_urlencoded = "1"
-http-body-util = "=0.1.0-rc.3"
+http-body-util = "0.1"
 pretty_env_logger = "0.5"
 spmc = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/ffi/http_types.rs
+++ b/src/ffi/http_types.rs
@@ -20,12 +20,14 @@ pub struct hyper_response(pub(super) Response<IncomingBody>);
 /// An HTTP header map.
 ///
 /// These can be part of a request or response.
+#[derive(Clone)]
 pub struct hyper_headers {
     pub(super) headers: HeaderMap,
     orig_casing: HeaderCaseMap,
     orig_order: OriginalHeaderOrder,
 }
 
+#[derive(Clone)]
 pub(crate) struct OnInformational {
     func: hyper_request_on_informational_callback,
     data: UserDataPointer,

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -76,6 +76,7 @@ pub const HYPER_HTTP_VERSION_1_1: libc::c_int = 11;
 /// The HTTP/2 version.
 pub const HYPER_HTTP_VERSION_2: libc::c_int = 20;
 
+#[derive(Clone)]
 struct UserDataPointer(*mut std::ffi::c_void);
 
 // We don't actually know anything about this pointer, it's up to the user

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -38,6 +38,7 @@ async fn tcp_connect(addr: &SocketAddr) -> std::io::Result<TokioIo<TcpStream>> {
     TcpStream::connect(*addr).await.map(TokioIo::new)
 }
 
+#[derive(Clone)]
 struct HttpInfo {
     remote_addr: SocketAddr,
 }


### PR DESCRIPTION
Updates dependencies `http` and `http-body` to 1.0.

To do so, implements `Clone` for `OnUpgrade`.

BREAKING CHANGE: Upgrade to `http` 1.0.

