### PR TITLE
chore(lib): update to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 keywords = ["http", "hyper", "hyperium"]
 categories = ["network-programming", "web-programming::http-client", "web-programming::http-server"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.63" # keep in sync with MSRV.md dev doc
 
 include = [
@@ -23,7 +23,6 @@ include = [
 bytes = "1"
 http = "1"
 http-body = "1"
-pin-project-lite = "0.2.4"
 tokio = { version = "1", features = ["sync"] }
 
 # Optional
@@ -36,6 +35,7 @@ httparse = { version = "1.8", optional = true }
 httpdate = { version = "1.0", optional = true }
 itoa = { version = "1", optional = true }
 libc = { version = "0.2", optional = true }
+pin-project-lite = { version = "0.2.4", optional = true }
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 want = { version = "0.3", optional = true }
 
@@ -80,8 +80,8 @@ http1 = ["dep:futures-channel", "dep:futures-util", "dep:httparse", "dep:itoa"]
 http2 = ["dep:futures-channel", "dep:futures-util", "dep:h2"]
 
 # Client/Server
-client = ["dep:want"]
-server = ["dep:httpdate"]
+client = ["dep:want", "dep:pin-project-lite"]
+server = ["dep:httpdate", "dep:pin-project-lite"]
 
 # C-API support (currently unstable (no semver))
 ffi = ["dep:libc", "dep:http-body-util"]

--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -413,6 +413,7 @@ fn spawn_server(rt: &tokio::runtime::Runtime, opts: &Opts) -> SocketAddr {
     let body = opts.response_body;
     let opts = opts.clone();
     rt.spawn(async move {
+        let _ = &opts;
         while let Ok((sock, _)) = listener.accept().await {
             let io = support::TokioIo::new(sock);
             if opts.http2 {

--- a/src/ffi/body.rs
+++ b/src/ffi/body.rs
@@ -150,6 +150,7 @@ ffi_fn! {
         let userdata = UserDataPointer(userdata);
 
         Box::into_raw(hyper_task::boxed(async move {
+            let _ = &userdata;
             while let Some(item) = body.0.frame().await {
                 let frame = item?;
                 if let Ok(chunk) = frame.into_data() {


### PR DESCRIPTION
Our MSRV is already past when 2021 edition was introduced, so might as well. It gets us a the better resolver for dependencies.

Closes #3541 