### PR TITLE
fix(http2): gate server `Builder` keep-alive interfaces

### DIFF
--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -195,6 +195,9 @@ impl<E> Builder<E> {
     ///
     /// # Cargo Feature
     ///
+    /// Requires the `runtime` cargo feature to be enabled.
+    #[cfg(feature = "runtime")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "runtime")))]
     pub fn keep_alive_interval(&mut self, interval: impl Into<Option<Duration>>) -> &mut Self {
         self.h2_builder.keep_alive_interval = interval.into();
         self
@@ -209,6 +212,9 @@ impl<E> Builder<E> {
     ///
     /// # Cargo Feature
     ///
+    /// Requires the `runtime` cargo feature to be enabled.
+    #[cfg(feature = "runtime")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "runtime")))]
     pub fn keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.h2_builder.keep_alive_timeout = timeout;
         self


### PR DESCRIPTION
currently, dependents of hyper 0.14 that enable the `server` and `http2` feature flags will see an error if they enable the `backports` flag.

building hyper like so...

```sh
cargo check --features server,http2,backports
```

...will yield the following errors (shown in "short" format here for brevity):

```text
src/server/conn.rs:75:9: warning: unused import: `tracing::trace`
src/server/conn/http2.rs:185:25: error[E0609]: no field `keep_alive_interval` on type `h2::server::Config`
src/server/conn/http2.rs:199:25: error[E0609]: no field `keep_alive_timeout` on type `h2::server::Config`
warning: `hyper` (lib) generated 1 warning
error: could not compile `hyper` (lib) due to 2 previous errors; 1 warning emitted
```

this stems from the fact that the deprecated connection builder `hyper::server::conn::Builder` and the backported
`hyper::server::conn::http2::Builder` both operate on the same internal `Config` structure. this structure has changed slightly between 0.14 and 1.0 however. see:

```sh
; git diff 0.14.x master -- src/proto/h2/server.rs | grep 'struct Config' -A 11
```

```diff
@@ -51,12 +51,11 @@ pub(crate) struct Config {
     pub(crate) max_concurrent_streams: Option<u32>,
     pub(crate) max_pending_accept_reset_streams: Option<usize>,
     pub(crate) max_local_error_reset_streams: Option<usize>,
-    #[cfg(feature = "runtime")]
     pub(crate) keep_alive_interval: Option<Duration>,
-    #[cfg(feature = "runtime")]
     pub(crate) keep_alive_timeout: Duration,
     pub(crate) max_send_buffer_size: usize,
     pub(crate) max_header_list_size: u32,
+    pub(crate) date_header: bool,
 }
```

the `runtime` feature flag has since been removed. see: <https://docs.rs/hyper/1.5.1/hyper/#optional-features>

the backported code, consequently, does not include these conditional compilation attributes. i was able to recreate this as far back as v0.14.25, when these backported types were first released.

this commit proposes the addition of `#[cfg(feature = "runtime")]` attributes to the `keep_alive_timeout(..)` and `keep_alive_interval(..)` methods of the backported http/2 server connection `Builder`.

this will allow hyper users that only require the `server` and `http2` feature flags to address deprecations and prepare to upgrade to hyper 1.0, _without_ having to opt into previously disabled feature flags.

