### PR TITLE
improve uri docs for send_request of http1 send request

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -176,8 +176,15 @@ where
     ///
     /// `req` must have a `Host` header.
     ///
-    /// Absolute-form `Uri`s are not required. If received, they will be serialized
-    /// as-is.
+    /// # Uri
+    ///
+    /// - The `Uri` of the request is serialized as-is;
+    /// - Usually you want absolute-path form (`/path?query`), as that is in general
+    ///   expected for non CONNECT requests.
+    /// - For CONNECT requests, you do want an absolute-form `Uri`.
+    ///
+    /// This is however not enforced or validated and it is up to the user
+    /// of this method to ensure the `Uri` is correct for their intended purpose.
     pub fn send_request(
         &mut self,
         req: Request<B>,


### PR DESCRIPTION
This behaviour surprised me as discussed over Discord.
As such here is a small patch in an attempt to be more clear about the fact
that hyper has a hands-off approach regarding the Uri field in the subject line of Http1 requests.