### PR TITLE
feat(client): add `SendRequest::try_send_request()` method

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -12,7 +12,7 @@ use futures_util::ready;
 use http::{Request, Response};
 use httparse::ParserConfig;
 
-use super::super::dispatch;
+use super::super::dispatch::{self, TrySendError};
 use crate::body::{Body, Incoming as IncomingBody};
 use crate::proto;
 
@@ -200,33 +200,38 @@ where
         }
     }
 
-    /*
-    pub(super) fn send_request_retryable(
+    /// Sends a `Request` on the associated connection.
+    ///
+    /// Returns a future that if successful, yields the `Response`.
+    ///
+    /// # Error
+    ///
+    /// If there was an error before trying to serialize the request to the
+    /// connection, the message will be returned as part of this error.
+    pub fn try_send_request(
         &mut self,
         req: Request<B>,
-    ) -> impl Future<Output = Result<Response<Body>, (crate::Error, Option<Request<B>>)>> + Unpin
-    where
-        B: Send,
-    {
-        match self.dispatch.try_send(req) {
-            Ok(rx) => {
-                Either::Left(rx.then(move |res| {
-                    match res {
-                        Ok(Ok(res)) => future::ok(res),
-                        Ok(Err(err)) => future::err(err),
-                        // this is definite bug if it happens, but it shouldn't happen!
-                        Err(_) => panic!("dispatch dropped without returning error"),
-                    }
-                }))
-            }
-            Err(req) => {
-                debug!("connection was not ready");
-                let err = crate::Error::new_canceled().with("connection was not ready");
-                Either::Right(future::err((err, Some(req))))
+    ) -> impl Future<Output = Result<Response<IncomingBody>, TrySendError<Request<B>>>> {
+        let sent = self.dispatch.try_send(req);
+        async move {
+            match sent {
+                Ok(rx) => match rx.await {
+                    Ok(Ok(res)) => Ok(res),
+                    Ok(Err(err)) => Err(err),
+                    // this is definite bug if it happens, but it shouldn't happen!
+                    Err(_) => panic!("dispatch dropped without returning error"),
+                },
+                Err(req) => {
+                    debug!("connection was not ready");
+                    let error = crate::Error::new_canceled().with("connection was not ready");
+                    Err(TrySendError {
+                        error,
+                        message: Some(req),
+                    })
+                }
             }
         }
     }
-    */
 }
 
 impl<B> fmt::Debug for SendRequest<B> {

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -13,7 +13,7 @@ use crate::rt::{Read, Write};
 use futures_util::ready;
 use http::{Request, Response};
 
-use super::super::dispatch;
+use super::super::dispatch::{self, TrySendError};
 use crate::body::{Body, Incoming as IncomingBody};
 use crate::common::time::Time;
 use crate::proto;
@@ -152,33 +152,38 @@ where
         }
     }
 
-    /*
-    pub(super) fn send_request_retryable(
+    /// Sends a `Request` on the associated connection.
+    ///
+    /// Returns a future that if successful, yields the `Response`.
+    ///
+    /// # Error
+    ///
+    /// If there was an error before trying to serialize the request to the
+    /// connection, the message will be returned as part of this error.
+    pub fn try_send_request(
         &mut self,
         req: Request<B>,
-    ) -> impl Future<Output = Result<Response<Body>, (crate::Error, Option<Request<B>>)>> + Unpin
-    where
-        B: Send,
-    {
-        match self.dispatch.try_send(req) {
-            Ok(rx) => {
-                Either::Left(rx.then(move |res| {
-                    match res {
-                        Ok(Ok(res)) => future::ok(res),
-                        Ok(Err(err)) => future::err(err),
-                        // this is definite bug if it happens, but it shouldn't happen!
-                        Err(_) => panic!("dispatch dropped without returning error"),
-                    }
-                }))
-            }
-            Err(req) => {
-                debug!("connection was not ready");
-                let err = crate::Error::new_canceled().with("connection was not ready");
-                Either::Right(future::err((err, Some(req))))
+    ) -> impl Future<Output = Result<Response<IncomingBody>, TrySendError<Request<B>>>> {
+        let sent = self.dispatch.try_send(req);
+        async move {
+            match sent {
+                Ok(rx) => match rx.await {
+                    Ok(Ok(res)) => Ok(res),
+                    Ok(Err(err)) => Err(err),
+                    // this is definite bug if it happens, but it shouldn't happen!
+                    Err(_) => panic!("dispatch dropped without returning error"),
+                },
+                Err(req) => {
+                    debug!("connection was not ready");
+                    let error = crate::Error::new_canceled().with("connection was not ready");
+                    Err(TrySendError {
+                        error,
+                        message: Some(req),
+                    })
+                }
             }
         }
     }
-    */
 }
 
 impl<B> fmt::Debug for SendRequest<B> {

--- a/src/client/conn/mod.rs
+++ b/src/client/conn/mod.rs
@@ -18,3 +18,5 @@
 pub mod http1;
 #[cfg(feature = "http2")]
 pub mod http2;
+
+pub use super::dispatch::TrySendError;

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -13,9 +13,20 @@ use tokio::sync::{mpsc, oneshot};
 #[cfg(feature = "http2")]
 use crate::{body::Incoming, proto::h2::client::ResponseFutMap};
 
-#[cfg(test)]
-pub(crate) type RetryPromise<T, U> = oneshot::Receiver<Result<U, (crate::Error, Option<T>)>>;
+pub(crate) type RetryPromise<T, U> = oneshot::Receiver<Result<U, TrySendError<T>>>;
 pub(crate) type Promise<T> = oneshot::Receiver<Result<T, crate::Error>>;
+
+/// An error when calling `try_send_request`.
+///
+/// There is a possibility of an error occuring on a connection in-between the
+/// time that a request is queued and when it is actually written to the IO
+/// transport. If that happens, it is safe to return the request back to the
+/// caller, as it was never fully sent.
+#[derive(Debug)]
+pub struct TrySendError<T> {
+    pub(crate) error: crate::Error,
+    pub(crate) message: Option<T>,
+}
 
 pub(crate) fn channel<T, U>() -> (Sender<T, U>, Receiver<T, U>) {
     let (tx, rx) = mpsc::unbounded_channel();
@@ -92,7 +103,7 @@ impl<T, U> Sender<T, U> {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(feature = "http1")]
     pub(crate) fn try_send(&mut self, val: T) -> Result<RetryPromise<T, U>, T> {
         if !self.can_send() {
             return Err(val);
@@ -135,7 +146,6 @@ impl<T, U> UnboundedSender<T, U> {
         self.giver.is_canceled()
     }
 
-    #[cfg(test)]
     pub(crate) fn try_send(&mut self, val: T) -> Result<RetryPromise<T, U>, T> {
         let (tx, rx) = oneshot::channel();
         self.inner
@@ -210,17 +220,17 @@ struct Envelope<T, U>(Option<(T, Callback<T, U>)>);
 impl<T, U> Drop for Envelope<T, U> {
     fn drop(&mut self) {
         if let Some((val, cb)) = self.0.take() {
-            cb.send(Err((
-                crate::Error::new_canceled().with("connection closed"),
-                Some(val),
-            )));
+            cb.send(Err(TrySendError {
+                error: crate::Error::new_canceled().with("connection closed"),
+                message: Some(val),
+            }));
         }
     }
 }
 
 pub(crate) enum Callback<T, U> {
     #[allow(unused)]
-    Retry(Option<oneshot::Sender<Result<U, (crate::Error, Option<T>)>>>),
+    Retry(Option<oneshot::Sender<Result<U, TrySendError<T>>>>),
     NoRetry(Option<oneshot::Sender<Result<U, crate::Error>>>),
 }
 
@@ -229,7 +239,10 @@ impl<T, U> Drop for Callback<T, U> {
         match self {
             Callback::Retry(tx) => {
                 if let Some(tx) = tx.take() {
-                    let _ = tx.send(Err((dispatch_gone(), None)));
+                    let _ = tx.send(Err(TrySendError {
+                        error: dispatch_gone(),
+                        message: None,
+                    }));
                 }
             }
             Callback::NoRetry(tx) => {
@@ -269,15 +282,31 @@ impl<T, U> Callback<T, U> {
         }
     }
 
-    pub(crate) fn send(mut self, val: Result<U, (crate::Error, Option<T>)>) {
+    pub(crate) fn send(mut self, val: Result<U, TrySendError<T>>) {
         match self {
             Callback::Retry(ref mut tx) => {
                 let _ = tx.take().unwrap().send(val);
             }
             Callback::NoRetry(ref mut tx) => {
-                let _ = tx.take().unwrap().send(val.map_err(|e| e.0));
+                let _ = tx.take().unwrap().send(val.map_err(|e| e.error));
             }
         }
+    }
+}
+
+impl<T> TrySendError<T> {
+    /// Take the message from this error.
+    ///
+    /// The message will not always have been recovered. If an error occurs
+    /// after the message has been serialized onto the connection, it will not
+    /// be available here.
+    pub fn take_message(&mut self) -> Option<T> {
+        self.message.take()
+    }
+
+    /// Consumes this to return the inner error.
+    pub fn into_error(self) -> crate::Error {
+        self.error
     }
 }
 
@@ -325,8 +354,8 @@ where
                 trace!("send_when canceled");
                 Poll::Ready(())
             }
-            Poll::Ready(Err(err)) => {
-                call_back.send(Err(err));
+            Poll::Ready(Err((error, message))) => {
+                call_back.send(Err(TrySendError { error, message }));
                 Poll::Ready(())
             }
         }
@@ -389,8 +418,8 @@ mod tests {
         let err = fulfilled
             .expect("fulfilled")
             .expect_err("promise should error");
-        match (err.0.kind(), err.1) {
-            (&crate::error::Kind::Canceled, Some(_)) => (),
+        match (err.error.is_canceled(), err.message) {
+            (true, Some(_)) => (),
             e => panic!("expected Error::Cancel(_), found {:?}", e),
         }
     }


### PR DESCRIPTION
This change adds a `try_send_request()` method to `SendRequest`. This method returns a `TrySendError` type, which allows for returning the request back to the caller if an error occured between queuing and trying to write the request.

This method is added for both `http1` and `http2`.

Closes #3673 
Closes https://github.com/seanmonstar/reqwest/issues/2325

(Well, after hyper-util makes use of it.)

---

## Problem

If you try to `send_request(req)` at the same time the server is closing the connection, it's possible hyper will notice the HUP before the request gets serialized. If so, theoretically the request is safe to try on another connection.

But there isn't a mechanism for hyper to give the request _back_. And since the pool was moved out of hyper, it doesn't know how to just grab another connection.

**Need**: a mechanism to return the request on specific kinds of errors.

## Options

- Something like `try_send_request(req)`, which returns a `TrySendError`.
- Embed the request into the `hyper::Error`.
- Put some channel-like thing in `req.extensions()`.

### TrySendError

```rust
let mut req = Request::new(body);
loop {
    match tx.try_send_request(req).await {
        Ok(_) => yay,
        Err(TrySendError::Queued { error, request }) => {
            req = req_back;
            continue;
        },
        Err(TrySendError::Sent { error }) => {
            return Err(e);
        }
    }
}
```

Pros:

- From a Rust perspective, it's simple. There's [`std::sync::mpsc::TrySendError`](https://doc.rust-lang.org/std/sync/mpsc/enum.TrySendError.html) as prior art.
- Cheap, no allocations needed, even on the happy path.

Cons:

- Would be needed for each `http1::SendRequest` and `http2::SendRequest`.
- Intangibly, it feels "clumsy". Why wouldn't `send_request()` have handled this?
    - If after trying this out and finding it should be the way, we could create `fn send()` and hide `try_send_request()` and `send_request()`.
- Structural matching and enums must be designed with future-compatility changes.
    - We don't have to expose an enum. It can just have methods.

### Embed in `hyper::Error`

After writing all this out, this is probably not possible.

Pros:

- Feels more elegant.

Cons:

- How do you access the request after?
    - Adding `Error::request()` set of APIs seems to pollute the type.
        - Perhaps an `ext` API can access it...
            - But that would require allocation even on success.
- What if you keep the `Error` around but didn't expect the `Request<B>` to live with it?
    - Is this really a problem? Unknown... But if it is...
    - Could an `ext` be set to signal to hyper that it's OK? Then it becomes opt-in.
- Cannot embed `Request<B>` if the body is `!Send`
    - Can we even do this generically at all?
    - Maybe if the `ext` passed converts into an `Any`...

### Pass `ext::CaptureTrySend`?

```rust
let mut req = Request::new(body);
loop {
    // inserts a capture channel extension, returns the receiver
    let try_rx = hyper::ext::capture_try_send(&mut req);

    match tx.send_request(req).await {
        Ok(_) => yay,
        Err(e) => {
            // take it back
            if let Some(req_back) = try_rx.req().await {
                // try again...
                req = req_back;
                continue;
            } else {
                return Err(e);
            }
        }
    }
}
```

Pros:

- Works with any `B`
- Doesn't keep request stuck in the `Error` for longer than expected


Cons:

- Requires allocating `req.extensions()` for basically every request...

