### PR TITLE
fix(http1): make `date_header` effective

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -152,6 +152,11 @@ where
         self.state.allow_half_close = true;
     }
 
+    #[cfg(feature = "server")]
+    pub(crate) fn disable_date_header(&mut self) {
+        self.state.date_header = false;
+    }
+
     pub(crate) fn into_inner(self) -> (I, Bytes) {
         self.io.into_inner()
     }

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -459,6 +459,9 @@ impl Builder {
         if let Some(max) = self.max_buf_size {
             conn.set_max_buf_size(max);
         }
+        if !self.date_header {
+            conn.disable_date_header();
+        }
         let sd = proto::h1::dispatch::Server::new(service);
         let proto = proto::h1::Dispatcher::new(sd, conn);
         Connection { conn: proto }


### PR DESCRIPTION
`date_header` option is not work in http1 because the argument in `Builder` is forgotten to pass into the further connection object.