### PR TITLE
Include exec arg in client::conn::http2::handshake doc

### DIFF
--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -63,7 +63,7 @@ pub struct Builder<Ex> {
 
 /// Returns a handshake future over some IO.
 ///
-/// This is a shortcut for `Builder::new().handshake(io)`.
+/// This is a shortcut for `Builder::new(exec).handshake(io)`.
 /// See [`client::conn`](crate::client::conn) for more.
 pub async fn handshake<E, T, B>(
     exec: E,


### PR DESCRIPTION
I just noticed that the `Http2ClientConnExec` argument is missing from the doc comment for `handshake`.