### PR TITLE
fix(server): `max_local_error_reset_streams` function `mut self` -> `&mut self`

### DIFF
--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -141,7 +141,7 @@ impl<E> Builder<E> {
     /// See <https://rustsec.org/advisories/RUSTSEC-2024-0003.html> for more information.
     #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-    pub fn max_local_error_reset_streams(mut self, max: impl Into<Option<usize>>) -> Self {
+    pub fn max_local_error_reset_streams(&mut self, max: impl Into<Option<usize>>) -> &mut Self {
         self.h2_builder.max_local_error_reset_streams = max.into();
         self
     }


### PR DESCRIPTION
This PR fixes an inconsistency with the HTTP/2 builder, which I assume was unintentional. This is a breaking change. Hopefully it counts as acceptable breakage.

I searched and only found one public, non-fork user of `max_local_error_reset_streams` on GitHub (https://github.com/IGrok2/monorepo/blob/955a9b9bbed159b99637cf7576482af831acac7d/src/opnieuw/src/main.rs#L380-L388) and I think this PR wouldn't even break it.