### PR TITLE
feat(http1): support configurable `max_headers`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ httpdate = { version = "1.0", optional = true }
 itoa = { version = "1", optional = true }
 libc = { version = "0.2", optional = true }
 pin-project-lite = { version = "0.2.4", optional = true }
+smallvec = { version = "1.12", features = ["const_generics", "const_new"], optional = true }
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 want = { version = "0.3", optional = true }
 
@@ -80,8 +81,8 @@ http1 = ["dep:futures-channel", "dep:futures-util", "dep:httparse", "dep:itoa"]
 http2 = ["dep:futures-channel", "dep:futures-util", "dep:h2"]
 
 # Client/Server
-client = ["dep:want", "dep:pin-project-lite"]
-server = ["dep:httpdate", "dep:pin-project-lite"]
+client = ["dep:want", "dep:pin-project-lite", "dep:smallvec"]
+server = ["dep:httpdate", "dep:pin-project-lite", "dep:smallvec"]
 
 # C-API support (currently unstable (no semver))
 ffi = ["dep:libc", "dep:http-body-util"]

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -54,6 +54,7 @@ where
                 keep_alive: KA::Busy,
                 method: None,
                 h1_parser_config: ParserConfig::default(),
+                h1_max_headers: None,
                 #[cfg(feature = "server")]
                 h1_header_read_timeout: None,
                 #[cfg(feature = "server")]
@@ -132,6 +133,10 @@ where
         self.state.h09_responses = true;
     }
 
+    pub(crate) fn set_http1_max_headers(&mut self, val: usize) {
+        self.state.h1_max_headers = Some(val);
+    }
+
     #[cfg(feature = "server")]
     pub(crate) fn set_http1_header_read_timeout(&mut self, val: Duration) {
         self.state.h1_header_read_timeout = Some(val);
@@ -207,6 +212,7 @@ where
                 cached_headers: &mut self.state.cached_headers,
                 req_method: &mut self.state.method,
                 h1_parser_config: self.state.h1_parser_config.clone(),
+                h1_max_headers: self.state.h1_max_headers,
                 #[cfg(feature = "server")]
                 h1_header_read_timeout: self.state.h1_header_read_timeout,
                 #[cfg(feature = "server")]
@@ -847,6 +853,7 @@ struct State {
     /// a body or not.
     method: Option<Method>,
     h1_parser_config: ParserConfig,
+    h1_max_headers: Option<usize>,
     #[cfg(feature = "server")]
     h1_header_read_timeout: Option<Duration>,
     #[cfg(feature = "server")]

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -184,6 +184,7 @@ where
                     cached_headers: parse_ctx.cached_headers,
                     req_method: parse_ctx.req_method,
                     h1_parser_config: parse_ctx.h1_parser_config.clone(),
+                    h1_max_headers: parse_ctx.h1_max_headers,
                     #[cfg(feature = "server")]
                     h1_header_read_timeout: parse_ctx.h1_header_read_timeout,
                     #[cfg(feature = "server")]
@@ -725,6 +726,7 @@ mod tests {
                 cached_headers: &mut None,
                 req_method: &mut None,
                 h1_parser_config: Default::default(),
+                h1_max_headers: None,
                 h1_header_read_timeout: None,
                 h1_header_read_timeout_fut: &mut None,
                 h1_header_read_timeout_running: &mut false,

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -78,6 +78,7 @@ pub(crate) struct ParseContext<'a> {
     cached_headers: &'a mut Option<HeaderMap>,
     req_method: &'a mut Option<Method>,
     h1_parser_config: ParserConfig,
+    h1_max_headers: Option<usize>,
     #[cfg(feature = "server")]
     h1_header_read_timeout: Option<Duration>,
     #[cfg(feature = "server")]

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -75,6 +75,7 @@ pub struct Builder {
     h1_keep_alive: bool,
     h1_title_case_headers: bool,
     h1_preserve_header_case: bool,
+    h1_max_headers: Option<usize>,
     h1_header_read_timeout: Dur,
     h1_writev: Option<bool>,
     max_buf_size: Option<usize>,
@@ -242,6 +243,7 @@ impl Builder {
             h1_keep_alive: true,
             h1_title_case_headers: false,
             h1_preserve_header_case: false,
+            h1_max_headers: None,
             h1_header_read_timeout: Dur::Default(Some(Duration::from_secs(30))),
             h1_writev: None,
             max_buf_size: None,
@@ -291,6 +293,24 @@ impl Builder {
     /// Default is false.
     pub fn preserve_header_case(&mut self, enabled: bool) -> &mut Self {
         self.h1_preserve_header_case = enabled;
+        self
+    }
+
+    /// Set the maximum number of headers.
+    ///
+    /// When a request is received, the parser will reserve a buffer to store headers for optimal
+    /// performance.
+    ///
+    /// If server receives more headers than the buffer size, it responds to the client with
+    /// "431 Request Header Fields Too Large".
+    ///
+    /// Note that headers is allocated on the stack by default, which has higher performance. After
+    /// setting this value, headers will be allocated in heap memory, that is, heap memory
+    /// allocation will occur for each request, and there will be a performance drop of about 5%.
+    ///
+    /// Default is 100.
+    pub fn max_headers(&mut self, val: usize) -> &mut Self {
+        self.h1_max_headers = Some(val);
         self
     }
 
@@ -411,6 +431,9 @@ impl Builder {
         }
         if self.h1_preserve_header_case {
             conn.set_preserve_header_case();
+        }
+        if let Some(max_headers) = self.h1_max_headers {
+            conn.set_http1_max_headers(max_headers);
         }
         if let Some(dur) = self
             .timer


### PR DESCRIPTION
Recently we encountered a problem when using `hyper`.

After the client sent the request, it received response `431 Request Header Fields Too Large`. After investigation, we found that `hyper` sets an upper limit on the number of `headers`, and this upper limit is a fixed and non-configurable value.

#3283 also encountered similar problems.

This PR sets `max_headers` to a configurable value. Its default value remains the same as the previous code, and we can set this value when needed.

Additionally, unit tests have been added and the current code passes.