### PR TITLE
export Incoming::empty

### DIFF
--- a/src/body/incoming.rs
+++ b/src/body/incoming.rs
@@ -139,8 +139,8 @@ impl Incoming {
         Incoming { kind }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn empty() -> Incoming {
+    /// Create an empty `Body`.
+    pub fn empty() -> Incoming {
         Incoming::new(Kind::Empty)
     }
 


### PR DESCRIPTION
Change the existing `Incoming::empty` function from `pub(crate)` to `pub. 
Previously, it was almost impossible to create an Incoming object outside of hyper. 
 
If you can use this function, it may be of some help when writing common code. 
(At least in my case. It's a bit of an exception.)

This is a bit minor, but I think it has to do with API design direction. 

What do you think about this?