### PR TITLE
chore(ci): use yq to get rust-version in manifest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Get MSRV from package metadata
         id: msrv
-        run: grep rust-version Cargo.toml | cut -d'"' -f2 | sed 's/^/version=/' >> $GITHUB_OUTPUT
+        run: echo "version=$(yq '.package.rust-version' Cargo.toml)" >> $GITHUB_OUTPUT
 
       - name: Install Rust (${{ steps.msrv.outputs.version }})
         uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
`yq` can be used to get values from TOML file.