### PR TITLE
refactor(lib): use non_exhaustive attribute

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -29,6 +29,7 @@ pub struct SendRequest<B> {
 /// This allows taking apart a `Connection` at a later time, in order to
 /// reclaim the IO object, and additional related pieces.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct Parts<T> {
     /// The original IO object used in the handshake.
     pub io: T,
@@ -41,7 +42,6 @@ pub struct Parts<T> {
     /// You will want to check for any existing bytes if you plan to continue
     /// communicating on the IO object.
     pub read_buf: Bytes,
-    _inner: (),
 }
 
 /// A future that processes all HTTP state for the IO object.
@@ -68,11 +68,7 @@ where
     /// Only works for HTTP/1 connections. HTTP/2 connections will panic.
     pub fn into_parts(self) -> Parts<T> {
         let (io, read_buf, _) = self.inner.into_inner();
-        Parts {
-            io,
-            read_buf,
-            _inner: (),
-        }
+        Parts { io, read_buf }
     }
 
     /// Poll the connection for completion, but without calling `shutdown`
@@ -589,11 +585,7 @@ mod upgrades {
             match ready!(Pin::new(&mut self.inner.as_mut().unwrap().inner).poll(cx)) {
                 Ok(proto::Dispatched::Shutdown) => Poll::Ready(Ok(())),
                 Ok(proto::Dispatched::Upgrade(pending)) => {
-                    let Parts {
-                        io,
-                        read_buf,
-                        _inner,
-                    } = self.inner.take().unwrap().into_parts();
+                    let Parts { io, read_buf } = self.inner.take().unwrap().into_parts();
                     pending.fulfill(Upgraded::new(io, read_buf));
                     Poll::Ready(Ok(()))
                 }

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -86,6 +86,7 @@ pub struct Builder {
 /// This allows taking apart a `Connection` at a later time, in order to
 /// reclaim the IO object, and additional related pieces.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct Parts<T, S> {
     /// The original IO object used in the handshake.
     pub io: T,
@@ -100,7 +101,6 @@ pub struct Parts<T, S> {
     pub read_buf: Bytes,
     /// The `Service` used to serve this connection.
     pub service: S,
-    _inner: (),
 }
 
 // ===== impl Connection =====
@@ -151,7 +151,6 @@ where
             io,
             read_buf,
             service: dispatch.into_service(),
-            _inner: (),
         }
     }
 

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -79,6 +79,7 @@ pub struct OnUpgrade {
 /// Includes the original IO type, and a read buffer of bytes that the
 /// HTTP state machine may have already read before completing an upgrade.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct Parts<T> {
     /// The original IO object used before the upgrade.
     pub io: T,
@@ -91,7 +92,6 @@ pub struct Parts<T> {
     /// You will want to check for any existing bytes if you plan to continue
     /// communicating on the IO object.
     pub read_buf: Bytes,
-    _inner: (),
 }
 
 /// Gets a pending HTTP upgrade from this message.
@@ -154,7 +154,6 @@ impl Upgraded {
             Ok(t) => Ok(Parts {
                 io: *t,
                 read_buf: buf,
-                _inner: (),
             }),
             Err(io) => Err(Upgraded {
                 io: Rewind::new_buffered(io, buf),


### PR DESCRIPTION
Uses `non_exhaustive` attribute instead of manual implementation.