### PR TITLE
refactor(lib): remove lint config to allow unused code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,6 @@ include = [
 
 [dependencies]
 bytes = "1"
-futures-channel = "0.3"
-futures-util = { version = "0.3", default-features = false }
 http = "1"
 http-body = "1"
 pin-project-lite = "0.2.4"
@@ -30,6 +28,8 @@ tokio = { version = "1", features = ["sync"] }
 
 # Optional
 
+futures-channel = { version = "0.3", optional = true }
+futures-util = { version = "0.3", default-features = false, optional = true }
 h2 = { version = "0.4", optional = true }
 http-body-util = { version = "0.1", optional = true }
 httparse = { version = "1.8", optional = true }
@@ -74,8 +74,8 @@ full = [
 ]
 
 # HTTP versions
-http1 = ["dep:httparse", "dep:itoa"]
-http2 = ["dep:h2"]
+http1 = ["dep:futures-channel", "dep:futures-util", "dep:httparse", "dep:itoa"]
+http2 = ["dep:futures-channel", "dep:futures-util", "dep:h2"]
 
 # Client/Server
 client = ["dep:want"]

--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -40,6 +40,10 @@ impl DecodedLength {
     }
 
     /// Converts to an Option<u64> representing a Known or Unknown length.
+    #[cfg(all(
+        any(feature = "http1", feature = "http2"),
+        any(feature = "client", feature = "server")
+    ))]
     pub(crate) fn into_opt(self) -> Option<u64> {
         match self {
             DecodedLength::CHUNKED | DecodedLength::CLOSE_DELIMITED => None,
@@ -58,6 +62,10 @@ impl DecodedLength {
         }
     }
 
+    #[cfg(all(
+        any(feature = "http1", feature = "http2"),
+        any(feature = "client", feature = "server")
+    ))]
     pub(crate) fn sub_if(&mut self, amt: u64) {
         match *self {
             DecodedLength::CHUNKED | DecodedLength::CLOSE_DELIMITED => (),

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -28,6 +28,10 @@ pub use self::incoming::Incoming;
 
 #[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
 pub(crate) use self::incoming::Sender;
+#[cfg(all(
+    any(feature = "http1", feature = "http2"),
+    any(feature = "client", feature = "server")
+))]
 pub(crate) use self::length::DecodedLength;
 
 mod incoming;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,7 @@
+#[cfg(all(
+    any(feature = "client", feature = "server"),
+    any(feature = "http1", feature = "http2")
+))]
 macro_rules! ready {
     ($e:expr) => {
         match $e {
@@ -18,4 +22,5 @@ pub(crate) mod task;
     all(any(feature = "client", feature = "server"), feature = "http2"),
 ))]
 pub(crate) mod time;
+#[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
 pub(crate) mod watch;

--- a/src/common/watch.rs
+++ b/src/common/watch.rs
@@ -15,6 +15,7 @@ type Value = usize;
 
 pub(crate) const CLOSED: usize = 0;
 
+#[cfg(all(feature = "http1", any(feature = "client", feature = "server")))]
 pub(crate) fn channel(initial: Value) -> (Sender, Receiver) {
     debug_assert!(
         initial != CLOSED,

--- a/src/common/watch.rs
+++ b/src/common/watch.rs
@@ -15,7 +15,6 @@ type Value = usize;
 
 pub(crate) const CLOSED: usize = 0;
 
-#[cfg(all(feature = "http1", any(feature = "client", feature = "server")))]
 pub(crate) fn channel(initial: Value) -> (Sender, Receiver) {
     debug_assert!(
         initial != CLOSED,


### PR DESCRIPTION
Removes the lint configs of allowing unused code, and adds features `cfg` attributes to them.