### PR TITLE
chore(client/conn): `SendRequest` conversion glue

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -250,6 +250,14 @@ impl<B> fmt::Debug for SendRequest<B> {
     }
 }
 
+/// A [`SendRequest<B>`] can be constructed from its legacy counterpart.
+#[cfg_attr(feature = "deprecated", allow(deprecated))]
+impl<B> From<super::SendRequest<B>> for SendRequest<B> {
+    fn from(super::SendRequest { dispatch }: super::SendRequest<B>) -> Self {
+        SendRequest { dispatch }
+    }
+}
+
 // ===== impl Connection
 
 impl<T, B> fmt::Debug for Connection<T, B>

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -188,6 +188,16 @@ impl<B> fmt::Debug for SendRequest<B> {
     }
 }
 
+/// A [`SendRequest<B>`] can be constructed from its legacy counterpart.
+#[cfg_attr(feature = "deprecated", allow(deprecated))]
+impl<B> From<super::SendRequest<B>> for SendRequest<B> {
+    fn from(super::SendRequest { dispatch }: super::SendRequest<B>) -> Self {
+        Self {
+            dispatch: dispatch.unbound(),
+        }
+    }
+}
+
 // ===== impl Connection
 
 impl<T, B> Connection<T, B>


### PR DESCRIPTION
users of the `backports` feature that are attempting to migrate from 0.14 to 1.0 may need to convert from a legacy `SendRequest` (returned by some of the connector builders) to an instance of the new protocol specific `conn::http2::SendRequest<B>` or
`conn::http1::SendRequest<B>` senders.

this adds `From<T>` implementation to the type provided by the `backports` feature, to help facilitate incremental migration.

