### PR TITLE
fix(server): fix failing tests for server feature

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Run FFI unit tests
         env:
           RUSTFLAGS: --cfg hyper_unstable_ffi
-        run: cargo test --features server,client,http1,http2,ffi --lib
+        run: cargo test --features client,http1,http2,ffi --lib
 
   ffi-header:
     name: Verify hyper.h is up to date
@@ -279,7 +279,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-05-01  # Compatible version for cargo-check-external-types
+          toolchain: nightly-2024-05-01 # Compatible version for cargo-check-external-types
 
       - name: Install cargo-check-external-types
         uses: taiki-e/cache-cargo-install-action@v2

--- a/examples/hello-http2.rs
+++ b/examples/hello-http2.rs
@@ -1,13 +1,14 @@
 #![deny(warnings)]
-
-use std::convert::Infallible;
-use std::net::SocketAddr;
+#![allow(unused_imports)]
 
 use http_body_util::Full;
 use hyper::body::Bytes;
+#[cfg(feature = "server")]
 use hyper::server::conn::http2;
 use hyper::service::service_fn;
 use hyper::{Request, Response};
+use std::convert::Infallible;
+use std::net::SocketAddr;
 use tokio::net::TcpListener;
 
 // This would normally come from the `hyper-util` crate, but we can't depend
@@ -18,6 +19,7 @@ use support::TokioIo;
 
 // An async function that consumes a request, does nothing with it and returns a
 // response.
+#[cfg(feature = "server")]
 async fn hello(_: Request<hyper::body::Incoming>) -> Result<Response<Full<Bytes>>, Infallible> {
     Ok(Response::new(Full::new(Bytes::from("Hello, World!"))))
 }
@@ -40,6 +42,7 @@ where
     }
 }
 
+#[cfg(feature = "server")]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     pretty_env_logger::init();
@@ -78,4 +81,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             }
         });
     }
+}
+
+#[cfg(not(feature = "server"))]
+fn main() {
+    panic!("This example requires the 'server' feature to be enabled");
 }

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -506,6 +506,7 @@ mod tests {
         assert!(encoder.end::<()>().unwrap().is_none());
     }
 
+    #[cfg(feature = "server")]
     #[test]
     fn eof() {
         let mut encoder = Encoder::close_delimited();

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1646,6 +1646,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(feature = "server")]
     #[test]
     fn test_parse_request() {
         let _ = pretty_env_logger::try_init();
@@ -1701,6 +1702,7 @@ mod tests {
         assert_eq!(msg.head.headers["Content-Length"], "0");
     }
 
+    #[cfg(feature = "server")]
     #[test]
     fn test_parse_request_errors() {
         let mut raw = BytesMut::from("GET htt:p// HTTP/1.1\r\nHost: hyper.rs\r\n\r\n");
@@ -1814,6 +1816,7 @@ mod tests {
         Client::parse(&mut raw, ctx).unwrap_err();
     }
 
+    #[cfg(feature = "server")]
     #[test]
     fn test_parse_preserve_header_case_in_request() {
         let mut raw =
@@ -1852,6 +1855,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "server")]
     #[test]
     fn test_decoder_request() {
         fn parse(s: &str) -> ParsedMessage<RequestLine> {
@@ -2462,9 +2466,11 @@ mod tests {
             Encode {
                 head: &mut head,
                 body: Some(BodyLength::Known(10)),
+                #[cfg(feature = "server")]
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: true,
+                #[cfg(feature = "server")]
                 date_header: true,
             },
             &mut vec,
@@ -2494,9 +2500,11 @@ mod tests {
             Encode {
                 head: &mut head,
                 body: Some(BodyLength::Known(10)),
+                #[cfg(feature = "server")]
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: false,
+                #[cfg(feature = "server")]
                 date_header: true,
             },
             &mut vec,
@@ -2529,9 +2537,11 @@ mod tests {
             Encode {
                 head: &mut head,
                 body: Some(BodyLength::Known(10)),
+                #[cfg(feature = "server")]
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: true,
+                #[cfg(feature = "server")]
                 date_header: true,
             },
             &mut vec,
@@ -2545,6 +2555,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "server")]
     #[test]
     fn test_server_encode_connect_method() {
         let mut head = MessageHead::default();
@@ -2566,6 +2577,7 @@ mod tests {
         assert!(encoder.is_last());
     }
 
+    #[cfg(feature = "server")]
     #[test]
     fn test_server_response_encode_title_case() {
         use crate::proto::BodyLength;
@@ -2599,6 +2611,7 @@ mod tests {
         assert_eq!(&vec[..expected_response.len()], &expected_response[..]);
     }
 
+    #[cfg(feature = "server")]
     #[test]
     fn test_server_response_encode_orig_case() {
         use crate::proto::BodyLength;
@@ -2634,6 +2647,7 @@ mod tests {
         assert_eq!(&vec[..expected_response.len()], &expected_response[..]);
     }
 
+    #[cfg(feature = "server")]
     #[test]
     fn test_server_response_encode_orig_and_title_case() {
         use crate::proto::BodyLength;
@@ -2670,6 +2684,7 @@ mod tests {
         assert_eq!(&vec[..expected_response.len()], &expected_response[..]);
     }
 
+    #[cfg(feature = "server")]
     #[test]
     fn test_disabled_date_header() {
         use crate::proto::BodyLength;
@@ -2729,6 +2744,7 @@ mod tests {
         assert_eq!(parsed.head.headers["server"], "hello\tworld");
     }
 
+    #[cfg(feature = "server")]
     #[test]
     fn parse_too_large_headers() {
         fn gen_req_with_headers(num: usize) -> String {


### PR DESCRIPTION
Update tests that require the server feature to only be compiled when the feature is enabled. After updating these tests, the server feature is no longer required for the ffi job when running tests.

Closes #3790

