### PR TITLE
feat(http2): add `initial_max_send_streams` method to HTTP/2 client builder

### DIFF
--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -310,15 +310,11 @@ where
     /// This value will be overwritten by the value included in the initial
     /// SETTINGS frame received from the peer as part of a [connection preface].
     ///
-    /// Passing `None` will do nothing.
-    ///
-    /// If not set, hyper will use a default.
+    /// The default value is determined by the `h2` crate, but may change.
     ///
     /// [connection preface]: https://httpwg.org/specs/rfc9113.html#preface
     pub fn initial_max_send_streams(&mut self, initial: impl Into<Option<usize>>) -> &mut Self {
-        if let Some(initial) = initial.into() {
-            self.h2_builder.initial_max_send_streams = initial;
-        }
+        self.h2_builder.initial_max_send_streams = initial.into();
         self
     }
 

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -305,6 +305,23 @@ where
         self
     }
 
+    /// Sets the initial maximum of locally initiated (send) streams.
+    ///
+    /// This value will be overwritten by the value included in the initial
+    /// SETTINGS frame received from the peer as part of a [connection preface].
+    ///
+    /// Passing `None` will do nothing.
+    ///
+    /// If not set, hyper will use a default.
+    ///
+    /// [connection preface]: https://httpwg.org/specs/rfc9113.html#preface
+    pub fn initial_max_send_streams(&mut self, initial: impl Into<Option<usize>>) -> &mut Self {
+        if let Some(initial) = initial.into() {
+            self.h2_builder.initial_max_send_streams = initial;
+        }
+        self
+    }
+
     /// Sets whether to use an adaptive flow control.
     ///
     /// Enabling this will override the limits set in

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -52,21 +52,12 @@ const DEFAULT_STREAM_WINDOW: u32 = 1024 * 1024 * 2; // 2mb
 const DEFAULT_MAX_FRAME_SIZE: u32 = 1024 * 16; // 16kb
 const DEFAULT_MAX_SEND_BUF_SIZE: usize = 1024 * 1024; // 1mb
 
-// The maximum number of concurrent streams that the client is allowed to open
-// before it receives the initial SETTINGS frame from the server.
-// This default value is derived from what the HTTP/2 spec recommends as the
-// minimum value that endpoints advertise to their peers. It means that using
-// this value will minimize the chance of the failure where the local endpoint
-// attempts to open too many streams and gets rejected by the remote peer with
-// the `REFUSED_STREAM` error.
-const DEFAULT_INITIAL_MAX_SEND_STREAMS: usize = 100;
-
 #[derive(Clone, Debug)]
 pub(crate) struct Config {
     pub(crate) adaptive_window: bool,
     pub(crate) initial_conn_window_size: u32,
     pub(crate) initial_stream_window_size: u32,
-    pub(crate) initial_max_send_streams: usize,
+    pub(crate) initial_max_send_streams: Option<usize>,
     pub(crate) max_frame_size: u32,
     pub(crate) keep_alive_interval: Option<Duration>,
     pub(crate) keep_alive_timeout: Duration,
@@ -81,7 +72,7 @@ impl Default for Config {
             adaptive_window: false,
             initial_conn_window_size: DEFAULT_CONN_WINDOW,
             initial_stream_window_size: DEFAULT_STREAM_WINDOW,
-            initial_max_send_streams: DEFAULT_INITIAL_MAX_SEND_STREAMS,
+            initial_max_send_streams: None,
             max_frame_size: DEFAULT_MAX_FRAME_SIZE,
             keep_alive_interval: None,
             keep_alive_timeout: Duration::from_secs(20),
@@ -95,12 +86,14 @@ impl Default for Config {
 fn new_builder(config: &Config) -> Builder {
     let mut builder = Builder::default();
     builder
-        .initial_max_send_streams(config.initial_max_send_streams)
         .initial_window_size(config.initial_stream_window_size)
         .initial_connection_window_size(config.initial_conn_window_size)
         .max_frame_size(config.max_frame_size)
         .max_send_buffer_size(config.max_send_buffer_size)
         .enable_push(false);
+    if let Some(initial_max_send_streams) = config.initial_max_send_streams {
+        builder.initial_max_send_streams(initial_max_send_streams);
+    }
     if let Some(max) = config.max_concurrent_reset_streams {
         builder.max_concurrent_reset_streams(max);
     }

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -52,11 +52,21 @@ const DEFAULT_STREAM_WINDOW: u32 = 1024 * 1024 * 2; // 2mb
 const DEFAULT_MAX_FRAME_SIZE: u32 = 1024 * 16; // 16kb
 const DEFAULT_MAX_SEND_BUF_SIZE: usize = 1024 * 1024; // 1mb
 
+// The maximum number of concurrent streams that the client is allowed to open
+// before it receives the initial SETTINGS frame from the server.
+// This default value is derived from what the HTTP/2 spec recommends as the
+// minimum value that endpoints advertise to their peers. It means that using
+// this value will minimize the chance of the failure where the local endpoint
+// attempts to open too many streams and gets rejected by the remote peer with
+// the `REFUSED_STREAM` error.
+const DEFAULT_INITIAL_MAX_SEND_STREAMS: usize = 100;
+
 #[derive(Clone, Debug)]
 pub(crate) struct Config {
     pub(crate) adaptive_window: bool,
     pub(crate) initial_conn_window_size: u32,
     pub(crate) initial_stream_window_size: u32,
+    pub(crate) initial_max_send_streams: usize,
     pub(crate) max_frame_size: u32,
     pub(crate) keep_alive_interval: Option<Duration>,
     pub(crate) keep_alive_timeout: Duration,
@@ -71,6 +81,7 @@ impl Default for Config {
             adaptive_window: false,
             initial_conn_window_size: DEFAULT_CONN_WINDOW,
             initial_stream_window_size: DEFAULT_STREAM_WINDOW,
+            initial_max_send_streams: DEFAULT_INITIAL_MAX_SEND_STREAMS,
             max_frame_size: DEFAULT_MAX_FRAME_SIZE,
             keep_alive_interval: None,
             keep_alive_timeout: Duration::from_secs(20),
@@ -84,6 +95,7 @@ impl Default for Config {
 fn new_builder(config: &Config) -> Builder {
     let mut builder = Builder::default();
     builder
+        .initial_max_send_streams(config.initial_max_send_streams)
         .initial_window_size(config.initial_stream_window_size)
         .initial_connection_window_size(config.initial_conn_window_size)
         .max_frame_size(config.max_frame_size)


### PR DESCRIPTION
This adds `initial_max_send_streams` method to the HTTP/2 client builder.

The value set via this method will then be forwarded to [`h2::client::Builder::initial_max_send_streams`]. If not set, the default value defined in `h2` crate will be used in case some users might rely on this behavior. However, in the following version we plan to explicitly set `100` as a reasonable default value (see https://github.com/hyperium/h2/issues/731 for rationale on why this can be considered a reasonable value).

[`h2::client::Builder::initial_max_send_streams`]: https://docs.rs/h2/0.4.1/h2/client/struct.Builder.html#method.initial_max_send_streams

