### PR TITLE
fix(client): add missing without_shutdown method

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -91,12 +91,13 @@ where
 
     /// Prevent shutdown of the underlying IO object at the end of service the request,
     /// instead run `into_parts`. This is a convenience wrapper over `poll_without_shutdown`.
-    pub fn without_shutdown(self) -> impl Future<Output = crate::Result<Parts<T>>> {
+    pub async fn without_shutdown(self) -> crate::Result<Parts<T>> {
         let mut conn = Some(self);
         futures_util::future::poll_fn(move |cx| -> Poll<crate::Result<Parts<T>>> {
             ready!(conn.as_mut().unwrap().poll_without_shutdown(cx))?;
             Poll::Ready(Ok(conn.take().unwrap().into_parts()))
         })
+        .await
     }
 }
 

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -88,6 +88,16 @@ where
     pub fn poll_without_shutdown(&mut self, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
         self.inner.poll_without_shutdown(cx)
     }
+
+    /// Prevent shutdown of the underlying IO object at the end of service the request,
+    /// instead run `into_parts`. This is a convenience wrapper over `poll_without_shutdown`.
+    pub fn without_shutdown(self) -> impl Future<Output = crate::Result<Parts<T>>> {
+        let mut conn = Some(self);
+        futures_util::future::poll_fn(move |cx| -> Poll<crate::Result<Parts<T>>> {
+            ready!(conn.as_mut().unwrap().poll_without_shutdown(cx))?;
+            Poll::Ready(Ok(conn.take().unwrap().into_parts()))
+        })
+    }
 }
 
 /// A builder to configure an HTTP connection.


### PR DESCRIPTION
in `client::conn::http1::Connection` the method `poll_without_shutdown` references `without_shutdown` in its documentation, but the method `without_shutdown` is not present in the code. This PR copies `without_shutdown` from hyper `0.14.x`: https://github.com/hyperium/hyper/blob/0.14.x/src/client/conn.rs#L520-L528