### PR TITLE
forward implement Service for reference types

### DIFF
--- a/src/service/service.rs
+++ b/src/service/service.rs
@@ -38,3 +38,58 @@ pub trait Service<Request> {
     /// The discussion on this is here: <https://github.com/hyperium/hyper/issues/3040>
     fn call(&self, req: Request) -> Self::Future;
 }
+
+impl<Request, S: Service<Request> + ?Sized> Service<Request> for &'_ S {
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn call(&self, req: Request) -> Self::Future {
+        (**self).call(req)
+    }
+}
+
+impl<Request, S: Service<Request> + ?Sized> Service<Request> for &'_ mut S {
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn call(&self, req: Request) -> Self::Future {
+        (**self).call(req)
+    }
+}
+
+impl<Request, S: Service<Request> + ?Sized> Service<Request> for Box<S> {
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn call(&self, req: Request) -> Self::Future {
+        (**self).call(req)
+    }
+}
+
+impl<Request, S: Service<Request> + ?Sized> Service<Request> for std::rc::Rc<S> {
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn call(&self, req: Request) -> Self::Future {
+        (**self).call(req)
+    }
+}
+
+impl<Request, S: Service<Request> + ?Sized> Service<Request> for std::sync::Arc<S> {
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn call(&self, req: Request) -> Self::Future {
+        (**self).call(req)
+    }
+}


### PR DESCRIPTION
simplifies the usage of `dyn Service`s and making `Service` types `Clone` by wrapping them in a `Rc`or `Arc`