### PR TITLE
Add unexpected cfgs to `[lints]` table

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,6 @@ jobs:
       - features
       - ffi
       - ffi-header
-      - unexpected-cfgs
       - doc
       - check-external-types
       - udeps
@@ -220,22 +219,6 @@ jobs:
 
       - name: Ensure that hyper.h is up to date
         run: ./capi/gen_header.sh --verify
-
-  unexpected-cfgs:
-    runs-on: ubuntu-latest
-    needs: [style]
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo check --all-features
-        env:
-          RUSTFLAGS: >-
-            -D unexpected_cfgs
-            --cfg hyper_internal_check_unexpected_cfgs
-            --cfg hyper_unstable_tracing
-            --cfg hyper_unstable_ffi
-            --check-cfg=cfg(hyper_internal_check_unexpected_cfgs,hyper_unstable_tracing,hyper_unstable_ffi)
 
   doc:
     name: Build docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ check-cfg = [
 
 [package.metadata.docs.rs]
 features = ["ffi", "full", "tracing"]
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "hyper_unstable_ffi", "--cfg", "hyper_unstable_tracing"]
+rustdoc-args = ["--cfg", "hyper_unstable_ffi", "--cfg", "hyper_unstable_tracing"]
 
 [package.metadata.playground]
 features = ["full"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,13 @@ tracing = ["dep:tracing"]
 # internal features used in CI
 nightly = []
 
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(hyper_unstable_tracing)',
+    'cfg(hyper_unstable_ffi)'
+]
+
 [package.metadata.docs.rs]
 features = ["ffi", "full", "tracing"]
 rustdoc-args = ["--cfg", "docsrs", "--cfg", "hyper_unstable_ffi", "--cfg", "hyper_unstable_tracing"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
-#![cfg_attr(not(hyper_internal_check_unexpected_cfgs), allow(unexpected_cfgs))]
 #![cfg_attr(test, deny(rust_2018_idioms))]
 #![cfg_attr(all(test, feature = "full"), deny(unreachable_pub))]
 #![cfg_attr(all(test, feature = "full"), deny(warnings))]


### PR DESCRIPTION
With the release of rust-lang/cargo#13913 (in nightly-2024-05-19), there is no longer any need for the kind of workarounds employed in #3660. Cargo has now gain the ability to declare `--check-cfg` args directly inside the `[lints]` table with [`[lints.rust.unexpected_cfgs.check-cfg]`](https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html#check-cfg-in-lintsrust-table)[^1]:

`Cargo.toml`:
```toml
[lints.rust]
unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hyper_unstable_tracing,hyper_unstable_ffi)'] }
```

This PR adds those unexpected cfgs inside the `[lints]`, reverts #3660 and remove the manual `--cfg docsrs` (since it's automaticly added by docs.rs).

[^1]: take effect on Rust 1.80 (current nightly), is ignored on Rust 1.79 (current beta), and produce an unused warning below