### PR TITLE
feat(http1): add support for receiving trailer fields

### DIFF
--- a/src/body/incoming.rs
+++ b/src/body/incoming.rs
@@ -403,6 +403,19 @@ impl Sender {
             .map_err(|err| err.into_inner().expect("just sent Ok"))
     }
 
+    #[cfg(feature = "http1")]
+    pub(crate) fn try_send_trailers(
+        &mut self,
+        trailers: HeaderMap,
+    ) -> Result<(), Option<HeaderMap>> {
+        let tx = match self.trailers_tx.take() {
+            Some(tx) => tx,
+            None => return Err(None),
+        };
+
+        tx.send(trailers).map_err(|err| Some(err))
+    }
+
     #[cfg(test)]
     pub(crate) fn abort(mut self) {
         self.send_error(crate::Error::new_body_write_aborted());

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -267,10 +267,20 @@ where
                 self.try_keep_alive(cx);
             }
         } else if msg.expect_continue && msg.head.version.gt(&Version::HTTP_10) {
-            self.state.reading = Reading::Continue(Decoder::new(msg.decode));
+            let h1_max_header_size = None; // TODO: remove this when we land h1_max_header_size support
+            self.state.reading = Reading::Continue(Decoder::new(
+                msg.decode,
+                self.state.h1_max_headers,
+                h1_max_header_size,
+            ));
             wants = wants.add(Wants::EXPECT);
         } else {
-            self.state.reading = Reading::Body(Decoder::new(msg.decode));
+            let h1_max_header_size = None; // TODO: remove this when we land h1_max_header_size support
+            self.state.reading = Reading::Body(Decoder::new(
+                msg.decode,
+                self.state.h1_max_headers,
+                h1_max_header_size,
+            ));
         }
 
         self.state.allow_trailer_fields = msg

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -1063,7 +1063,7 @@ mod tests {
         b.bytes = LEN as u64;
 
         b.iter(|| {
-            let mut decoder = Decoder::chunked();
+            let mut decoder = Decoder::chunked(None, None);
             rt.block_on(async {
                 let mut raw = content.clone();
                 let chunk = decoder

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -30,7 +30,7 @@ use crate::proto::h1::{
 use crate::proto::RequestHead;
 use crate::proto::{BodyLength, MessageHead, RequestLine};
 
-const DEFAULT_MAX_HEADERS: usize = 100;
+pub(crate) const DEFAULT_MAX_HEADERS: usize = 100;
 const AVERAGE_HEADER_SIZE: usize = 30; // totally scientific
 #[cfg(feature = "server")]
 const MAX_URI_LEN: usize = (u16::MAX - 1) as usize;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -785,7 +785,7 @@ test! {
                 "chunky-trailer3" => "header data3",
                 "chunky-trailer4" => "header data4",
                 "chunky-trailer5" => "header data5",
-                "sneaky-trailer" => "i should not be sent",
+                "sneaky-trailer" => "not in trailer header",
                 "transfer-encoding" => "chunked",
                 "content-length" => "5",
                 "trailer" => "foo",

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -758,7 +758,7 @@ test! {
             chunky-trailer3: header data3\r\n\
             chunky-trailer4: header data4\r\n\
             chunky-trailer5: header data5\r\n\
-            sneaky-trailer: i should not be sent\r\n\
+            sneaky-trailer: not in trailer header\r\n\
             transfer-encoding: chunked\r\n\
             content-length: 5\r\n\
             trailer: foo\r\n\

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -34,6 +34,17 @@ where
     b.collect().await.map(|c| c.to_bytes())
 }
 
+async fn concat_with_trailers<B>(b: B) -> Result<(Bytes, Option<HeaderMap>), B::Error>
+where
+    B: hyper::body::Body,
+{
+    let collect = b.collect().await?;
+    let trailers = collect.trailers().cloned();
+    let bytes = collect.to_bytes();
+
+    Ok((bytes, trailers))
+}
+
 async fn tcp_connect(addr: &SocketAddr) -> std::io::Result<TokioIo<TcpStream>> {
     TcpStream::connect(*addr).await.map(TokioIo::new)
 }
@@ -122,6 +133,9 @@ macro_rules! test {
                 status: $client_status:ident,
                 headers: { $($response_header_name:expr => $response_header_val:expr,)* },
                 body: $response_body:expr,
+                $(trailers: {$(
+                    $response_trailer_name:expr => $response_trailer_val:expr,
+                )*},)?
     ) => (
         #[test]
         fn $name() {
@@ -158,12 +172,23 @@ macro_rules! test {
                 );
             )*
 
-            let body = rt.block_on(concat(res))
+            let (body, _trailers) = rt.block_on(concat_with_trailers(res))
                 .expect("body concat wait");
 
             let expected_res_body = Option::<&[u8]>::from($response_body)
                 .unwrap_or_default();
             assert_eq!(body.as_ref(), expected_res_body);
+
+            $($(
+                assert_eq!(
+                    _trailers.as_ref().expect("trailers is None")
+                        .get($response_trailer_name)
+                        .expect(concat!("trailer header '", stringify!($response_trailer_name), "'")),
+                    $response_trailer_val,
+                    "trailer '{}'",
+                    stringify!($response_trailer_name),
+                );
+            )*)?
         }
     );
     (
@@ -677,6 +702,94 @@ test! {
             status: OK,
             headers: {},
             body: None,
+}
+
+test! {
+    name: client_res_body_chunked_with_trailer,
+
+    server:
+        expected: "GET / HTTP/1.1\r\nte: trailers\r\nhost: {addr}\r\n\r\n",
+        reply: "\
+            HTTP/1.1 200 OK\r\n\
+            transfer-encoding: chunked\r\n\
+            trailer: chunky-trailer\r\n\
+            \r\n\
+            5\r\n\
+            hello\r\n\
+            0\r\n\
+            chunky-trailer: header data\r\n\
+            \r\n\
+            ",
+
+    client:
+        request: {
+            method: GET,
+            url: "http://{addr}/",
+            headers: {
+                "te" => "trailers",
+            },
+        },
+        response:
+            status: OK,
+            headers: {
+                "Transfer-Encoding" => "chunked",
+            },
+            body: &b"hello"[..],
+            trailers: {
+                "chunky-trailer" => "header data",
+            },
+}
+
+test! {
+    name: client_res_body_chunked_with_pathological_trailers,
+
+    server:
+        expected: "GET / HTTP/1.1\r\nte: trailers\r\nhost: {addr}\r\n\r\n",
+        reply: "\
+            HTTP/1.1 200 OK\r\n\
+            transfer-encoding: chunked\r\n\
+            trailer: chunky-trailer1, chunky-trailer2, chunky-trailer3, chunky-trailer4, chunky-trailer5\r\n\
+            \r\n\
+            5\r\n\
+            hello\r\n\
+            0\r\n\
+            chunky-trailer1: header data1\r\n\
+            chunky-trailer2: header data2\r\n\
+            chunky-trailer3: header data3\r\n\
+            chunky-trailer4: header data4\r\n\
+            chunky-trailer5: header data5\r\n\
+            sneaky-trailer: i should not be sent\r\n\
+            transfer-encoding: chunked\r\n\
+            content-length: 5\r\n\
+            trailer: foo\r\n\
+            \r\n\
+            ",
+
+    client:
+        request: {
+            method: GET,
+            url: "http://{addr}/",
+            headers: {
+                "te" => "trailers",
+            },
+        },
+        response:
+            status: OK,
+            headers: {
+                "Transfer-Encoding" => "chunked",
+            },
+            body: &b"hello"[..],
+            trailers: {
+                "chunky-trailer1" => "header data1",
+                "chunky-trailer2" => "header data2",
+                "chunky-trailer3" => "header data3",
+                "chunky-trailer4" => "header data4",
+                "chunky-trailer5" => "header data5",
+                "sneaky-trailer" => "i should not be sent",
+                "transfer-encoding" => "chunked",
+                "content-length" => "5",
+                "trailer" => "foo",
+            },
 }
 
 test! {


### PR DESCRIPTION
Closes #2703

In https://github.com/hyperium/hyper/pull/3375 we were strict about sending trailers per RFC 7230. In this PR, I have been much more accepting of trailers. Is this the behavior we want?

Some questions:

- If the client does not send `TE: trailers` but the server sends trailer headers, should trailers be parsed and passed along?
- If the server does not include a `trailers: ...` header indicating which trailer headers are being returned, should trailers be parsed and passed along? I think this one is almost certainly "yes".
- If the server includes trailers with invalid header names, such as `Content-Length: 5`, should that still be parsed and passed along?