### PR TITLE
chore: use `Trait` rather than `Into<Box<dyn Trait>>`

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -61,7 +61,7 @@ impl<T, B> Connection<T, B>
 where
     T: Read + Write + Unpin + 'static,
     B: Body + 'static,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
 {
     /// Return the inner IO object, and additional information.
     ///
@@ -131,7 +131,7 @@ where
     T: Read + Write + Unpin + 'static,
     B: Body + 'static,
     B::Data: Send,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
 {
     Builder::new().handshake(io).await
 }
@@ -253,7 +253,7 @@ impl<T, B> Connection<T, B>
 where
     T: Read + Write + Unpin + Send + 'static,
     B: Body + 'static,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
 {
     /// Enable this connection to support higher-level HTTP upgrades.
     ///
@@ -278,7 +278,7 @@ where
     T: Read + Write + Unpin + 'static,
     B: Body + 'static,
     B::Data: Send,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
 {
     type Output = crate::Result<()>;
 
@@ -516,7 +516,7 @@ impl Builder {
         T: Read + Write + Unpin + 'static,
         B: Body + 'static,
         B::Data: Send,
-        B::Error: Into<Box<dyn StdError + Send + Sync>>,
+        B::Error: StdError + Send + Sync,
     {
         let opts = self.clone();
 
@@ -579,7 +579,7 @@ mod upgrades {
     where
         T: Read + Write + Unpin + Send + 'static,
         B: Body + 'static,
-        B::Error: Into<Box<dyn StdError + Send + Sync>>,
+        B::Error: StdError + Send + Sync,
     {
         pub(super) inner: Option<Connection<T, B>>,
     }
@@ -589,7 +589,7 @@ mod upgrades {
         I: Read + Write + Unpin + Send + 'static,
         B: Body + 'static,
         B::Data: Send,
-        B::Error: Into<Box<dyn StdError + Send + Sync>>,
+        B::Error: StdError + Send + Sync,
     {
         type Output = crate::Result<()>;
 

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -43,7 +43,7 @@ where
     T: Read + Write + 'static + Unpin,
     B: Body + 'static,
     E: Http2ClientConnExec<B, T> + Unpin,
-    B::Error: Into<Box<dyn Error + Send + Sync>>,
+    B::Error: Error + Send + Sync,
 {
     inner: (PhantomData<T>, proto::h2::ClientTask<B, E, T>),
 }
@@ -73,7 +73,7 @@ where
     T: Read + Write + Unpin + 'static,
     B: Body + 'static,
     B::Data: Send,
-    B::Error: Into<Box<dyn Error + Send + Sync>>,
+    B::Error: Error + Send + Sync,
     E: Http2ClientConnExec<B, T> + Unpin + Clone,
 {
     Builder::new(exec).handshake(io).await
@@ -202,7 +202,7 @@ where
     T: Read + Write + Unpin + 'static,
     B: Body + Unpin + 'static,
     B::Data: Send,
-    B::Error: Into<Box<dyn Error + Send + Sync>>,
+    B::Error: Error + Send + Sync,
     E: Http2ClientConnExec<B, T> + Unpin,
 {
     /// Returns whether the [extended CONNECT protocol][1] is enabled or not.
@@ -224,7 +224,7 @@ where
     T: Read + Write + fmt::Debug + 'static + Unpin,
     B: Body + 'static,
     E: Http2ClientConnExec<B, T> + Unpin,
-    B::Error: Into<Box<dyn Error + Send + Sync>>,
+    B::Error: Error + Send + Sync,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Connection").finish()
@@ -237,7 +237,7 @@ where
     B: Body + 'static + Unpin,
     B::Data: Send,
     E: Unpin,
-    B::Error: Into<Box<dyn Error + Send + Sync>>,
+    B::Error: Error + Send + Sync,
     E: Http2ClientConnExec<B, T> + 'static + Send + Sync + Unpin,
 {
     type Output = crate::Result<()>;
@@ -420,7 +420,7 @@ where
         T: Read + Write + Unpin + 'static,
         B: Body + 'static,
         B::Data: Send,
-        B::Error: Into<Box<dyn Error + Send + Sync>>,
+        B::Error: Error + Send + Sync,
         Ex: Http2ClientConnExec<B, T> + Unpin,
     {
         let opts = self.clone();

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -69,11 +69,11 @@ where
             PollBody = Bs,
             RecvItem = MessageHead<T::Incoming>,
         > + Unpin,
-    D::PollError: Into<Box<dyn StdError + Send + Sync>>,
+    D::PollError: StdError + Send + Sync,
     I: Read + Write + Unpin,
     T: Http1Transaction + Unpin,
     Bs: Body + 'static,
-    Bs::Error: Into<Box<dyn StdError + Send + Sync>>,
+    Bs::Error: StdError + Send + Sync,
 {
     pub(crate) fn new(dispatch: D, conn: Conn<I, Bs::Data, T>) -> Self {
         Dispatcher {
@@ -434,11 +434,11 @@ where
             PollBody = Bs,
             RecvItem = MessageHead<T::Incoming>,
         > + Unpin,
-    D::PollError: Into<Box<dyn StdError + Send + Sync>>,
+    D::PollError: StdError + Send + Sync,
     I: Read + Write + Unpin,
     T: Http1Transaction + Unpin,
     Bs: Body + 'static,
-    Bs::Error: Into<Box<dyn StdError + Send + Sync>>,
+    Bs::Error: StdError + Send + Sync,
 {
     type Output = crate::Result<Dispatched>;
 
@@ -497,7 +497,7 @@ cfg_server! {
     impl<S, Bs> Dispatch for Server<S, IncomingBody>
     where
         S: HttpService<IncomingBody, ResBody = Bs>,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        S::Error: StdError + Send + Sync,
         Bs: Body,
     {
         type PollItem = MessageHead<http::StatusCode>;

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -125,7 +125,7 @@ where
     B: Body + 'static,
     B::Data: Send + 'static,
     E: Http2ClientConnExec<B, T> + Unpin,
-    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    B::Error: std::error::Error + Send + Sync,
 {
     let (h2_tx, mut conn) = new_builder(config)
         .handshake::<_, SendBuf<B::Data>>(Compat::new(io))
@@ -336,7 +336,7 @@ pin_project! {
     where
         B: http_body::Body,
         B: 'static,
-        B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        B::Error: std::error::Error + Send + Sync,
         T: Read,
         T: Write,
         T: Unpin,
@@ -359,7 +359,7 @@ pin_project! {
 impl<B, T> Future for H2ClientFuture<B, T>
 where
     B: http_body::Body + 'static,
-    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    B::Error: std::error::Error + Send + Sync,
     T: Read + Write + Unpin,
 {
     type Output = ();
@@ -408,7 +408,7 @@ impl<B, E, T> ClientTask<B, E, T>
 where
     B: Body + 'static,
     E: Http2ClientConnExec<B, T> + Unpin,
-    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    B::Error: std::error::Error + Send + Sync,
     T: Read + Write + Unpin,
 {
     pub(crate) fn is_extended_connect_protocol_enabled(&self) -> bool {
@@ -433,7 +433,7 @@ pin_project! {
 impl<B> Future for PipeMap<B>
 where
     B: http_body::Body,
-    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    B::Error: std::error::Error + Send + Sync,
 {
     type Output = ();
 
@@ -460,7 +460,7 @@ where
     B: Body + 'static + Unpin,
     B::Data: Send,
     E: Http2ClientConnExec<B, T> + Unpin,
-    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    B::Error: std::error::Error + Send + Sync,
     T: Read + Write + Unpin,
 {
     fn poll_pipe(&mut self, f: FutCtx<B>, cx: &mut Context<'_>) {
@@ -594,7 +594,7 @@ impl<B, E, T> Future for ClientTask<B, E, T>
 where
     B: Body + 'static + Unpin,
     B::Data: Send,
-    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    B::Error: std::error::Error + Send + Sync,
     E: Http2ClientConnExec<B, T> + 'static + Send + Sync + Unpin,
     T: Read + Write + Unpin,
 {

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -114,7 +114,7 @@ where
 impl<S> Future for PipeToSendStream<S>
 where
     S: Body,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    S::Error: StdError + Send + Sync,
 {
     type Output = crate::Result<()>;
 
@@ -197,14 +197,14 @@ where
 trait SendStreamExt {
     fn on_user_err<E>(&mut self, err: E) -> crate::Error
     where
-        E: Into<Box<dyn std::error::Error + Send + Sync>>;
+        E: std::error::Error + Send + Sync;
     fn send_eos_frame(&mut self) -> crate::Result<()>;
 }
 
 impl<B: Buf> SendStreamExt for SendStream<SendBuf<B>> {
     fn on_user_err<E>(&mut self, err: E) -> crate::Error
     where
-        E: Into<Box<dyn std::error::Error + Send + Sync>>,
+        E: std::error::Error + Send + Sync,
     {
         let err = crate::Error::new_user_body(err);
         debug!("send body user stream error: {}", err);

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -116,7 +116,7 @@ impl<T, S, B, E> Server<T, S, B, E>
 where
     T: Read + Write + Unpin,
     S: HttpService<IncomingBody, ResBody = B>,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    S::Error: StdError + Send + Sync,
     B: Body + 'static,
     E: Http2ServerConnExec<S::Future, B>,
 {
@@ -196,7 +196,7 @@ impl<T, S, B, E> Future for Server<T, S, B, E>
 where
     T: Read + Write + Unpin,
     S: HttpService<IncomingBody, ResBody = B>,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    S::Error: StdError + Send + Sync,
     B: Body + 'static,
     E: Http2ServerConnExec<S::Future, B>,
 {
@@ -251,7 +251,7 @@ where
     ) -> Poll<crate::Result<()>>
     where
         S: HttpService<IncomingBody, ResBody = B>,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        S::Error: StdError + Send + Sync,
         E: Http2ServerConnExec<S::Future, B>,
     {
         if self.closing.is_none() {
@@ -420,8 +420,8 @@ where
     F: Future<Output = Result<Response<B>, E>>,
     B: Body,
     B::Data: 'static,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
-    E: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
+    E: StdError + Send + Sync,
 {
     fn poll2(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
         let mut me = self.project();
@@ -513,8 +513,8 @@ where
     F: Future<Output = Result<Response<B>, E>>,
     B: Body,
     B::Data: 'static,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
-    E: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
+    E: StdError + Send + Sync,
 {
     type Output = ();
 

--- a/src/rt/bounds.rs
+++ b/src/rt/bounds.rs
@@ -28,7 +28,7 @@ mod h2_client {
     pub trait Http2ClientConnExec<B, T>: sealed_client::Sealed<(B, T)>
     where
         B: http_body::Body,
-        B::Error: Into<Box<dyn Error + Send + Sync>>,
+        B::Error: Error + Send + Sync,
         T: Read + Write + Unpin,
     {
         #[doc(hidden)]
@@ -39,7 +39,7 @@ mod h2_client {
     where
         E: Executor<H2ClientFuture<B, T>>,
         B: http_body::Body + 'static,
-        B::Error: Into<Box<dyn Error + Send + Sync>>,
+        B::Error: Error + Send + Sync,
         H2ClientFuture<B, T>: Future<Output = ()>,
         T: Read + Write + Unpin,
     {
@@ -52,7 +52,7 @@ mod h2_client {
     where
         E: Executor<H2ClientFuture<B, T>>,
         B: http_body::Body + 'static,
-        B::Error: Into<Box<dyn Error + Send + Sync>>,
+        B::Error: Error + Send + Sync,
         H2ClientFuture<B, T>: Future<Output = ()>,
         T: Read + Write + Unpin,
     {

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -118,10 +118,10 @@ where
 impl<I, B, S> Connection<I, S>
 where
     S: HttpService<IncomingBody, ResBody = B>,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    S::Error: StdError + Send + Sync,
     I: Read + Write + Unpin,
     B: Body + 'static,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
 {
     /// Start a graceful shutdown process for this connection.
     ///
@@ -205,10 +205,10 @@ where
 impl<I, B, S> Future for Connection<I, S>
 where
     S: HttpService<IncomingBody, ResBody = B>,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    S::Error: StdError + Send + Sync,
     I: Read + Write + Unpin + 'static,
     B: Body + 'static,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
 {
     type Output = crate::Result<()>;
 
@@ -398,7 +398,7 @@ impl Builder {
     /// # where
     /// #     I: Read + Write + Unpin + Send + 'static,
     /// #     S: Service<hyper::Request<Incoming>, Response=hyper::Response<Incoming>> + Send + 'static,
-    /// #     S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    /// #     S::Error: std::error::Error + Send + Sync,
     /// #     S::Future: Send,
     /// # {
     /// let http = Builder::new();
@@ -413,9 +413,9 @@ impl Builder {
     pub fn serve_connection<I, S>(&self, io: I, service: S) -> Connection<I, S>
     where
         S: HttpService<IncomingBody>,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        S::Error: StdError + Send + Sync,
         S::ResBody: 'static,
-        <S::ResBody as Body>::Error: Into<Box<dyn StdError + Send + Sync>>,
+        <S::ResBody as Body>::Error: StdError + Send + Sync,
         I: Read + Write + Unpin,
     {
         let mut conn = proto::Conn::new(io);
@@ -471,10 +471,10 @@ where
 impl<I, B, S> UpgradeableConnection<I, S>
 where
     S: HttpService<IncomingBody, ResBody = B>,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    S::Error: StdError + Send + Sync,
     I: Read + Write + Unpin,
     B: Body + 'static,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
 {
     /// Start a graceful shutdown process for this connection.
     ///
@@ -488,10 +488,10 @@ where
 impl<I, B, S> Future for UpgradeableConnection<I, S>
 where
     S: HttpService<IncomingBody, ResBody = B>,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    S::Error: StdError + Send + Sync,
     I: Read + Write + Unpin + Send + 'static,
     B: Body + 'static,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
 {
     type Output = crate::Result<()>;
 

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -60,10 +60,10 @@ where
 impl<I, B, S, E> Connection<I, S, E>
 where
     S: HttpService<IncomingBody, ResBody = B>,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    S::Error: StdError + Send + Sync,
     I: Read + Write + Unpin,
     B: Body + 'static,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
     E: Http2ServerConnExec<S::Future, B>,
 {
     /// Start a graceful shutdown process for this connection.
@@ -84,10 +84,10 @@ where
 impl<I, B, S, E> Future for Connection<I, S, E>
 where
     S: HttpService<IncomingBody, ResBody = B>,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    S::Error: StdError + Send + Sync,
     I: Read + Write + Unpin + 'static,
     B: Body + 'static,
-    B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    B::Error: StdError + Send + Sync,
     E: Http2ServerConnExec<S::Future, B>,
 {
     type Output = crate::Result<()>;
@@ -285,9 +285,9 @@ impl<E> Builder<E> {
     pub fn serve_connection<S, I, Bd>(&self, io: I, service: S) -> Connection<I, S, E>
     where
         S: HttpService<IncomingBody, ResBody = Bd>,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        S::Error: StdError + Send + Sync,
         Bd: Body + 'static,
-        Bd::Error: Into<Box<dyn StdError + Send + Sync>>,
+        Bd::Error: StdError + Send + Sync,
         I: Read + Write + Unpin,
         E: Http2ServerConnExec<S::Future, Bd>,
     {

--- a/src/service/http.rs
+++ b/src/service/http.rs
@@ -15,7 +15,7 @@ pub trait HttpService<ReqBody>: sealed::Sealed<ReqBody> {
     /// Note: Returning an `Error` to a hyper server will cause the connection
     /// to be abruptly aborted. In most cases, it is better to return a `Response`
     /// with a 4xx or 5xx status code.
-    type Error: Into<Box<dyn StdError + Send + Sync>>;
+    type Error: StdError + Send + Sync;
 
     /// The `Future` returned by this `Service`.
     type Future: Future<Output = Result<Response<Self::ResBody>, Self::Error>>;
@@ -28,7 +28,7 @@ impl<T, B1, B2> HttpService<B1> for T
 where
     T: Service<Request<B1>, Response = Response<B2>>,
     B2: Body,
-    T::Error: Into<Box<dyn StdError + Send + Sync>>,
+    T::Error: StdError + Send + Sync,
 {
     type ResBody = B2;
 

--- a/src/service/util.rs
+++ b/src/service/util.rs
@@ -49,7 +49,7 @@ where
     F: Fn(Request<ReqBody>) -> Ret,
     ReqBody: Body,
     Ret: Future<Output = Result<Response<ResBody>, E>>,
-    E: Into<Box<dyn StdError + Send + Sync>>,
+    E: StdError + Send + Sync,
     ResBody: Body,
 {
     type Response = crate::Response<ResBody>;


### PR DESCRIPTION
All types with `Error + Send + Sync` can be boxed into `Box<dyn Error + Send + Sync>`, but using `Error ...` directly is more flexible and less restrictive for the user.