### PR TITLE
perf: optimize error type

### DIFF
--- a/src/body/incoming.rs
+++ b/src/body/incoming.rs
@@ -253,7 +253,7 @@ impl Body for Incoming {
                                 Some(h2::Reason::NO_ERROR) | Some(h2::Reason::CANCEL) => {
                                     Poll::Ready(None)
                                 }
-                                _ => Poll::Ready(Some(Err(crate::Error::new_body(e)))),
+                                _ => Poll::Ready(Some(Err(crate::Error::new_body_h2(e)))),
                             };
                         }
                         None => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,7 @@ type Cause = Box<dyn StdError + Send + Sync>;
 /// on**. They may come from private internal dependencies, and are subject to
 /// change at any moment.
 pub struct Error {
-    inner: Box<ErrorImpl>,
+    inner: ErrorImpl,
 }
 
 struct ErrorImpl {
@@ -244,7 +244,7 @@ impl Error {
 
     pub(super) fn new(kind: Kind) -> Error {
         Error {
-            inner: Box::new(ErrorImpl { kind, cause: None }),
+            inner: ErrorImpl { kind, cause: None },
         }
     }
 
@@ -625,7 +625,11 @@ mod tests {
 
     #[test]
     fn error_size_of() {
-        assert_eq!(mem::size_of::<Error>(), mem::size_of::<usize>());
+        assert!(
+            mem::size_of::<Error>() <= mem::size_of::<usize>() * 4,
+            "Size of error was {}, we prefer <= 16",
+            mem::size_of::<Error>()
+        );
     }
 
     #[cfg(feature = "http2")]


### PR DESCRIPTION
The allocations and frees for these errors can get expensive in some cases. Any reduction in allocator usage here helps some use cases a lot it seems.