### PR TITLE
fix(http2): typo in trace logging

### DIFF
--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -426,7 +426,7 @@ where
         let opts = self.clone();
 
         async move {
-            trace!("client handshake HTTP2");
+            trace!("client handshake HTTP/2");
 
             let (tx, rx) = dispatch::channel();
             let h2 = proto::h2::client::handshake(io, rx, &opts.h2_builder, opts.exec, opts.timer)

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -426,7 +426,7 @@ where
         let opts = self.clone();
 
         async move {
-            trace!("client handshake HTTP/1");
+            trace!("client handshake HTTP2");
 
             let (tx, rx) = dispatch::channel();
             let h2 = proto::h2::client::handshake(io, rx, &opts.h2_builder, opts.exec, opts.timer)


### PR DESCRIPTION
fix simple typo in trace logging for http2 connection handshake.