### PR TITLE
misc: mark `Body::channel()` as deprecated in 0.14

### DIFF
--- a/src/body/body.rs
+++ b/src/body/body.rs
@@ -137,6 +137,13 @@ impl Body {
     ///
     /// Useful when wanting to stream chunks from another thread.
     #[inline]
+    #[cfg_attr(
+        feature = "deprecated",
+        deprecated(
+            note = "This function has been removed. Wrap `tokio::sync::mspc::Receiver<T>` in a `StreamBody` instead."
+        )
+    )]
+    #[cfg_attr(feature = "deprecated", allow(deprecated))]
     pub fn channel() -> (Sender, Body) {
         Self::new_channel(DecodedLength::CHUNKED, /*wanter =*/ false)
     }


### PR DESCRIPTION
this commit marks `Body::channel()` as deprecated in the 0.14 release.

#2970 (_see #2962_) made this interface private, and hyper 1.0 no longer includes this function. instead, users should wrap an `mpsc::Receiver<T>` in a `StreamBody`. this should help users migrating from hyper 0.14 to 1.0, by indicating that this interface is affected by the breaking changes in hyper 1.0, and indicating a suitable upgrade path.