### PR TITLE
Fix confusing usage of TokioTimer in hello.rs example

### DIFF
--- a/benches/support/tokiort.rs
+++ b/benches/support/tokiort.rs
@@ -49,6 +49,13 @@ impl Timer for TokioTimer {
     }
 }
 
+impl TokioTimer {
+    /// Create a new TokioTimer
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
 // Use TokioSleep to get tokio::time::Sleep to implement Unpin.
 // see https://docs.rs/tokio/latest/tokio/time/struct.Sleep.html
 pin_project! {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -53,7 +53,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             // Handle the connection from the client using HTTP1 and pass any
             // HTTP requests received on that connection to the `hello` function
             if let Err(err) = http1::Builder::new()
-                .timer(TokioTimer)
+                .timer(TokioTimer::new())
                 .serve_connection(io, service_fn(hello))
                 .await
             {


### PR DESCRIPTION
The usage of TokioTimer in the example differs from how it would be used with the hyper-util crate.  When you try to use the code like you see in the example, it says the type is private, but it is clearly public in the source code of hyper-util.  After coming back to this months later, it seems that in hyper-util itself, the usage of `#[non_exhaustive]` makes the type unconstructable outside the crate, which necessitates using the ::new() method.