### PR TITLE
refactor(proto): replace map and unwrap_or combination with map_or

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -276,8 +276,7 @@ where
             .head
             .headers
             .get(TE)
-            .map(|te_header| te_header == "trailers")
-            .unwrap_or(false);
+            .map_or(false, |te_header| te_header == "trailers");
 
         Poll::Ready(Some(Ok((msg.head, msg.decode, wants))))
     }
@@ -594,8 +593,7 @@ where
         let outgoing_is_keep_alive = head
             .headers
             .get(CONNECTION)
-            .map(connection_keep_alive)
-            .unwrap_or(false);
+            .map_or(false, connection_keep_alive);
 
         if !outgoing_is_keep_alive {
             match head.version {

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -54,8 +54,7 @@ fn strip_connection_headers(headers: &mut HeaderMap, is_request: bool) {
     if is_request {
         if headers
             .get(TE)
-            .map(|te_header| te_header != "trailers")
-            .unwrap_or(false)
+            .map_or(false, |te_header| te_header != "trailers")
         {
             warn!("TE headers not set to \"trailers\" are illegal in HTTP/2 requests");
             headers.remove(TE);


### PR DESCRIPTION
The `Option::map` and `Option::unwrap_or` methods combination could be written as more idiomatic API `Option::map_or`. In this case, there is a more idiomatic API `Option::is_some_and`, but it requires Rust 1.70.

https://doc.rust-lang.org/std/option/enum.Option.html#method.is_some_and