### PR TITLE
fix(rt): `Sleep::downcast_mut_pin()` no longer extend lifetime

### DIFF
--- a/src/rt/timer.rs
+++ b/src/rt/timer.rs
@@ -104,7 +104,7 @@ impl dyn Sleep {
     }
 
     /// Downcast a pinned &mut Sleep object to its original type
-    pub fn downcast_mut_pin<T>(self: Pin<&mut Self>) -> Option<Pin<&'static mut T>>
+    pub fn downcast_mut_pin<T>(self: Pin<&mut Self>) -> Option<Pin<&mut T>>
     where
         T: Sleep + 'static,
     {


### PR DESCRIPTION
This lifetime extension was a mistake.

Closes #3556

BREAKING CHANGE: The returned lifetime from `Sleep::downcast_mut_pin()`
  is no longer `'static`. This shouldn't affect most usage. This sort of
  breaking change is needed because it is _wrong_.

