### PR TITLE
chore(proto/h2): fix module-level documentation

### DIFF
--- a/src/proto/h2/ping.rs
+++ b/src/proto/h2/ping.rs
@@ -1,23 +1,24 @@
-/// HTTP2 Ping usage
-///
-/// hyper uses HTTP2 pings for two purposes:
-///
-/// 1. Adaptive flow control using BDP
-/// 2. Connection keep-alive
-///
-/// Both cases are optional.
-///
-/// # BDP Algorithm
-///
-/// 1. When receiving a DATA frame, if a BDP ping isn't outstanding:
-///    1a. Record current time.
-///    1b. Send a BDP ping.
-/// 2. Increment the number of received bytes.
-/// 3. When the BDP ping ack is received:
-///    3a. Record duration from sent time.
-///    3b. Merge RTT with a running average.
-///    3c. Calculate bdp as bytes/rtt.
-///    3d. If bdp is over 2/3 max, set new max to bdp and update windows.
+//! HTTP2 Ping usage
+//!
+//! hyper uses HTTP2 pings for two purposes:
+//!
+//! 1. Adaptive flow control using BDP
+//! 2. Connection keep-alive
+//!
+//! Both cases are optional.
+//!
+//! # BDP Algorithm
+//!
+//! 1. When receiving a DATA frame, if a BDP ping isn't outstanding:
+//!    1a. Record current time.
+//!    1b. Send a BDP ping.
+//! 2. Increment the number of received bytes.
+//! 3. When the BDP ping ack is received:
+//!    3a. Record duration from sent time.
+//!    3b. Merge RTT with a running average.
+//!    3c. Calculate bdp as bytes/rtt.
+//!    3d. If bdp is over 2/3 max, set new max to bdp and update windows.
+
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;


### PR DESCRIPTION
`proto::h2::ping` has some documentation that won't be rendered properly, because it is written as documentation of an item rather than documenting the enclosing submodule.

this commit updates this comment, using `//!` notation.

