### PR TITLE
fix(http1): is_timeout works on HeaderTimeout

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -240,16 +240,11 @@ impl Error {
 
     /// Returns true if the error was caused by a timeout.
     pub fn is_timeout(&self) -> bool {
-        #[cfg(any(
-            all(feature = "http1", feature = "server"),
-            feature = "ffi"
-        ))]
-        return matches!(self.inner.kind, Kind::HeaderTimeout) || self.find_source::<TimedOut>().is_some();
+        #[cfg(any(all(feature = "http1", feature = "server"), feature = "ffi"))]
+        return matches!(self.inner.kind, Kind::HeaderTimeout)
+            || self.find_source::<TimedOut>().is_some();
 
-        #[cfg(not(any(
-            all(feature = "http1", feature = "server"),
-            feature = "ffi"
-        )))]
+        #[cfg(not(any(all(feature = "http1", feature = "server"), feature = "ffi")))]
         self.find_source::<TimedOut>().is_some()
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -240,6 +240,16 @@ impl Error {
 
     /// Returns true if the error was caused by a timeout.
     pub fn is_timeout(&self) -> bool {
+        #[cfg(any(
+            all(feature = "http1", feature = "server"),
+            feature = "ffi"
+        ))]
+        return matches!(self.inner.kind, Kind::HeaderTimeout) || self.find_source::<TimedOut>().is_some();
+
+        #[cfg(not(any(
+            all(feature = "http1", feature = "server"),
+            feature = "ffi"
+        )))]
         self.find_source::<TimedOut>().is_some()
     }
 

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2862,7 +2862,7 @@ fn http1_trailer_recv_fields() {
 }
 
 #[tokio::test]
-async fn timeout_err() {
+async fn http1_timeout_error() {
     let (listener, addr) = setup_tcp_listener();
 
     let j = tokio::spawn(async move {
@@ -2873,16 +2873,17 @@ async fn timeout_err() {
             .timer(TokioTimer)
             .header_read_timeout(Duration::from_secs(1))
             .serve_connection(socket, HelloWorld)
-            .await {
-                Some(e.is_timeout())
-            } else {
-                None
-            }
+            .await
+        {
+            Some(e.is_timeout())
+        } else {
+            None
+        }
     });
 
     let tcp = TokioIo::new(connect_async(addr).await);
     let (_client, conn) = hyper::client::conn::http1::Builder::new()
-        .handshake::<_,Empty<Bytes>>(tcp)
+        .handshake::<_, Empty<Bytes>>(tcp)
         .await
         .expect("http handshake");
 


### PR DESCRIPTION
Changed `hyper::Error::is_timeout()` to also check if the kind of the error is a `HeaderTimeout`. I also added a test at the end of `server.rs` to check for this kind of timeout error.

Fixes #3780 