### PR TITLE
feat(client): `TrySendError<T>` is `From<Error>`

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -310,6 +310,15 @@ impl<T> TrySendError<T> {
     }
 }
 
+impl<T> From<crate::Error> for TrySendError<T> {
+    fn from(error: crate::Error) -> Self {
+        Self {
+            error,
+            message: None,
+        }
+    }
+}
+
 #[cfg(feature = "http2")]
 pin_project! {
     pub struct SendWhen<B>


### PR DESCRIPTION
this commit introduces a new trait implementation for `hyper::client::conn::TrySendError<T>`.

this commit allows a `TrySendError<T>` to be constructed `From` a conventional `hyper::Error`.

one example of a motivating use case for this change is that this is needed in order to use interfaces like
`hyper::client::conn::http2::SendRequest::try_send_request()` or `hyper::client::conn::http1::SendRequest::try_send_request()` in the context of tower middleware; the `Service<T>` trait's signature is such that the same error type be returned from `Service::poll_ready()` and `Service::call()`.

thus, the `?` operator can construct a `TrySendError<T>` from errors possibly returned by
`hyper::client::conn::http2::SendRequest::poll_ready()` or `hyper::client::conn::http1::SendRequest::poll_ready()`, within a `Service<T>` that eventually calls `try_send_request()` in the context of `Service::call()`.

---

see:

* #3691
* https://docs.rs/hyper/latest/hyper/client/conn/struct.TrySendError.html
* https://docs.rs/hyper/latest/hyper/struct.Error.html
* https://docs.rs/hyper/latest/hyper/client/conn/http2/struct.SendRequest.html#method.try_send_request
* https://docs.rs/tower/latest/tower/trait.Service.html#associatedtype.Error
* https://docs.rs/hyper/latest/hyper/client/conn/http1/struct.SendRequest.html#method.poll_ready
* https://docs.rs/hyper/latest/hyper/client/conn/http2/struct.SendRequest.html#method.poll_ready

