### PR TITLE
Backport 0.14.x: feat(http1): support configurable max_headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ want = "0.3"
 # Optional
 
 libc = { version = "0.2", optional = true }
+smallvec = { version = "1.12", features = ["const_generics", "const_new"], optional = true }
 socket2 = { version = ">=0.4.7, <0.6.0", optional = true, features = ["all"] }
 
 [dev-dependencies]
@@ -87,8 +88,8 @@ http1 = []
 http2 = ["h2"]
 
 # Client/Server
-client = []
-server = []
+client = ["dep:smallvec"]
+server = ["dep:smallvec"]
 
 # `impl Stream` for things
 stream = []

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -115,6 +115,7 @@ pub struct Builder {
     h1_writev: Option<bool>,
     h1_title_case_headers: bool,
     h1_preserve_header_case: bool,
+    h1_max_headers: Option<usize>,
     #[cfg(feature = "ffi")]
     h1_preserve_header_order: bool,
     h1_read_buf_exact_size: Option<usize>,
@@ -302,6 +303,7 @@ impl Builder {
             h1_parser_config: Default::default(),
             h1_title_case_headers: false,
             h1_preserve_header_case: false,
+            h1_max_headers: None,
             #[cfg(feature = "ffi")]
             h1_preserve_header_order: false,
             h1_max_buf_size: None,
@@ -434,6 +436,24 @@ impl Builder {
         self
     }
 
+    /// Set the maximum number of headers.
+    ///
+    /// When a response is received, the parser will reserve a buffer to store headers for optimal
+    /// performance.
+    ///
+    /// If client receives more headers than the buffer size, the error "message header too large"
+    /// is returned.
+    ///
+    /// Note that headers is allocated on the stack by default, which has higher performance. After
+    /// setting this value, headers will be allocated in heap memory, that is, heap memory
+    /// allocation will occur for each response, and there will be a performance drop of about 5%.
+    ///
+    /// Default is 100.
+    pub fn max_headers(&mut self, val: usize) -> &mut Self {
+        self.h1_max_headers = Some(val);
+        self
+    }
+
     /// Set whether to support preserving original header order.
     ///
     /// Currently, this will record the order in which headers are received, and store this
@@ -513,6 +533,9 @@ impl Builder {
             }
             if opts.h1_preserve_header_case {
                 conn.set_preserve_header_case();
+            }
+            if let Some(max_headers) = opts.h1_max_headers {
+                conn.set_http1_max_headers(max_headers);
             }
             #[cfg(feature = "ffi")]
             if opts.h1_preserve_header_order {

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -53,6 +53,7 @@ where
                 keep_alive: KA::Busy,
                 method: None,
                 h1_parser_config: ParserConfig::default(),
+                h1_max_headers: None,
                 #[cfg(all(feature = "server", feature = "runtime"))]
                 h1_header_read_timeout: None,
                 #[cfg(all(feature = "server", feature = "runtime"))]
@@ -123,6 +124,10 @@ where
     #[cfg(feature = "client")]
     pub(crate) fn set_h09_responses(&mut self) {
         self.state.h09_responses = true;
+    }
+
+    pub(crate) fn set_http1_max_headers(&mut self, val: usize) {
+        self.state.h1_max_headers = Some(val);
     }
 
     #[cfg(all(feature = "server", feature = "runtime"))]
@@ -198,6 +203,7 @@ where
                 cached_headers: &mut self.state.cached_headers,
                 req_method: &mut self.state.method,
                 h1_parser_config: self.state.h1_parser_config.clone(),
+                h1_max_headers: self.state.h1_max_headers,
                 #[cfg(all(feature = "server", feature = "runtime"))]
                 h1_header_read_timeout: self.state.h1_header_read_timeout,
                 #[cfg(all(feature = "server", feature = "runtime"))]
@@ -822,6 +828,7 @@ struct State {
     /// a body or not.
     method: Option<Method>,
     h1_parser_config: ParserConfig,
+    h1_max_headers: Option<usize>,
     #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout: Option<Duration>,
     #[cfg(all(feature = "server", feature = "runtime"))]

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -191,6 +191,7 @@ where
                     cached_headers: parse_ctx.cached_headers,
                     req_method: parse_ctx.req_method,
                     h1_parser_config: parse_ctx.h1_parser_config.clone(),
+                    h1_max_headers: parse_ctx.h1_max_headers,
                     #[cfg(all(feature = "server", feature = "runtime"))]
                     h1_header_read_timeout: parse_ctx.h1_header_read_timeout,
                     #[cfg(all(feature = "server", feature = "runtime"))]
@@ -741,6 +742,7 @@ mod tests {
                 cached_headers: &mut None,
                 req_method: &mut None,
                 h1_parser_config: Default::default(),
+                h1_max_headers: None,
                 #[cfg(feature = "runtime")]
                 h1_header_read_timeout: None,
                 #[cfg(feature = "runtime")]

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -76,6 +76,7 @@ pub(crate) struct ParseContext<'a> {
     cached_headers: &'a mut Option<HeaderMap>,
     req_method: &'a mut Option<Method>,
     h1_parser_config: ParserConfig,
+    h1_max_headers: Option<usize>,
     #[cfg(all(feature = "server", feature = "runtime"))]
     h1_header_read_timeout: Option<Duration>,
     #[cfg(all(feature = "server", feature = "runtime"))]


### PR DESCRIPTION
Backport #3523 to `0.14.x`.

Context: At my work, we can't update to `1.x`, but we need this change to fix the customer's issue.
I backported #3523 and tried to resolve all conflicts.
Tests are passing, but I'm not sure about a few places.
I will mark this place with comments.
