### PR TITLE
chore(ci): use tokio-util 0.7.11 in msrv job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,6 +118,7 @@ jobs:
       - name: Pin some dependencies
         run: |
           cargo update -p tokio --precise 1.38.1
+          cargo update -p tokio-util --precise 0.7.11
 
       - name: Check
         run: cargo check --features full


### PR DESCRIPTION
Uses `tokio-util` 0.7.11 in msrv job.