### PR TITLE
fix(http1): reject final chunked if missing 0

### DIFF
--- a/tests/server.rs
+++ b/tests/server.rs
@@ -573,6 +573,29 @@ fn post_with_incomplete_body() {
 }
 
 #[test]
+fn post_with_chunked_missing_final_digit() {
+    let _ = pretty_env_logger::try_init();
+    let server = serve();
+    let mut req = connect(server.addr());
+    req.write_all(
+        b"\
+        POST / HTTP/1.1\r\n\
+        Host: example.domain\r\n\
+        transfer-encoding: chunked\r\n\
+        \r\n\
+        1\r\n\
+        Z\r\n\
+        \r\n\r\n\
+    ",
+    )
+    .expect("write");
+
+    server.body_err();
+
+    req.read(&mut [0; 256]).expect("read");
+}
+
+#[test]
 fn head_response_can_send_content_length() {
     let _ = pretty_env_logger::try_init();
     let server = serve();


### PR DESCRIPTION
If a chunked body had valid chunks, but ended without a `0` in the final chunk (so, just `\r\n\r\n`), it would be parsed as a valid end. Now it will be rejected as the final chunk MUST be `0\r\n\r\n`.

This was partially done before (https://github.com/hyperium/hyper/pull/3494), but only if there were no chunks before the final. This fixes both paths.

