### PR TITLE
test(body): re-enable miri on a few channel tests

### DIFF
--- a/src/body/incoming.rs
+++ b/src/body/incoming.rs
@@ -554,7 +554,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(miri))] // TODO issue #3015
     fn channel_wanter() {
         let (mut tx, mut rx) =
             Incoming::new_channel(DecodedLength::CHUNKED, /*wanter = */ true);
@@ -577,7 +576,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(miri))] // TODO issue #3015
     fn channel_notices_closure() {
         let (mut tx, rx) = Incoming::new_channel(DecodedLength::CHUNKED, /*wanter = */ true);
 


### PR DESCRIPTION
After prodding from https://github.com/hyperium/hyper/issues/3015#issuecomment-1829333578, checking to see if this works now.