### PR TITLE
Make ReadBuf::new public

### DIFF
--- a/src/rt/io.rs
+++ b/src/rt/io.rs
@@ -132,9 +132,9 @@ pub struct ReadBufCursor<'a> {
 }
 
 impl<'data> ReadBuf<'data> {
+    /// Create a new `ReadBuf` with a slice of initialized bytes.
     #[inline]
-    #[cfg(test)]
-    pub(crate) fn new(raw: &'data mut [u8]) -> Self {
+    pub fn new(raw: &'data mut [u8]) -> Self {
         let len = raw.len();
         Self {
             // SAFETY: We never de-init the bytes ourselves.


### PR DESCRIPTION
Needed when interfacing with std::io APIs like in hyper-openssl: https://github.com/sfackler/hyper-openssl/blob/2ca0514a5903bd52c402d16f80117efc4f4b3841/src/lib.rs#L57