### PR TITLE
chore(ci): update to cargo-check-external-types 0.1.11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -247,12 +247,12 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2023-10-10  # Compatible version for cargo-check-external-types
+          toolchain: nightly-2024-02-07  # Compatible version for cargo-check-external-types
 
       - name: Install cargo-check-external-types
         uses: taiki-e/cache-cargo-install-action@v1
         with:
-          tool: cargo-check-external-types@0.1.9
+          tool: cargo-check-external-types@0.1.11
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
Updates to `cargo-check-external-types` 0.1.11.