### PR TITLE
fix(http2): "Trailer" header should be allowed in HTTP/2 responses as per RFC 9110

### DIFF
--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -8,7 +8,7 @@ use std::task::{Context, Poll};
 use bytes::{Buf, Bytes};
 use futures_util::ready;
 use h2::{Reason, RecvStream, SendStream};
-use http::header::{HeaderName, CONNECTION, TE, TRAILER, TRANSFER_ENCODING, UPGRADE};
+use http::header::{HeaderName, CONNECTION, TE, TRANSFER_ENCODING, UPGRADE};
 use http::HeaderMap;
 use pin_project_lite::pin_project;
 
@@ -31,15 +31,13 @@ cfg_server! {
 /// Default initial stream window size defined in HTTP2 spec.
 pub(crate) const SPEC_WINDOW_SIZE: u32 = 65_535;
 
-// List of connection headers from:
-// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection
+// List of connection headers from RFC 9110 Section 7.6.1
 //
 // TE headers are allowed in HTTP/2 requests as long as the value is "trailers", so they're
 // tested separately.
-static CONNECTION_HEADERS: [HeaderName; 5] = [
+static CONNECTION_HEADERS: [HeaderName; 4] = [
     HeaderName::from_static("keep-alive"),
     HeaderName::from_static("proxy-connection"),
-    TRAILER,
     TRANSFER_ENCODING,
     UPGRADE,
 ];


### PR DESCRIPTION
This pull request addresses the incorrect handling of the `Trailer` header in HTTP/2 responses within the hyper project. According to RFC 9110 "HTTP Semantics", the `Trailer` header is not listed as a "hop-by-hop" header in section 7.6.1. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html) specifies that a sender intending to generate one or more trailer fields in a message should use the `Trailer` header in the header section to indicate potential trailer fields, as mentioned in section 6.6.2.

The current implementation in hyper may result in unnecessary warnings for gRPC calls, as gRPC implementations, such as grpc-go, routinely use the `Trailer` header to indicate the presence of trailers after the response body. (See this behavior in [grpc-go's implementation](https://github.com/grpc/grpc-go/blob/d32e66ce27447a0a217464a36fdd3935801c0453/internal/transport/handler_server.go#L306).

This fix updates hyper to correctly allow the `Trailer` header in HTTP/2 responses, aligning it with RFC 9110 and preventing misleading warnings in environments using gRPC, such as linkerd2-proxy, which prints a warning `Connection header illegal in HTTP/2: trailer` on every gRPC call.

Note: [Mozilla's documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection) mistakenly lists `Trailer` as a hop-by-hop header, which is incorrect.