### PR TITLE
refactor(error): resolve unused trait error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -601,11 +601,6 @@ impl From<http::uri::InvalidUriParts> for Parse {
     }
 }
 
-#[doc(hidden)]
-trait AssertSendSync: Send + Sync + 'static {}
-#[doc(hidden)]
-impl AssertSendSync for Error {}
-
 // ===== impl TimedOut ====
 
 impl fmt::Display for TimedOut {
@@ -620,6 +615,13 @@ impl StdError for TimedOut {}
 mod tests {
     use super::*;
     use std::mem;
+
+    fn assert_send_sync<T: Send + Sync + 'static>() {}
+
+    #[test]
+    fn error_satisfies_send_sync() {
+        assert_send_sync::<Error>()
+    }
 
     #[test]
     fn error_size_of() {


### PR DESCRIPTION
Resolves an unused trait error.