### PR TITLE
Bumb h2 version to 0.3.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ http = "0.2"
 http-body = "0.4"
 httpdate = "1.0"
 httparse = "1.8"
-h2 = { version = "0.3.17", optional = true }
+h2 = { version = "0.3.24", optional = true }
 itoa = "1"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 pin-project-lite = "0.2.4"


### PR DESCRIPTION
This is to address the following advisory:
https://rustsec.org/advisories/RUSTSEC-2024-0003.html

