### PR TITLE
feat: add Error::is_shutdown()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -238,6 +238,15 @@ impl Error {
         matches!(self.inner.kind, Kind::User(User::BodyWriteAborted))
     }
 
+    /// Returns true if the error was caused while calling `AsyncWrite::shutdown()`.
+    pub fn is_shutdown(&self) -> bool {
+        #[cfg(all(feature = "http1", any(feature = "client", feature = "server")))]
+        if matches!(self.inner.kind, Kind::Shutdown) {
+            return true;
+        }
+        false
+    }
+
     /// Returns true if the error was caused by a timeout.
     pub fn is_timeout(&self) -> bool {
         #[cfg(all(feature = "http1", feature = "server"))]


### PR DESCRIPTION
Benchmarking tools often cause connections to be ungracefully shutdown.
This makes it possible to filter these errors out.

Replaces #2745
