### PR TITLE
(nit) Update http_proxy example to use (host, port) pair as addr

### DIFF
--- a/examples/http_proxy.rs
+++ b/examples/http_proxy.rs
@@ -90,9 +90,8 @@ async fn proxy(
     } else {
         let host = req.uri().host().expect("uri has no host");
         let port = req.uri().port_u16().unwrap_or(80);
-        let addr = format!("{}:{}", host, port);
 
-        let stream = TcpStream::connect(addr).await.unwrap();
+        let stream = TcpStream::connect((host, port)).await.unwrap();
         let io = TokioIo::new(stream);
 
         let (mut sender, conn) = Builder::new()


### PR DESCRIPTION
Just nits, I think it makes it slightly better.