### PR TITLE
fix(http2): pass proper value to h2 `max_local_error_reset_streams`

### DIFF
--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -135,7 +135,7 @@ where
             .initial_connection_window_size(config.initial_conn_window_size)
             .max_frame_size(config.max_frame_size)
             .max_header_list_size(config.max_header_list_size)
-            .max_local_error_reset_streams(config.max_pending_accept_reset_streams)
+            .max_local_error_reset_streams(config.max_local_error_reset_streams)
             .max_send_buffer_size(config.max_send_buffer_size);
         if let Some(max) = config.max_concurrent_streams {
             builder.max_concurrent_streams(max);


### PR DESCRIPTION
The patch #3528 added the ability for hyper users to configure `max_local_error_reset_streams` via the server builder to hyper v0.14.29. It was then pulled in to hyper v1.2.0 as well in #3530, where the wrong parameter `max_pending_accept_reset_streams` is passed to h2's builder as `max_local_error_reset_streams`.

This could lead to significant impact especially when a hyper user does not set `max_pending_accept_reset_streams`, because its default value is `None` and passing `None` to h2's `max_local_error_reset_streams` method will make the server vulnerable to DOS attacks.

This issue has been fixed in this patch, simply by passing the correct value to the h2's builder method.

Note that the original patch merged into v0.14 does not suffer this problem.

