### PR TITLE
Remove incorrect comment in example

### DIFF
--- a/examples/service_struct_impl.rs
+++ b/examples/service_struct_impl.rs
@@ -65,8 +65,7 @@ impl Service<Request<IncomingBody>> for Svc {
                 "authors extraordinare! counter = {:?}",
                 self.counter
             )),
-            // Return the 404 Not Found for other routes, and don't increment counter.
-            _ => return Box::pin(async { mk_response("oh no! not found".into()) }),
+            _ => mk_response("oh no! not found".into()),
         };
 
         Box::pin(async { res })


### PR DESCRIPTION
There was a comment in the service_struct_impl.rs example indicating that the default match arm would somehow return a 404 and not increment the counter. This wasn't the case. That arm also had a redundant return.

