### PR TITLE
docs(lib): do not inline http rexports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,10 +96,8 @@ pub use http;
 #[cfg(all(test, feature = "nightly"))]
 extern crate test;
 
-pub use crate::http::{header, Method, Request, Response, StatusCode, Uri, Version};
-
 #[doc(no_inline)]
-pub use crate::http::HeaderMap;
+pub use http::{header, HeaderMap, Method, Request, Response, StatusCode, Uri, Version};
 
 pub use crate::error::{Error, Result};
 


### PR DESCRIPTION
I think this will make the docs clearer. Before this change, `HeaderMap` is separate as a re-export, and the other types all look native to hyper. This will show that most of the top level types in hyper are re-exports from `http`.