### PR TITLE
Update README.md: added hyper-util to the dependencies section

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,6 +22,7 @@ serde_json = "1.0"
 form_urlencoded = "1"
 http = "1"
 futures-util = { version = "0.3", default-features = false }
+hyper-util = { version = "0.1", features = ["full"] }
 ```
 
 ## Getting Started

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -8,9 +8,7 @@ use hyper::Request;
 use tokio::io::{self, AsyncWriteExt as _};
 use tokio::net::TcpStream;
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 // A simple type alias so as to DRY.
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;

--- a/examples/client_json.rs
+++ b/examples/client_json.rs
@@ -7,9 +7,7 @@ use hyper::{body::Buf, Request};
 use serde::Deserialize;
 use tokio::net::TcpStream;
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 // A simple type alias so as to DRY.
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -10,9 +10,7 @@ use hyper::service::service_fn;
 use hyper::{body::Body, Method, Request, Response, StatusCode};
 use tokio::net::TcpListener;
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 /// This is our service handler. It receives a Request, routes on its
 /// path, and returns a Future of a Response.

--- a/examples/gateway.rs
+++ b/examples/gateway.rs
@@ -4,9 +4,7 @@ use hyper::{server::conn::http1, service::service_fn};
 use std::net::SocketAddr;
 use tokio::net::{TcpListener, TcpStream};
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/graceful_shutdown.rs
+++ b/examples/graceful_shutdown.rs
@@ -12,9 +12,7 @@ use hyper::{Request, Response};
 use tokio::net::TcpListener;
 use tokio::pin;
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 // An async function that consumes a request, does nothing with it and returns a
 // response.

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -10,9 +10,7 @@ use hyper::service::service_fn;
 use hyper::{Request, Response};
 use tokio::net::TcpListener;
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 // An async function that consumes a request, does nothing with it and returns a
 // response.

--- a/examples/http_proxy.rs
+++ b/examples/http_proxy.rs
@@ -12,9 +12,7 @@ use hyper::{Method, Request, Response};
 
 use tokio::net::{TcpListener, TcpStream};
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 // To try this example:
 // 1. cargo run --example http_proxy

--- a/examples/multi_server.rs
+++ b/examples/multi_server.rs
@@ -11,9 +11,7 @@ use hyper::service::service_fn;
 use hyper::{Request, Response};
 use tokio::net::TcpListener;
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 static INDEX1: &[u8] = b"The 1st service!";
 static INDEX2: &[u8] = b"The 2nd service!";

--- a/examples/params.rs
+++ b/examples/params.rs
@@ -12,9 +12,7 @@ use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 static INDEX: &[u8] = b"<html><body><form action=\"post\" method=\"post\">Name: <input type=\"text\" name=\"name\"><br>Number: <input type=\"text\" name=\"number\"><br><input type=\"submit\"></body></html>";
 static MISSING: &[u8] = b"Missing field";

--- a/examples/send_file.rs
+++ b/examples/send_file.rs
@@ -10,9 +10,7 @@ use http_body_util::Full;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, Result, StatusCode};
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 static INDEX: &str = "examples/send_file_index.html";
 static NOTFOUND: &[u8] = b"Not Found";

--- a/examples/service_struct_impl.rs
+++ b/examples/service_struct_impl.rs
@@ -10,9 +10,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Mutex;
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 type Counter = i32;
 

--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -28,9 +28,7 @@ use std::task::{Context, Poll};
 use std::thread;
 use tokio::net::TcpStream;
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 struct Body {
     // Our Body type is !Send and !Sync:

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -12,9 +12,7 @@ use hyper::{server::conn::http1, service::service_fn};
 use hyper::{Error, Response};
 use tokio::net::TcpListener;
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/examples/upgrades.rs
+++ b/examples/upgrades.rs
@@ -16,9 +16,7 @@ use hyper::service::service_fn;
 use hyper::upgrade::Upgraded;
 use hyper::{Request, Response, StatusCode};
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 // A simple type alias so as to DRY.
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;

--- a/examples/web_api.rs
+++ b/examples/web_api.rs
@@ -9,9 +9,7 @@ use hyper::service::service_fn;
 use hyper::{body::Incoming as IncomingBody, header, Method, Request, Response, StatusCode};
 use tokio::net::{TcpListener, TcpStream};
 
-#[path = "../benches/support/mod.rs"]
-mod support;
-use support::TokioIo;
+use hyper_util::rt::TokioIo;
 
 type GenericError = Box<dyn std::error::Error + Send + Sync>;
 type Result<T> = std::result::Result<T, GenericError>;


### PR DESCRIPTION
There is a need to include the hyper-util crate to compile examples, otherwise, it cannot solve the dependency for TokioIo.  It looks like the examples also need to be updated as they refer to an internal "../benches/support/mod.rs" for TokioIo.

