### PR TITLE
feat(http1): support request body limit

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -70,6 +70,12 @@ pub(super) enum Kind {
         any(feature = "http1", feature = "http2")
     ))]
     Body,
+    /// Error when body is too large
+    #[cfg(all(
+        any(feature = "client", feature = "server"),
+        any(feature = "http1", feature = "http2")
+    ))]
+    BodyTooLarge,
     /// Error while writing a body to connection.
     #[cfg(all(
         any(feature = "client", feature = "server"),
@@ -333,6 +339,14 @@ impl Error {
         any(feature = "client", feature = "server"),
         any(feature = "http1", feature = "http2")
     ))]
+    pub(super) fn new_body_too_large() -> Error {
+        Error::new(Kind::BodyTooLarge)
+    }
+
+    #[cfg(all(
+        any(feature = "client", feature = "server"),
+        any(feature = "http1", feature = "http2")
+    ))]
     pub(super) fn new_body_write<E: Into<Cause>>(cause: E) -> Error {
         Error::new(Kind::BodyWrite).with(cause)
     }
@@ -508,6 +522,7 @@ impl Error {
             Kind::User(User::DispatchGone) => "dispatch task is gone",
             #[cfg(feature = "ffi")]
             Kind::User(User::AbortedByCallback) => "operation aborted by an application callback",
+            Kind::BodyTooLarge => "body larger than the limit",
         }
     }
 }

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -214,6 +214,7 @@ where
                             continue;
                         }
                     }
+
                     match self.conn.poll_read_body(cx) {
                         Poll::Ready(Some(Ok(frame))) => {
                             if frame.is_data() {

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -469,6 +469,7 @@ impl Http1Transaction for Server {
             | Kind::Parse(Parse::Version) => StatusCode::BAD_REQUEST,
             Kind::Parse(Parse::TooLarge) => StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
             Kind::Parse(Parse::UriTooLong) => StatusCode::URI_TOO_LONG,
+            Kind::BodyTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
             _ => return None,
         };
 

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -76,6 +76,7 @@ pub struct Builder {
     h1_title_case_headers: bool,
     h1_preserve_header_case: bool,
     h1_max_headers: Option<usize>,
+    h1_max_body: Option<usize>,
     h1_header_read_timeout: Dur,
     h1_writev: Option<bool>,
     max_buf_size: Option<usize>,
@@ -239,6 +240,7 @@ impl Builder {
             h1_title_case_headers: false,
             h1_preserve_header_case: false,
             h1_max_headers: None,
+            h1_max_body: None,
             h1_header_read_timeout: Dur::Default(Some(Duration::from_secs(30))),
             h1_writev: None,
             max_buf_size: None,
@@ -320,6 +322,15 @@ impl Builder {
     /// Default is 100.
     pub fn max_headers(&mut self, val: usize) -> &mut Self {
         self.h1_max_headers = Some(val);
+        self
+    }
+
+    /// Set the maximum size of body.
+    ///
+    /// If server receives bigger body than the max size, it responds to the client with
+    /// "413 Payload Too Large".
+    pub fn max_body(&mut self, val: usize) -> &mut Self {
+        self.h1_max_body = Some(val);
         self
     }
 
@@ -457,6 +468,9 @@ impl Builder {
         }
         if let Some(max_headers) = self.h1_max_headers {
             conn.set_http1_max_headers(max_headers);
+        }
+        if let Some(max_body) = self.h1_max_body {
+            conn.set_http1_max_body(max_body);
         }
         if let Some(dur) = self
             .timer


### PR DESCRIPTION
I propose the ability to limit the size of the request body.

This could be implemented at the application level as well, but I think it would be more efficient to handle it at the hyper implementation level.