### PR TITLE
chore: fix unexpected cfg warning

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(hyper_unstable_ffi)");
+    println!("cargo:rustc-check-cfg=cfg(hyper_unstable_tracing)");
+}


### PR DESCRIPTION
Fixes unexpected cfg warnings, which cause the ci fail.

https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg