### PR TITLE
chore(server/conn): backport `max_pending_accept_reset_streams()`

### DIFF
--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -175,6 +175,17 @@ impl<E> Builder<E> {
         self
     }
 
+    /// Configures the maximum number of pending reset streams allowed before a GOAWAY will be sent.
+    ///
+    /// This will default to the default value set by the [`h2` crate](https://crates.io/crates/h2).
+    /// As of v0.3.17, it is 20.
+    ///
+    /// See <https://github.com/hyperium/hyper/issues/2877> for more information.
+    pub fn max_pending_accept_reset_streams(&mut self, max: impl Into<Option<usize>>) -> &mut Self {
+        self.h2_builder.max_pending_accept_reset_streams = max.into();
+        self
+    }
+
     /// Sets an interval for HTTP2 Ping frames should be sent to keep a
     /// connection alive.
     ///


### PR DESCRIPTION
**NB:** this commit is based on the `0.14.x` release series.

the `server::conn::http2` submodule provides types that are conditionally compiled when the [`backports`](https://hyper.rs/guides/1/upgrading/) feature is active, to facilitate upgrading to the `1.x` release.

i've been working on upgrading the
[`linkerd2-proxy`](https://github.com/linkerd/linkerd2-proxy/) project to use hyper 1.0, but encountered a pertinent gap in `Builder<E>`'s interface when setting the `backports` and `deprecated` features.

this adds a `max_pending_accept_reset_streams(..)` method (_added in #3201_) to this builder, so that 0.14.x users relying on this functionality can prepare to upgrade to hyper 1.x safely.

this is effectively a backport of #3507, which restored this interface to the 1.0 release.

for more information, see:

* https://github.com/hyperium/hyper/pull/3201
* https://github.com/hyperium/hyper/pull/3507
* https://github.com/hyperium/hyper/issues/3461
* https://hyper.rs/guides/1/upgrading/

