### PR TITLE
h2: "readd" max_pending_accept_reset_streams configuration option

### DIFF
--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -49,6 +49,7 @@ pub(crate) struct Config {
     pub(crate) max_frame_size: u32,
     pub(crate) enable_connect_protocol: bool,
     pub(crate) max_concurrent_streams: Option<u32>,
+    pub(crate) max_pending_accept_reset_streams: Option<usize>,
     pub(crate) keep_alive_interval: Option<Duration>,
     pub(crate) keep_alive_timeout: Duration,
     pub(crate) max_send_buffer_size: usize,
@@ -64,6 +65,7 @@ impl Default for Config {
             max_frame_size: DEFAULT_MAX_FRAME_SIZE,
             enable_connect_protocol: false,
             max_concurrent_streams: Some(200),
+            max_pending_accept_reset_streams: None,
             keep_alive_interval: None,
             keep_alive_timeout: Duration::from_secs(20),
             max_send_buffer_size: DEFAULT_MAX_SEND_BUF_SIZE,
@@ -130,6 +132,9 @@ where
             .max_send_buffer_size(config.max_send_buffer_size);
         if let Some(max) = config.max_concurrent_streams {
             builder.max_concurrent_streams(max);
+        }
+        if let Some(max) = config.max_pending_accept_reset_streams {
+            builder.max_pending_accept_reset_streams(max);
         }
         if config.enable_connect_protocol {
             builder.enable_connect_protocol();

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -120,6 +120,17 @@ impl<E> Builder<E> {
         }
     }
 
+    /// Configures the maximum number of pending reset streams allowed before a GOAWAY will be sent.
+    ///
+    /// This will default to the default value set by the [`h2` crate](https://crates.io/crates/h2).
+    /// As of v0.4.0, it is 20.
+    ///
+    /// See <https://github.com/hyperium/hyper/issues/2877> for more information.
+    pub fn max_pending_accept_reset_streams(&mut self, max: impl Into<Option<usize>>) -> &mut Self {
+        self.h2_builder.max_pending_accept_reset_streams = max.into();
+        self
+    }
+
     /// Sets the [`SETTINGS_INITIAL_WINDOW_SIZE`][spec] option for HTTP2
     /// stream-level flow control.
     ///


### PR DESCRIPTION
This PR is a partial reimplementation of @Noah-Kennedy's changes in #3201.

As described in hyperium/hyper#3461, `hyper` is missing the `max_pending_accept_reset_streams` added to `h2` in #3201. 

I essentially copy/pasted Noah's code, but not sure how to signal that he wrote the code in this PR. Not a git wizard, so if there's some way to remerge his changes from the original PR, I will close this.

~~Edit: Per the PR guidelines, happy to add tests for the existing configuration values to prevent this from re-occurring.~~
 wouldn't have stopped this from happening 🤷, just lmk