### PR TITLE
Revert "fix(client): send content-length even with no body"

### DIFF
--- a/tests/client.rs
+++ b/tests/client.rs
@@ -889,30 +889,6 @@ test! {
 }
 
 test! {
-    name: client_post_empty_auto_length,
-
-    server:
-        expected: "\
-            POST /empty HTTP/1.1\r\n\
-            host: {addr}\r\n\
-            content-length: 0\r\n\
-            \r\n\
-            ",
-        reply: REPLY_OK,
-
-    client:
-        request: {
-            method: POST,
-            url: "http://{addr}/empty",
-            headers: {},
-        },
-        response:
-            status: OK,
-            headers: {},
-            body: None,
-}
-
-test! {
     name: client_head_ignores_body,
 
     server:


### PR DESCRIPTION
This reverts commit 172fdfaf0e0d9222917f271a83339238082e2657.

The curl test suite noticed this change, and it was unexpected. https://github.com/curl/curl/issues/13380

On further review, [RFC 9112 Section 6.3](https://httpwg.org/specs/rfc9112.html#rfc.section.6.3) states:

> If this is a request message and none of the above are true, then the message body length is zero (no message body is present).

So, hyper does not need to do this. Any server that fails to understand there is no body is in direct violation of the spec.