### PR TITLE
feat(dependencies): make tokio optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ futures-util = { version = "0.3", default-features = false }
 http = "1"
 http-body = "1"
 pin-project-lite = "0.2.4"
-tokio = { version = "1", features = ["sync"] }
 
 # Optional
 
@@ -36,6 +35,7 @@ httparse = { version = "1.8", optional = true }
 httpdate = { version = "1.0", optional = true }
 itoa = { version = "1", optional = true }
 libc = { version = "0.2", optional = true }
+tokio = { version = "1", features = ["sync"], optional = true }
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 want = { version = "0.3", optional = true }
 
@@ -74,7 +74,7 @@ full = [
 
 # HTTP versions
 http1 = ["dep:httparse", "dep:itoa"]
-http2 = ["dep:h2"]
+http2 = ["dep:h2", "tokio"]
 
 # Client/Server
 client = ["dep:want"]

--- a/src/common/io/compat.rs
+++ b/src/common/io/compat.rs
@@ -19,6 +19,7 @@ impl<T> Compat<T> {
     }
 }
 
+#[cfg(feature = "tokio")]
 impl<T> tokio::io::AsyncRead for Compat<T>
 where
     T: crate::rt::Read,
@@ -51,6 +52,7 @@ where
     }
 }
 
+#[cfg(feature = "tokio")]
 impl<T> tokio::io::AsyncWrite for Compat<T>
 where
     T: crate::rt::Write,

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -51,6 +51,9 @@ use std::task::{Context, Poll};
 
 use crate::rt::{Read, ReadBufCursor, Write};
 use bytes::Bytes;
+#[cfg(not(feature = "tokio"))]
+use futures_channel::oneshot;
+#[cfg(feature = "tokio")]
 use tokio::sync::oneshot;
 
 use crate::common::io::Rewind;


### PR DESCRIPTION
I've noticed the discussion in #3281 . This PR is a little different that, it doesn't remove usage of tokio channel. Instead, it makes tokio behind a feature gate. If the "tokio" feature is disabled, `futures-channel` will be used.

"http2" feature still requires `tokio` because of the design of `h2`.