### PR TITLE
feat(h2/client): add `max_pending_accept_reset_streams` option

### DIFF
--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -403,6 +403,17 @@ where
         self
     }
 
+    /// Configures the maximum number of pending reset streams allowed before a GOAWAY will be sent.
+    ///
+    /// This will default to the default value set by the [`h2` crate](https://crates.io/crates/h2).
+    /// As of v0.4.0, it is 20.
+    ///
+    /// See <https://github.com/hyperium/hyper/issues/2877> for more information.
+    pub fn max_pending_accept_reset_streams(&mut self, max: impl Into<Option<usize>>) -> &mut Self {
+        self.h2_builder.max_pending_accept_reset_streams = max.into();
+        self
+    }
+
     /// Constructs a connection with the configured options and IO.
     /// See [`client::conn`](crate::client::conn) for more.
     ///

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -73,6 +73,7 @@ pub(crate) struct Config {
     pub(crate) keep_alive_while_idle: bool,
     pub(crate) max_concurrent_reset_streams: Option<usize>,
     pub(crate) max_send_buffer_size: usize,
+    pub(crate) max_pending_accept_reset_streams: Option<usize>,
 }
 
 impl Default for Config {
@@ -88,6 +89,7 @@ impl Default for Config {
             keep_alive_while_idle: false,
             max_concurrent_reset_streams: None,
             max_send_buffer_size: DEFAULT_MAX_SEND_BUF_SIZE,
+            max_pending_accept_reset_streams: None,
         }
     }
 }
@@ -103,6 +105,9 @@ fn new_builder(config: &Config) -> Builder {
         .enable_push(false);
     if let Some(max) = config.max_concurrent_reset_streams {
         builder.max_concurrent_reset_streams(max);
+    }
+    if let Some(max) = config.max_pending_accept_reset_streams {
+        builder.max_pending_accept_reset_streams(max);
     }
     builder
 }


### PR DESCRIPTION
This PR exposes `max_pending_accept_reset_streams` option for `client`.

Necessary to support https://github.com/hyperium/tonic/pull/1670