### PR TITLE
refactor(common): move common feature cfg in common::task to common::mod

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod buf;
 #[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 pub(crate) mod date;
 pub(crate) mod io;
+#[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
 pub(crate) mod task;
 #[cfg(any(
     all(feature = "server", feature = "http1"),

--- a/src/common/task.rs
+++ b/src/common/task.rs
@@ -1,10 +1,8 @@
-#[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
 use std::task::{Context, Poll};
 
 /// A function to help "yield" a future, such that it is re-scheduled immediately.
 ///
 /// Useful for spin counts, so a future doesn't hog too much time.
-#[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
 pub(crate) fn yield_now(cx: &mut Context<'_>) -> Poll<std::convert::Infallible> {
     cx.waker().wake_by_ref();
     Poll::Pending


### PR DESCRIPTION
Reduces the redundant feature cfg.