### PR TITLE
fix(examples): send only path of URI in request

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -54,9 +54,10 @@ async fn fetch_url(url: hyper::Uri) -> Result<()> {
     });
 
     let authority = url.authority().unwrap().clone();
+    let uri = url.path_and_query().map(|p| p.as_str()).unwrap_or("/");
 
     let req = Request::builder()
-        .uri(url)
+        .uri(uri)
         .header(hyper::header::HOST, authority.as_str())
         .body(Empty::<Bytes>::new())?;
 

--- a/examples/client_json.rs
+++ b/examples/client_json.rs
@@ -43,10 +43,11 @@ async fn fetch_json(url: hyper::Uri) -> Result<Vec<User>> {
     });
 
     let authority = url.authority().unwrap().clone();
+    let uri = url.path_and_query().map(|p| p.as_str()).unwrap_or("/");
 
     // Fetch the url...
     let req = Request::builder()
-        .uri(url)
+        .uri(uri)
         .header(hyper::header::HOST, authority.as_str())
         .body(Empty::<Bytes>::new())?;
 


### PR DESCRIPTION
A client request must transmit the URI as absolute path and the authority in the `Host` header. Only when the request goes via a HTTP proxy, the URI in the request shall contain the network location as well. Current implementation transmit the network location unconditionally.

In Hyper 0.14 the connection knew if it is connected to an proxy or directly to a HTTP server. The connection then wrote the network location conditionally only when a proxy is involved.

This PR updates the client example such that only the path is used for the URI in the request.

According to the RFC both cases must work, but after this PR it is more clear that the user is responsible to form the correct URI value.

> To allow for transition to absoluteURIs in all requests in future
>  versions of HTTP, all HTTP/1.1 servers MUST accept the absoluteURI
> form in requests, even though HTTP/1.1 clients will only generate
>them in requests to proxies.