### PR TITLE
feat(server): Universal h1 header read timeout.

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -1123,6 +1123,14 @@ impl State {
         if !T::should_read_first() {
             self.notify_read = true;
         }
+
+        #[cfg(feature = "server")]
+        if self.h1_header_read_timeout.is_some() {
+            // Next read will start and poll the header read timeout,
+            // so we can close the connection if another header isn't
+            // received in a timely manner.
+            self.notify_read = true;
+        }
     }
 
     fn is_idle(&self) -> bool {


### PR DESCRIPTION
## Motivation

Currently, the header read timeout is started before any part of the first request is received. This allows closing the connection if no requests are received. However, after the first request, the connection can remain open indefinitely. This change ensures that the header read timeout is started immediately after the connection is idle, following the transmission of the response, before the first part of each subsequent request is received.

This is particularly relevant in the case that browsers open 6+ h1 connections when a page loads and then neglect to close any of them, distracting, in my case, from DDoS attackers.

This is like an "idle timeout"

## Changes
- [x] Start `header_read_timeout` when waiting for subsequent requests
- [ ] Test this functionality, while fixing existing tests (like #3743 did)

## Related

Related: #1628
Related: #2355
Supersedes #3743 (this PR required additional complexity, but allowed a different value for the header read timeout and the idle timeout)