### PR TITLE
docs: Link to Read and Write traits from Upgraded doc comment

### DIFF
--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -58,7 +58,7 @@ use crate::common::io::Rewind;
 ///
 /// This type holds a trait object internally of the original IO that
 /// was used to speak HTTP before the upgrade. It can be used directly
-/// as a `Read` or `Write` for convenience.
+/// as a [`Read`] or [`Write`] for convenience.
 ///
 /// Alternatively, if the exact type is known, this can be deconstructed
 /// into its parts.


### PR DESCRIPTION
I found myself wishing those were clickable, so I'm paying it forward.

There's probably a lot more throughout the codebase — they're easy to miss.