### PR TITLE
Make Future implementation on Connection unconditional on executor being Send + Sync.

### DIFF
--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -611,7 +611,7 @@ where
     B: Body + 'static + Unpin,
     B::Data: Send,
     B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
-    E: Http2ClientConnExec<B, T> + 'static + Send + Sync + Unpin,
+    E: Http2ClientConnExec<B, T> + Unpin,
     T: Read + Write + Unpin,
 {
     type Output = crate::Result<Dispatched>;


### PR DESCRIPTION
This PR is created to raise the question if `Future` implementation on `Connection` is mandatory to request Executor to be `Send` + `Sync`.
Question initially raised here https://discord.com/channels/500028886025895936/670880858630258689/1247563996068970557.

