### PR TITLE
fix(http1): improve debug messages when sending trailers

### DIFF
--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -165,6 +165,7 @@ impl Encoder {
         trailers: HeaderMap,
         title_case_headers: bool,
     ) -> Option<EncodedBuf<B>> {
+        trace!("encoding trailers");
         match &self.kind {
             Kind::Chunked(Some(ref allowed_trailer_fields)) => {
                 let allowed_trailer_field_map = allowed_trailer_field_map(&allowed_trailer_fields);
@@ -178,10 +179,14 @@ impl Encoder {
                     }
                     let name = cur_name.as_ref().expect("current header name");
 
-                    if allowed_trailer_field_map.contains_key(name.as_str())
-                        && is_valid_trailer_field(name)
-                    {
-                        allowed_trailers.insert(name, value);
+                    if allowed_trailer_field_map.contains_key(name.as_str()) {
+                        if is_valid_trailer_field(name) {
+                            allowed_trailers.insert(name, value);
+                        } else {
+                            debug!("trailer field is not valid: {}", &name);
+                        }
+                    } else {
+                        debug!("trailer header name not found in trailer header: {}", &name);
                     }
                 }
 
@@ -199,6 +204,10 @@ impl Encoder {
                 Some(EncodedBuf {
                     kind: BufKind::Trailers(b"0\r\n".chain(Bytes::from(buf)).chain(b"\r\n")),
                 })
+            }
+            Kind::Chunked(None) => {
+                debug!("attempted to encode trailers, but the trailer header is not set");
+                None
             }
             _ => {
                 debug!("attempted to encode trailers for non-chunked response");


### PR DESCRIPTION
When the "trailer" header was not found in the response, the debug message would say "attempted to encode trailers for non-chunked response". This was quite misleading as the response was chunked. We now include a better debug message that hints to the user that the "trailer" header was not specified.

When a chunked response contained a trailer header that did not match the header names specified in the "trailer" response header, there was no debug message to the user. We now include debug messages that tell the user if the header name is not allowed and if the header name was not specified in the "trailer" response header.

