### PR TITLE
fix pin-project-lite not found error in vs code.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ futures-channel = { version = "0.3", features = ["sink"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc", "sink"] }
 http-body-util = "0.1"
 pretty_env_logger = "0.5"
+pin-project-lite = "0.2.4"
 spmc = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## How to reproduce?

1. Open this project in vs code. 
2. Open `benches/support/tokiort.rs`, check error report by IDE at:
   https://github.com/hyperium/hyper/blob/0bd4adfed2bf40dda6867260ded05542d5b921c5/benches/support/tokiort.rs#L11