### PR TITLE
feat(client): support Expect: 100-continue

### DIFF
--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -197,6 +197,8 @@ where
                     h09_responses: parse_ctx.h09_responses,
                     #[cfg(feature = "ffi")]
                     on_informational: parse_ctx.on_informational,
+                    #[cfg(feature = "client")]
+                    awaiting_100_continue: parse_ctx.awaiting_100_continue,
                 },
             )? {
                 Some(msg) => {
@@ -734,6 +736,8 @@ mod tests {
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
                 on_informational: &mut None,
+                #[cfg(feature = "client")]
+                awaiting_100_continue: &mut false,
             };
             assert!(buffered
                 .parse::<ClientTransaction>(cx, parse_ctx)

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -92,6 +92,8 @@ pub(crate) struct ParseContext<'a> {
     h09_responses: bool,
     #[cfg(feature = "ffi")]
     on_informational: &'a mut Option<crate::ffi::OnInformational>,
+    #[cfg(feature = "client")]
+    awaiting_100_continue: &'a mut bool,
 }
 
 /// Passed to Http1Transaction::encode

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1073,6 +1073,10 @@ impl Http1Transaction for Client {
                 }));
             }
 
+            if head.subject == StatusCode::CONTINUE {
+                *ctx.awaiting_100_continue = false;
+            }
+
             #[cfg(feature = "ffi")]
             if head.subject.is_informational() {
                 if let Some(callback) = ctx.on_informational {
@@ -1574,6 +1578,8 @@ mod tests {
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
                 on_informational: &mut None,
+                #[cfg(feature = "client")]
+                awaiting_100_continue: &mut false,
             },
         )
         .unwrap()
@@ -1605,6 +1611,8 @@ mod tests {
             h09_responses: false,
             #[cfg(feature = "ffi")]
             on_informational: &mut None,
+            #[cfg(feature = "client")]
+            awaiting_100_continue: &mut false,
         };
         let msg = Client::parse(&mut raw, ctx).unwrap().unwrap();
         assert_eq!(raw.len(), 0);
@@ -1631,6 +1639,8 @@ mod tests {
             h09_responses: false,
             #[cfg(feature = "ffi")]
             on_informational: &mut None,
+            #[cfg(feature = "client")]
+            awaiting_100_continue: &mut false,
         };
         Server::parse(&mut raw, ctx).unwrap_err();
     }
@@ -1655,6 +1665,8 @@ mod tests {
             h09_responses: true,
             #[cfg(feature = "ffi")]
             on_informational: &mut None,
+            #[cfg(feature = "client")]
+            awaiting_100_continue: &mut false,
         };
         let msg = Client::parse(&mut raw, ctx).unwrap().unwrap();
         assert_eq!(raw, H09_RESPONSE);
@@ -1681,6 +1693,8 @@ mod tests {
             h09_responses: false,
             #[cfg(feature = "ffi")]
             on_informational: &mut None,
+            #[cfg(feature = "client")]
+            awaiting_100_continue: &mut false,
         };
         Client::parse(&mut raw, ctx).unwrap_err();
         assert_eq!(raw, H09_RESPONSE);
@@ -1711,6 +1725,8 @@ mod tests {
             h09_responses: false,
             #[cfg(feature = "ffi")]
             on_informational: &mut None,
+            #[cfg(feature = "client")]
+            awaiting_100_continue: &mut false,
         };
         let msg = Client::parse(&mut raw, ctx).unwrap().unwrap();
         assert_eq!(raw.len(), 0);
@@ -1738,6 +1754,8 @@ mod tests {
             h09_responses: false,
             #[cfg(feature = "ffi")]
             on_informational: &mut None,
+            #[cfg(feature = "client")]
+            awaiting_100_continue: &mut false,
         };
         Client::parse(&mut raw, ctx).unwrap_err();
     }
@@ -1760,6 +1778,8 @@ mod tests {
             h09_responses: false,
             #[cfg(feature = "ffi")]
             on_informational: &mut None,
+            #[cfg(feature = "client")]
+            awaiting_100_continue: &mut false,
         };
         let parsed_message = Server::parse(&mut raw, ctx).unwrap().unwrap();
         let orig_headers = parsed_message
@@ -1803,6 +1823,8 @@ mod tests {
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
                     on_informational: &mut None,
+                    #[cfg(feature = "client")]
+                    awaiting_100_continue: &mut false,
                 },
             )
             .expect("parse ok")
@@ -1827,6 +1849,8 @@ mod tests {
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
                     on_informational: &mut None,
+                    #[cfg(feature = "client")]
+                    awaiting_100_continue: &mut false,
                 },
             )
             .expect_err(comment)
@@ -2060,6 +2084,8 @@ mod tests {
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
                     on_informational: &mut None,
+                    #[cfg(feature = "client")]
+                    awaiting_100_continue: &mut false,
                 }
             )
             .expect("parse ok")
@@ -2084,6 +2110,8 @@ mod tests {
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
                     on_informational: &mut None,
+                    #[cfg(feature = "client")]
+                    awaiting_100_continue: &mut false,
                 },
             )
             .expect("parse ok")
@@ -2108,6 +2136,8 @@ mod tests {
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
                     on_informational: &mut None,
+                    #[cfg(feature = "client")]
+                    awaiting_100_continue: &mut false,
                 },
             )
             .expect_err("parse should err")
@@ -2627,6 +2657,8 @@ mod tests {
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
                 on_informational: &mut None,
+                #[cfg(feature = "client")]
+                awaiting_100_continue: &mut false,
             },
         )
         .expect("parse ok")
@@ -2715,6 +2747,8 @@ mod tests {
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
                     on_informational: &mut None,
+                    #[cfg(feature = "client")]
+                    awaiting_100_continue: &mut false,
                 },
             )
             .unwrap()
@@ -2759,6 +2793,8 @@ mod tests {
                     h09_responses: false,
                     #[cfg(feature = "ffi")]
                     on_informational: &mut None,
+                    #[cfg(feature = "client")]
+                    awaiting_100_continue: &mut false,
                 },
             )
             .unwrap()


### PR DESCRIPTION
This patch modifies hyper clients to respect the `Expect: 100-Continue` header.
When the header is present on a request, the client will not send the request body
until the `100 Continue` informational response is received from the server.
Related issue: #2565

The implementation follows the existing `on_informational` callback mechanism,
threading the connection state through to the reponse header parsing.

This seems like the most straightforward modification to get `Expect: 100-Continue`
support, but happy to discuss alternatives.