### PR TITLE
feat: relax connection IO trait bounds

### DIFF
--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -205,7 +205,7 @@ impl<I, B, S> Future for Connection<I, S>
 where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: Read + Write + Unpin + 'static,
+    I: Read + Write + Unpin,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
 {

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -84,7 +84,7 @@ impl<I, B, S, E> Future for Connection<I, S, E>
 where
     S: HttpService<IncomingBody, ResBody = B>,
     S::Error: Into<Box<dyn StdError + Send + Sync>>,
-    I: Read + Write + Unpin + 'static,
+    I: Read + Write + Unpin,
     B: Body + 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
     E: Http2ServerConnExec<S::Future, B>,


### PR DESCRIPTION
I can't tell if this was intentional. hyper 0.14.x didn't have this requirement and as far as I can tell it's not actually needed.