### PR TITLE
capi: updated comments in gen_header.sh

### DIFF
--- a/capi/gen_header.sh
+++ b/capi/gen_header.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
-
-# This script regenerates hyper.h. As of April 2021, it only works with the
+#
+# This script regenerates hyper.h.
 # nightly build of Rust.
+#
+# Requirements:
+#
+# cargo install cbindgen
+# cargo install cargo-expand
 
 set -e
 


### PR DESCRIPTION
I've tested with 1.73 and the script now works on stable.

Also, added instructions to install requirements.