### PR TITLE
feat(server): add h1 `idle_timeout`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -64,6 +64,9 @@ pub(super) enum Kind {
     /// User took too long to send headers
     #[cfg(all(feature = "http1", feature = "server"))]
     HeaderTimeout,
+    /// User took too long to send another request
+    #[cfg(all(feature = "http1", feature = "server"))]
+    IdleTimeout,
     /// Error while reading a body from connection.
     #[cfg(all(
         any(feature = "client", feature = "server"),
@@ -360,6 +363,11 @@ impl Error {
         Error::new(Kind::HeaderTimeout)
     }
 
+    #[cfg(all(feature = "http1", feature = "server"))]
+    pub(super) fn new_idle_timeout() -> Error {
+        Error::new(Kind::IdleTimeout)
+    }
+
     #[cfg(feature = "http1")]
     #[cfg(feature = "server")]
     pub(super) fn new_user_unsupported_status_code() -> Error {
@@ -458,6 +466,8 @@ impl Error {
             Kind::Canceled => "operation was canceled",
             #[cfg(all(feature = "http1", feature = "server"))]
             Kind::HeaderTimeout => "read header from client timeout",
+            #[cfg(all(feature = "http1", feature = "server"))]
+            Kind::IdleTimeout => "idle client timeout",
             #[cfg(all(
                 any(feature = "client", feature = "server"),
                 any(feature = "http1", feature = "http2")

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -169,6 +169,7 @@ where
         &mut self,
         cx: &mut Context<'_>,
         parse_ctx: ParseContext<'_>,
+        progress: &mut bool,
     ) -> Poll<crate::Result<ParsedMessage<S::Incoming>>>
     where
         S: Http1Transaction,
@@ -205,6 +206,7 @@ where
                 trace!("parse eof");
                 return Poll::Ready(Err(crate::Error::new_incomplete()));
             }
+            *progress = true;
         }
     }
 
@@ -702,7 +704,7 @@ mod tests {
                 on_informational: &mut None,
             };
             assert!(buffered
-                .parse::<ClientTransaction>(cx, parse_ctx)
+                .parse::<ClientTransaction>(cx, parse_ctx, &mut false)
                 .is_pending());
             Poll::Ready(())
         })


### PR DESCRIPTION
## Motivation
Older browsers sometimes open 6 or more H1 connections and keep them alive and idle after resources are loaded, costing server resources and distracting from DoS attackers. In my specific case, DoS mitigation required limiting TCP connections per IP address, but limits had to be high to account for multiple legitimate H1 browsers on the same IP address.

Related: #1628
Related: #2355

## Changes
- [x] Added `idle_timeout` setting, optimized to avoid creating an additional timer per request
- [ ] ~~Automatically send `keep-alive: timeout=#` header~~ (deferred due to: https://github.com/hyperium/http/issues/142)

## Testing

- [x] Fixed multiple pre-existing and broken, but relevant, tests
- [x] Added a test with idle timeout
- [x] Added a test without idle timeout (improves coverage)
- [x] Tested in my app

```toml
# Cargo.toml

[patch.crates-io]
hyper = { git = "https://github.com/finnbear/hyper", branch = "idle_timeout" }
hyper-util = { git = "https://github.com/finnbear/hyper-util", branch = "idle_timeout" }
```

## Future work
- [x] Support in `hyper-util` (https://github.com/hyperium/hyper-util/pull/146)
- [ ] Consider other timeouts (reading body, writing response)