### PR TITLE
fix: Do not include user information in Host header

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -53,12 +53,10 @@ async fn fetch_url(url: hyper::Uri) -> Result<()> {
         }
     });
 
-    let authority = url.authority().unwrap().clone();
-
     let path = url.path();
     let req = Request::builder()
         .uri(path)
-        .header(hyper::header::HOST, authority.as_str())
+        .header(hyper::header::HOST, format!("{}:{}", host, port))
         .body(Empty::<Bytes>::new())?;
 
     let mut res = sender.send_request(req).await?;

--- a/examples/client_json.rs
+++ b/examples/client_json.rs
@@ -42,12 +42,10 @@ async fn fetch_json(url: hyper::Uri) -> Result<Vec<User>> {
         }
     });
 
-    let authority = url.authority().unwrap().clone();
-
-    // Fetch the url...
+    // Fetch the URL...
     let req = Request::builder()
         .uri(url)
-        .header(hyper::header::HOST, authority.as_str())
+        .header(hyper::header::HOST, format!("{}:{}", host, port))
         .body(Empty::<Bytes>::new())?;
 
     let res = sender.send_request(req).await?;

--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -181,13 +181,11 @@ async fn http1_client(url: hyper::Uri) -> Result<(), Box<dyn std::error::Error>>
         }
     });
 
-    let authority = url.authority().unwrap().clone();
-
     // Make 4 requests
     for _ in 0..4 {
         let req = Request::builder()
             .uri(url.clone())
-            .header(hyper::header::HOST, authority.as_str())
+            .header(hyper::header::HOST, format!("{}:{}", host, port))
             .body(Body::from("test".to_string()))?;
 
         let mut res = sender.send_request(req).await?;
@@ -282,13 +280,11 @@ async fn http2_client(url: hyper::Uri) -> Result<(), Box<dyn std::error::Error>>
         }
     });
 
-    let authority = url.authority().unwrap().clone();
-
     // Make 4 requests
     for _ in 0..4 {
         let req = Request::builder()
             .uri(url.clone())
-            .header(hyper::header::HOST, authority.as_str())
+            .header(hyper::header::HOST, format!("{}:{}", host, port))
             .body(Body::from("test".to_string()))?;
 
         let mut res = sender.send_request(req).await?;


### PR DESCRIPTION
According to RFC 9110, section 7.2, the Host header should only comprise the URI host and an optional port.

Currently, the examples set the Host header to the URI's authority which may also contain user information (see RFC 3986, section 3.2).

Update the examples to construct the Host header manually to avoid sensitive information from showing up in server logs and to ensure that the server's routing logic works correctly when a username and password are supplied.

