### PR TITLE
refactor(common): Remove unused TokioTimeout

### DIFF
--- a/benches/support/tokiort.rs
+++ b/benches/support/tokiort.rs
@@ -49,21 +49,6 @@ impl Timer for TokioTimer {
     }
 }
 
-struct TokioTimeout<T> {
-    inner: Pin<Box<tokio::time::Timeout<T>>>,
-}
-
-impl<T> Future for TokioTimeout<T>
-where
-    T: Future,
-{
-    type Output = Result<T::Output, tokio::time::error::Elapsed>;
-
-    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
-        self.inner.as_mut().poll(context)
-    }
-}
-
 // Use TokioSleep to get tokio::time::Sleep to implement Unpin.
 // see https://docs.rs/tokio/latest/tokio/time/struct.Sleep.html
 pin_project! {


### PR DESCRIPTION
I was going through the `tokiort` module and noticed that the `TokioTimeout` struct was not used anywhere anymore.