### PR TITLE
chore(docs): add info on required timer for header_read_timeout

### DIFF
--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -316,6 +316,9 @@ impl Builder {
     /// Set a timeout for reading client request headers. If a client does not
     /// transmit the entire header within this time, the connection is closed.
     ///
+    /// Requires a [`Timer`] set by [`Builder::timer`] to take effect. Panics if `header_read_timeout` is configured
+    /// without a [`Timer`].
+    ///
     /// Pass `None` to disable.
     ///
     /// Default is 30 seconds.

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -57,7 +57,7 @@ pin_project_lite::pin_project! {
 /// # fn main() {
 /// let mut http = Builder::new();
 /// // Set options one at a time
-/// http.header_read_timeout(Duration::from_millis(200));
+/// http.half_close(false);
 ///
 /// // Or, chain multiple options
 /// http.keep_alive(false).title_case_headers(true).max_buf_size(8192);


### PR DESCRIPTION
Part of https://github.com/hyperium/hyper/issues/3567

This PR adds more info on the documentation for `header_read_timeout` that it will panic when timeout is configured without timer.