### PR TITLE
fix warnings / lint errors and format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,18 @@ repository = "https://github.com/hyperium/hyper"
 license = "MIT"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 keywords = ["http", "hyper", "hyperium"]
-categories = ["network-programming", "web-programming::http-client", "web-programming::http-server"]
+categories = [
+	"network-programming",
+	"web-programming::http-client",
+	"web-programming::http-server",
+]
 edition = "2021"
 rust-version = "1.63" # keep in sync with MSRV.md dev doc
 
-include = [
-  "Cargo.toml",
-  "LICENSE",
-  "src/**/*",
-]
+include = ["Cargo.toml", "LICENSE", "src/**/*"]
 
 [dependencies]
-bytes = "1.2"
+bytes = "1.6"
 http = "1"
 http-body = "1"
 tokio = { version = "1", features = ["sync"] }
@@ -36,30 +36,38 @@ httpdate = { version = "1.0", optional = true }
 itoa = { version = "1", optional = true }
 libc = { version = "0.2", optional = true }
 pin-project-lite = { version = "0.2.4", optional = true }
-smallvec = { version = "1.12", features = ["const_generics", "const_new"], optional = true }
-tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
+smallvec = { version = "1.12", features = [
+	"const_generics",
+	"const_new",
+], optional = true }
+tracing = { version = "0.1", default-features = false, features = [
+	"std",
+], optional = true }
 want = { version = "0.3", optional = true }
 
 [dev-dependencies]
 form_urlencoded = "1"
 futures-channel = { version = "0.3", features = ["sink"] }
-futures-util = { version = "0.3", default-features = false, features = ["alloc", "sink"] }
+futures-util = { version = "0.3", default-features = false, features = [
+	"alloc",
+	"sink",
+] }
 http-body-util = "0.1"
 pretty_env_logger = "0.5"
 spmc = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = [
-    "fs",
-    "macros",
-    "net",
-    "io-std",
-    "io-util",
-    "rt",
-    "rt-multi-thread", # so examples can use #[tokio::main]
-    "sync",
-    "time",
-    "test-util",
+	"fs",
+	"macros",
+	"net",
+	"io-std",
+	"io-util",
+	"rt",
+	"rt-multi-thread", # so examples can use #[tokio::main]
+	"sync",
+	"time",
+	"test-util",
 ] }
 tokio-test = "0.4"
 tokio-util = "0.7.10"
@@ -69,12 +77,7 @@ tokio-util = "0.7.10"
 default = []
 
 # Easily turn it all on
-full = [
-    "client",
-    "http1",
-    "http2",
-    "server",
-]
+full = ["client", "http1", "http2", "server"]
 
 # HTTP versions
 http1 = ["dep:futures-channel", "dep:futures-util", "dep:httparse", "dep:itoa"]
@@ -95,7 +98,14 @@ nightly = []
 
 [package.metadata.docs.rs]
 features = ["ffi", "full", "tracing"]
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "hyper_unstable_ffi", "--cfg", "hyper_unstable_tracing"]
+rustdoc-args = [
+	"--cfg",
+	"docsrs",
+	"--cfg",
+	"hyper_unstable_ffi",
+	"--cfg",
+	"hyper_unstable_tracing",
+]
 
 [package.metadata.playground]
 features = ["full"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/ext/h1_reason_phrase.rs
+++ b/src/ext/h1_reason_phrase.rs
@@ -174,26 +174,26 @@ mod tests {
 
     #[test]
     fn basic_valid() {
-        const PHRASE: &'static [u8] = b"OK";
+        const PHRASE: &[u8] = b"OK";
         assert_eq!(ReasonPhrase::from_static(PHRASE).as_bytes(), PHRASE);
         assert_eq!(ReasonPhrase::try_from(PHRASE).unwrap().as_bytes(), PHRASE);
     }
 
     #[test]
     fn empty_valid() {
-        const PHRASE: &'static [u8] = b"";
+        const PHRASE: &[u8] = b"";
         assert_eq!(ReasonPhrase::from_static(PHRASE).as_bytes(), PHRASE);
         assert_eq!(ReasonPhrase::try_from(PHRASE).unwrap().as_bytes(), PHRASE);
     }
 
     #[test]
     fn obs_text_valid() {
-        const PHRASE: &'static [u8] = b"hyp\xe9r";
+        const PHRASE: &[u8] = b"hyp\xe9r";
         assert_eq!(ReasonPhrase::from_static(PHRASE).as_bytes(), PHRASE);
         assert_eq!(ReasonPhrase::try_from(PHRASE).unwrap().as_bytes(), PHRASE);
     }
 
-    const NEWLINE_PHRASE: &'static [u8] = b"hyp\ner";
+    const NEWLINE_PHRASE: &[u8] = b"hyp\ner";
 
     #[test]
     #[should_panic]
@@ -206,7 +206,7 @@ mod tests {
         assert!(ReasonPhrase::try_from(NEWLINE_PHRASE).is_err());
     }
 
-    const CR_PHRASE: &'static [u8] = b"hyp\rer";
+    const CR_PHRASE: &[u8] = b"hyp\rer";
 
     #[test]
     #[should_panic]

--- a/src/ffi/body.rs
+++ b/src/ffi/body.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unused_unit)]
+#![allow(non_camel_case_types)]
 use std::ffi::c_void;
 use std::mem::ManuallyDrop;
 use std::ptr;

--- a/src/ffi/client.rs
+++ b/src/ffi/client.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unused_unit)]
+#![allow(non_camel_case_types)]
 use std::ptr;
 use std::sync::Arc;
 

--- a/src/ffi/error.rs
+++ b/src/ffi/error.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unused_unit)]
 use libc::size_t;
 
 /// A more detailed error object returned by some hyper functions.

--- a/src/ffi/http_types.rs
+++ b/src/ffi/http_types.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unused_unit)]
+#![allow(non_camel_case_types)]
 use bytes::Bytes;
 use libc::{c_int, size_t};
 use std::ffi::c_void;

--- a/src/ffi/io.rs
+++ b/src/ffi/io.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unused_unit)]
+#![allow(non_camel_case_types)]
 use std::ffi::c_void;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unused_unit)]
 // We have a lot of c-types in here, stop warning about their names!
 #![allow(non_camel_case_types)]
 // fmt::Debug isn't helpful on FFI types

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1717,7 +1717,7 @@ mod tests {
         Server::parse(&mut raw, ctx).unwrap_err();
     }
 
-    const H09_RESPONSE: &'static str = "Baguettes are super delicious, don't you agree?";
+    const H09_RESPONSE: &str = "Baguettes are super delicious, don't you agree?";
 
     #[test]
     fn test_parse_response_h09_allowed() {
@@ -1770,7 +1770,7 @@ mod tests {
         assert_eq!(raw, H09_RESPONSE);
     }
 
-    const RESPONSE_WITH_WHITESPACE_BETWEEN_HEADER_NAME_AND_COLON: &'static str =
+    const RESPONSE_WITH_WHITESPACE_BETWEEN_HEADER_NAME_AND_COLON: &str =
         "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Credentials : true\r\n\r\n";
 
     #[test]


### PR DESCRIPTION
- cargo.toml: format and upgrade bytes
- fix warnings / lint errors
