### PR TITLE
chore(lib): remove importing prelude trait in 2021 edition

### DIFF
--- a/src/ext/h1_reason_phrase.rs
+++ b/src/ext/h1_reason_phrase.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use bytes::Bytes;
 
 /// A reason phrase in an HTTP/1 response.

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -436,8 +436,6 @@ impl std::error::Error for NotEof {}
 
 #[cfg(test)]
 mod tests {
-    use std::iter::FromIterator;
-
     use bytes::BufMut;
     use http::{
         header::{

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -5,7 +5,6 @@ use std::convert::Infallible;
 use std::fmt;
 use std::future::Future;
 use std::io::{Read, Write};
-use std::iter::FromIterator;
 use std::net::{SocketAddr, TcpListener};
 use std::pin::Pin;
 use std::thread;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,7 +1,6 @@
 #![deny(warnings)]
 #![deny(rust_2018_idioms)]
 
-use std::convert::TryInto;
 use std::future::Future;
 use std::io::{self, Read, Write};
 use std::net::TcpListener as StdTcpListener;


### PR DESCRIPTION
These traits are now part of the 2021 edition's prelude.