### PR TITLE
refactor(clippy): Reduce some Clippy warnings

### DIFF
--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -82,7 +82,7 @@ fn http1_parallel_x10_req_10kb_100_chunks(b: &mut test::Bencher) {
 #[bench]
 #[ignore]
 fn http1_parallel_x10_res_1mb(b: &mut test::Bencher) {
-    let body = &[b'x'; 1024 * 1024 * 1];
+    let body = &[b'x'; 1024 * 1024];
     opts().parallel(10).response_body(body).bench(b)
 }
 
@@ -177,7 +177,7 @@ fn http2_parallel_x10_req_10kb_100_chunks_max_window(b: &mut test::Bencher) {
 
 #[bench]
 fn http2_parallel_x10_res_1mb(b: &mut test::Bencher) {
-    let body = &[b'x'; 1024 * 1024 * 1];
+    let body = &[b'x'; 1024 * 1024];
     opts()
         .http2()
         .parallel(10)

--- a/benches/support/tokiort.rs
+++ b/benches/support/tokiort.rs
@@ -44,7 +44,7 @@ impl Timer for TokioTimer {
 
     fn reset(&self, sleep: &mut Pin<Box<dyn Sleep>>, new_deadline: Instant) {
         if let Some(sleep) = sleep.as_mut().downcast_mut_pin::<TokioSleep>() {
-            sleep.reset(new_deadline.into())
+            sleep.reset(new_deadline)
         }
     }
 }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -71,7 +71,7 @@ async fn fetch_url(url: hyper::Uri) -> Result<()> {
     while let Some(next) = res.frame().await {
         let frame = next?;
         if let Some(chunk) = frame.data_ref() {
-            io::stdout().write_all(&chunk).await?;
+            io::stdout().write_all(chunk).await?;
         }
     }
 

--- a/examples/gateway.rs
+++ b/examples/gateway.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let in_addr: SocketAddr = ([127, 0, 0, 1], 3001).into();
     let out_addr: SocketAddr = ([127, 0, 0, 1], 3000).into();
 
-    let out_addr_clone = out_addr.clone();
+    let out_addr_clone = out_addr;
 
     let listener = TcpListener::bind(in_addr).await?;
 

--- a/examples/http_proxy.rs
+++ b/examples/http_proxy.rs
@@ -111,7 +111,7 @@ async fn proxy(
 }
 
 fn host_addr(uri: &http::Uri) -> Option<String> {
-    uri.authority().and_then(|auth| Some(auth.to_string()))
+    uri.authority().map(|auth| auth.to_string())
 }
 
 fn empty() -> BoxBody<Bytes, hyper::Error> {

--- a/examples/single_threaded.rs
+++ b/examples/single_threaded.rs
@@ -207,7 +207,7 @@ async fn http1_client(url: hyper::Uri) -> Result<(), Box<dyn std::error::Error>>
         while let Some(next) = res.frame().await {
             let frame = next?;
             if let Some(chunk) = frame.data_ref() {
-                stdout.write_all(&chunk).await.unwrap();
+                stdout.write_all(chunk).await.unwrap();
             }
         }
         stdout.write_all(b"\n-----------------\n").await.unwrap();
@@ -308,7 +308,7 @@ async fn http2_client(url: hyper::Uri) -> Result<(), Box<dyn std::error::Error>>
         while let Some(next) = res.frame().await {
             let frame = next?;
             if let Some(chunk) = frame.data_ref() {
-                stdout.write_all(&chunk).await.unwrap();
+                stdout.write_all(chunk).await.unwrap();
             }
         }
         stdout.write_all(b"\n-----------------\n").await.unwrap();

--- a/examples/upgrades.rs
+++ b/examples/upgrades.rs
@@ -169,7 +169,6 @@ async fn main() {
                             res = &mut conn => {
                                 if let Err(err) = res {
                                     println!("Error serving connection: {:?}", err);
-                                    return;
                                 }
                             }
                             // Continue polling the connection after enabling graceful shutdown.
@@ -187,7 +186,7 @@ async fn main() {
     });
 
     // Client requests a HTTP connection upgrade.
-    let request = client_upgrade_request(addr.clone());
+    let request = client_upgrade_request(addr);
     if let Err(e) = request.await {
         eprintln!("client error: {}", e);
     }

--- a/examples/web_api.rs
+++ b/examples/web_api.rs
@@ -117,7 +117,7 @@ async fn main() -> Result<()> {
         let io = TokioIo::new(stream);
 
         tokio::task::spawn(async move {
-            let service = service_fn(move |req| response_examples(req));
+            let service = service_fn(response_examples);
 
             if let Err(err) = http1::Builder::new().serve_connection(io, service).await {
                 println!("Failed to serve connection: {:?}", err);

--- a/src/ext/h1_reason_phrase.rs
+++ b/src/ext/h1_reason_phrase.rs
@@ -174,26 +174,26 @@ mod tests {
 
     #[test]
     fn basic_valid() {
-        const PHRASE: &'static [u8] = b"OK";
+        const PHRASE: &[u8] = b"OK";
         assert_eq!(ReasonPhrase::from_static(PHRASE).as_bytes(), PHRASE);
         assert_eq!(ReasonPhrase::try_from(PHRASE).unwrap().as_bytes(), PHRASE);
     }
 
     #[test]
     fn empty_valid() {
-        const PHRASE: &'static [u8] = b"";
+        const PHRASE: &[u8] = b"";
         assert_eq!(ReasonPhrase::from_static(PHRASE).as_bytes(), PHRASE);
         assert_eq!(ReasonPhrase::try_from(PHRASE).unwrap().as_bytes(), PHRASE);
     }
 
     #[test]
     fn obs_text_valid() {
-        const PHRASE: &'static [u8] = b"hyp\xe9r";
+        const PHRASE: &[u8] = b"hyp\xe9r";
         assert_eq!(ReasonPhrase::from_static(PHRASE).as_bytes(), PHRASE);
         assert_eq!(ReasonPhrase::try_from(PHRASE).unwrap().as_bytes(), PHRASE);
     }
 
-    const NEWLINE_PHRASE: &'static [u8] = b"hyp\ner";
+    const NEWLINE_PHRASE: &[u8] = b"hyp\ner";
 
     #[test]
     #[should_panic]
@@ -206,7 +206,7 @@ mod tests {
         assert!(ReasonPhrase::try_from(NEWLINE_PHRASE).is_err());
     }
 
-    const CR_PHRASE: &'static [u8] = b"hyp\rer";
+    const CR_PHRASE: &[u8] = b"hyp\rer";
 
     #[test]
     #[should_panic]

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -693,7 +693,7 @@ mod tests {
     use std::pin::Pin;
     use std::time::Duration;
 
-    impl<'a> MemRead for &'a [u8] {
+    impl MemRead for &[u8] {
         fn read_mem(&mut self, _: &mut Context<'_>, len: usize) -> Poll<io::Result<Bytes>> {
             let n = std::cmp::min(len, self.len());
             if n > 0 {
@@ -707,12 +707,12 @@ mod tests {
         }
     }
 
-    impl<'a> MemRead for &'a mut (dyn Read + Unpin) {
+    impl MemRead for &mut (dyn Read + Unpin) {
         fn read_mem(&mut self, cx: &mut Context<'_>, len: usize) -> Poll<io::Result<Bytes>> {
             let mut v = vec![0; len];
             let mut buf = ReadBuf::new(&mut v);
             ready!(Pin::new(self).poll_read(cx, buf.unfilled())?);
-            Poll::Ready(Ok(Bytes::copy_from_slice(&buf.filled())))
+            Poll::Ready(Ok(Bytes::copy_from_slice(buf.filled())))
         }
     }
 
@@ -761,7 +761,7 @@ mod tests {
                 })
                 .await;
                 let desc = format!("read_size failed for {:?}", s);
-                state = result.expect(desc.as_str());
+                state = result.expect(&desc);
                 if state == ChunkedState::Body || state == ChunkedState::EndCr {
                     break;
                 }

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -488,7 +488,7 @@ impl<'a, T> OptGuard<'a, T> {
     }
 }
 
-impl<'a, T> Drop for OptGuard<'a, T> {
+impl<T> Drop for OptGuard<'_, T> {
     fn drop(&mut self) {
         if self.1 {
             self.0.set(None);

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -535,19 +535,16 @@ mod tests {
         let trailers = vec![HeaderValue::from_static("chunky-trailer")];
         let encoder = encoder.into_chunked_with_trailing_fields(trailers);
 
-        let headers = HeaderMap::from_iter(
-            vec![
-                (
-                    HeaderName::from_static("chunky-trailer"),
-                    HeaderValue::from_static("header data"),
-                ),
-                (
-                    HeaderName::from_static("should-not-be-included"),
-                    HeaderValue::from_static("oops"),
-                ),
-            ]
-            .into_iter(),
-        );
+        let headers = HeaderMap::from_iter(vec![
+            (
+                HeaderName::from_static("chunky-trailer"),
+                HeaderValue::from_static("header data"),
+            ),
+            (
+                HeaderName::from_static("should-not-be-included"),
+                HeaderValue::from_static("oops"),
+            ),
+        ]);
 
         let buf1 = encoder.encode_trailers::<&[u8]>(headers, false).unwrap();
 
@@ -565,19 +562,16 @@ mod tests {
         ];
         let encoder = encoder.into_chunked_with_trailing_fields(trailers);
 
-        let headers = HeaderMap::from_iter(
-            vec![
-                (
-                    HeaderName::from_static("chunky-trailer"),
-                    HeaderValue::from_static("header data"),
-                ),
-                (
-                    HeaderName::from_static("chunky-trailer-2"),
-                    HeaderValue::from_static("more header data"),
-                ),
-            ]
-            .into_iter(),
-        );
+        let headers = HeaderMap::from_iter(vec![
+            (
+                HeaderName::from_static("chunky-trailer"),
+                HeaderValue::from_static("header data"),
+            ),
+            (
+                HeaderName::from_static("chunky-trailer-2"),
+                HeaderValue::from_static("more header data"),
+            ),
+        ]);
 
         let buf1 = encoder.encode_trailers::<&[u8]>(headers, false).unwrap();
 
@@ -593,13 +587,10 @@ mod tests {
     fn chunked_with_no_trailer_header() {
         let encoder = Encoder::chunked();
 
-        let headers = HeaderMap::from_iter(
-            vec![(
-                HeaderName::from_static("chunky-trailer"),
-                HeaderValue::from_static("header data"),
-            )]
-            .into_iter(),
-        );
+        let headers = HeaderMap::from_iter(vec![(
+            HeaderName::from_static("chunky-trailer"),
+            HeaderValue::from_static("header data"),
+        )]);
 
         assert!(encoder
             .encode_trailers::<&[u8]>(headers.clone(), false)
@@ -656,13 +647,10 @@ mod tests {
         let trailers = vec![HeaderValue::from_static("chunky-trailer")];
         let encoder = encoder.into_chunked_with_trailing_fields(trailers);
 
-        let headers = HeaderMap::from_iter(
-            vec![(
-                HeaderName::from_static("chunky-trailer"),
-                HeaderValue::from_static("header data"),
-            )]
-            .into_iter(),
-        );
+        let headers = HeaderMap::from_iter(vec![(
+            HeaderName::from_static("chunky-trailer"),
+            HeaderValue::from_static("header data"),
+        )]);
         let buf1 = encoder.encode_trailers::<&[u8]>(headers, true).unwrap();
 
         let mut dst = Vec::new();

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -320,7 +320,7 @@ where
     }
 
     #[cfg(test)]
-    fn flush<'a>(&'a mut self) -> impl std::future::Future<Output = io::Result<()>> + 'a {
+    fn flush(&mut self) -> impl std::future::Future<Output = io::Result<()>> + '_ {
         futures_util::future::poll_fn(move |cx| self.poll_flush(cx))
     }
 }

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -100,10 +100,8 @@ fn is_complete_fast(bytes: &[u8], prev_len: usize) -> bool {
             if bytes[i + 1..].chunks(3).next() == Some(&b"\n\r\n"[..]) {
                 return true;
             }
-        } else if b == b'\n' {
-            if bytes.get(i + 1) == Some(&b'\n') {
-                return true;
-            }
+        } else if b == b'\n' && bytes.get(i + 1) == Some(&b'\n') {
+            return true;
         }
     }
 
@@ -1622,7 +1620,7 @@ fn write_headers_original_case(
 struct FastWrite<'a>(&'a mut Vec<u8>);
 
 #[cfg(feature = "client")]
-impl<'a> fmt::Write for FastWrite<'a> {
+impl fmt::Write for FastWrite<'_> {
     #[inline]
     fn write_str(&mut self, s: &str) -> fmt::Result {
         extend(self.0, s.as_bytes());
@@ -1721,7 +1719,7 @@ mod tests {
         Server::parse(&mut raw, ctx).unwrap_err();
     }
 
-    const H09_RESPONSE: &'static str = "Baguettes are super delicious, don't you agree?";
+    const H09_RESPONSE: &str = "Baguettes are super delicious, don't you agree?";
 
     #[test]
     fn test_parse_response_h09_allowed() {
@@ -1766,7 +1764,7 @@ mod tests {
         assert_eq!(raw, H09_RESPONSE);
     }
 
-    const RESPONSE_WITH_WHITESPACE_BETWEEN_HEADER_NAME_AND_COLON: &'static str =
+    const RESPONSE_WITH_WHITESPACE_BETWEEN_HEADER_NAME_AND_COLON: &str =
         "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Credentials : true\r\n\r\n";
 
     #[test]
@@ -1842,14 +1840,12 @@ mod tests {
         assert_eq!(
             orig_headers
                 .get_all_internal(&HeaderName::from_static("host"))
-                .into_iter()
                 .collect::<Vec<_>>(),
             vec![&Bytes::from("Host")]
         );
         assert_eq!(
             orig_headers
                 .get_all_internal(&HeaderName::from_static("x-bread"))
-                .into_iter()
                 .collect::<Vec<_>>(),
             vec![&Bytes::from("X-BREAD")]
         );

--- a/src/proto/h2/ping.rs
+++ b/src/proto/h2/ping.rs
@@ -10,14 +10,14 @@
 /// # BDP Algorithm
 ///
 /// 1. When receiving a DATA frame, if a BDP ping isn't outstanding:
-///   1a. Record current time.
-///   1b. Send a BDP ping.
+///    1a. Record current time.
+///    1b. Send a BDP ping.
 /// 2. Increment the number of received bytes.
 /// 3. When the BDP ping ack is received:
-///   3a. Record duration from sent time.
-///   3b. Merge RTT with a running average.
-///   3c. Calculate bdp as bytes/rtt.
-///   3d. If bdp is over 2/3 max, set new max to bdp and update windows.
+///    3a. Record duration from sent time.
+///    3b. Merge RTT with a running average.
+///    3c. Calculate bdp as bytes/rtt.
+///    3d. If bdp is over 2/3 max, set new max to bdp and update windows.
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -181,13 +181,11 @@ where
         match self.state {
             State::Handshaking { .. } => {
                 self.close_pending = true;
-                return;
             }
             State::Serving(ref mut srv) => {
                 if srv.closing.is_none() {
                     srv.conn.graceful_shutdown();
                 }
-                return;
             }
         }
     }
@@ -227,7 +225,7 @@ where
                 }
                 State::Serving(ref mut srv) => {
                     // graceful_shutdown was called before handshaking finished,
-                    if true == me.close_pending && srv.closing.is_none() {
+                    if me.close_pending && srv.closing.is_none() {
                         srv.conn.graceful_shutdown();
                     }
                     ready!(srv.poll_server(cx, &mut me.service, &mut me.exec))?;

--- a/src/rt/io.rs
+++ b/src/rt/io.rs
@@ -211,7 +211,7 @@ impl<'data> ReadBuf<'data> {
     }
 }
 
-impl<'data> fmt::Debug for ReadBuf<'data> {
+impl fmt::Debug for ReadBuf<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ReadBuf")
             .field("filled", &self.filled)
@@ -221,7 +221,7 @@ impl<'data> fmt::Debug for ReadBuf<'data> {
     }
 }
 
-impl<'data> ReadBufCursor<'data> {
+impl ReadBufCursor<'_> {
     /// Access the unfilled part of the buffer.
     ///
     /// # Safety

--- a/src/service/service.rs
+++ b/src/service/service.rs
@@ -40,7 +40,7 @@ pub trait Service<Request> {
     /// - It's clearer that Services can likely be cloned
     /// - To share state across clones, you generally need `Arc<Mutex<_>>`
     ///   That means you're not really using the `&mut self` and could do with a `&self`.
-    /// The discussion on this is here: <https://github.com/hyperium/hyper/issues/3040>
+    ///   The discussion on this is here: <https://github.com/hyperium/hyper/issues/3040>
     fn call(&self, req: Request) -> Self::Future;
 }
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -1156,7 +1156,7 @@ test! {
             \r\n\
             ",
         reply: {
-            let long_header = std::iter::repeat("A").take(500_000).collect::<String>();
+            let long_header = "A".repeat(500_000);
             format!("\
                 HTTP/1.1 200 OK\r\n\
                 {}: {}\r\n\

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -156,7 +156,7 @@ mod response_body_lengths {
         let n = body.find("\r\n\r\n").unwrap() + 4;
 
         if case.expects_chunked {
-            if body_str.len() > 0 {
+            if !body_str.is_empty() {
                 let len = body.len();
                 assert_eq!(
                     &body[n + 1..n + 3],
@@ -1090,13 +1090,10 @@ fn pipeline_disabled() {
     // TODO: add in a delay to the `ServeReply` interface, to allow this
     // delay to prevent the 2 writes from happening before this test thread
     // can read from the socket.
-    match req.read(&mut buf) {
-        Ok(n) => {
-            // won't be 0, because we didn't say to close, and so socket
-            // will be open until `server` drops
-            assert_ne!(n, 0);
-        }
-        Err(_) => (),
+    if let Ok(n) = req.read(&mut buf) {
+        // won't be 0, because we didn't say to close, and so socket
+        // will be open until `server` drops
+        assert_ne!(n, 0);
     }
 }
 
@@ -1309,7 +1306,7 @@ async fn http1_graceful_shutdown_after_upgrade() {
 
         let response = s(&buf);
         assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"));
-        assert!(!has_header(&response, "content-length"));
+        assert!(!has_header(response, "content-length"));
         let _ = read_101_tx.send(());
     });
 
@@ -1481,9 +1478,8 @@ fn header_name_too_long() {
     let mut req = connect(server.addr());
     let mut write = Vec::with_capacity(1024 * 66);
     write.extend_from_slice(b"GET / HTTP/1.1\r\n");
-    for _ in 0..(1024 * 65) {
-        write.push(b'x');
-    }
+    write.extend_from_slice(vec![b'x'; 1024 * 64].as_slice());
+
     write.extend_from_slice(b": foo\r\n\r\n");
     req.write_all(&write).unwrap();
 
@@ -1769,7 +1765,7 @@ async fn upgrades_new() {
 
         let response = s(&buf);
         assert!(response.starts_with("HTTP/1.1 101 Switching Protocols\r\n"));
-        assert!(!has_header(&response, "content-length"));
+        assert!(!has_header(response, "content-length"));
         let _ = read_101_tx.send(());
 
         let n = tcp.read(&mut buf).expect("read 2");
@@ -2918,7 +2914,7 @@ struct ReplyBuilder<'a> {
     tx: &'a Mutex<spmc::Sender<Reply>>,
 }
 
-impl<'a> ReplyBuilder<'a> {
+impl ReplyBuilder<'_> {
     fn status(self, status: hyper::StatusCode) -> Self {
         self.tx.lock().unwrap().send(Reply::Status(status)).unwrap();
         self
@@ -2994,7 +2990,7 @@ impl<'a> ReplyBuilder<'a> {
     }
 }
 
-impl<'a> Drop for ReplyBuilder<'a> {
+impl Drop for ReplyBuilder<'_> {
     fn drop(&mut self) {
         if let Ok(mut tx) = self.tx.lock() {
             let _ = tx.send(Reply::End);

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -371,7 +371,7 @@ async fn async_test(cfg: __TestConfig) {
                 assert_eq!(req.method(), &sreq.method, "client method");
                 assert_eq!(req.version(), version, "client version");
                 for func in &sreq.headers {
-                    func(&req.headers());
+                    func(req.headers());
                 }
                 let sbody = sreq.body;
                 req.collect().map_ok(move |collected| {
@@ -460,7 +460,7 @@ async fn async_test(cfg: __TestConfig) {
             assert_eq!(res.status(), cstatus, "server status");
             assert_eq!(res.version(), version, "server version");
             for func in &cheaders {
-                func(&res.headers());
+                func(res.headers());
             }
 
             let body = res.collect().await.unwrap().to_bytes();


### PR DESCRIPTION
## What this PR want to do 

Tried to complete https://github.com/hyperium/hyper/issues/3802 as well as possible.

This PR wants to reduce some Clippy warnings that worth fixing.  Almost all of the changes are based on clippy prompts. And passed the MSRV 1.63 test.

Some of the warnings have not changed, mainly based on Clippy's false positives, and some clippy rules are newer than the current MSRV 1.63.

## How to test and review

Needs downgrade some crate versions to run on MSRV 1.63.
```
cargo update tokio --precise 1.38.1 
cargo update tokio-util --precise 0.7.11
cargo update hashbrown --precise 0.15.0
cargo update regex --precise 1.9.6
cargo update async-stream --precise 0.3.5
cargo update tokio-stream --precise 0.1.15
```

Run `cargo +1.63-x86_64-unknown-linux-gnu  clippy --workspace --no-deps --all-targets --features="full"  -- -D warnings`
The warnings/error reduces to 7.





