### PR TITLE
proto/h1/server: avoid copy-allocation in request path parsing

### DIFF
--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -1,4 +1,3 @@
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{cmp, io};

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -44,7 +44,6 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::future::Future;
 use std::io;
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};


### PR DESCRIPTION
This tweaks the request path parsing logic (in server role) in order to perform zero-copy URI parsing.

Closes: https://github.com/hyperium/hyper/issues/3574