### PR TITLE
fix(http2): `initial_max_send_streams` defaults to 100

### DIFF
--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -310,11 +310,15 @@ where
     /// This value will be overwritten by the value included in the initial
     /// SETTINGS frame received from the peer as part of a [connection preface].
     ///
-    /// The default value is determined by the `h2` crate, but may change.
+    /// Passing `None` will do nothing.
+    ///
+    /// If not set, hyper will use a default.
     ///
     /// [connection preface]: https://httpwg.org/specs/rfc9113.html#preface
     pub fn initial_max_send_streams(&mut self, initial: impl Into<Option<usize>>) -> &mut Self {
-        self.h2_builder.initial_max_send_streams = initial.into();
+        if let Some(initial) = initial.into() {
+            self.h2_builder.initial_max_send_streams = initial;
+        }
         self
     }
 


### PR DESCRIPTION
This sets the default value of `initial_max_send_streams` to 100, which previously was `usize::MAX` as defined in [`h2` crate](https://github.com/hyperium/h2/blob/4ce59557b56943eb8b5d7dc45f97eda3f0ae0104/src/client.rs#L653).

This default value can be considered reasonable given that widely-used HTTP/2 client implementations adopt this value such as nghttp2 and Go's x/net/http2, and [the HTTP/2 spec recommends that HTTP/2 servers should set `MAX_CONCURRENT_STREAM` they advertise to clients to at least 100](https://www.rfc-editor.org/rfc/rfc9113.html#section-6.5.2-2.6.1). More details can be found at https://github.com/hyperium/h2/issues/731.

Continuation of #3524