### PR TITLE
docs: link from Connection to handshake

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -48,6 +48,8 @@ pub struct Parts<T> {
 ///
 /// In most cases, this should just be spawned into an executor, so that it
 /// can process incoming and outgoing messages, notice hangups, and the like.
+///
+/// Instances of this type are typically created via the [`handshake`] function
 #[must_use = "futures do nothing unless polled"]
 pub struct Connection<T, B>
 where

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -37,6 +37,8 @@ impl<B> Clone for SendRequest<B> {
 ///
 /// In most cases, this should just be spawned into an executor, so that it
 /// can process incoming and outgoing messages, notice hangups, and the like.
+///
+/// Instances of this type are typically created via the [`handshake`] function
 #[must_use = "futures do nothing unless polled"]
 pub struct Connection<T, B, E>
 where


### PR DESCRIPTION
When reading the documentation for `Connection` it is not entirely obvious how instances of this type are obtained. Add a helpful link, mostly for those less familiar.

