### PR TITLE
Backport 0.14: fix intermitent panic parsing partial headers

### DIFF
--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -248,7 +248,11 @@ where
                         }
                     }
                     if curr_len > 0 {
+                        trace!("partial headers; {} bytes so far", curr_len);
                         self.partial_len = Some(curr_len);
+                    } else {
+                        // 1xx gobled some bytes
+                        self.partial_len = None;
                     }
                 }
             }


### PR DESCRIPTION
Backports #3812 to 0.14.x.

