### PR TITLE
feat(client): add a `TrySendError::message()` method

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -304,6 +304,15 @@ impl<T> TrySendError<T> {
         self.message.take()
     }
 
+    /// Returns a reference to the recovered message.
+    ///
+    /// The message will not always have been recovered. If an error occurs
+    /// after the message has been serialized onto the connection, it will not
+    /// be available here.
+    pub fn message(&self) -> Option<&T> {
+        self.message.as_ref()
+    }
+
     /// Consumes this to return the inner error.
     pub fn into_error(self) -> crate::Error {
         self.error


### PR DESCRIPTION
this commit introduces a new inherent method to
`hyper::client::conn::TrySendError<T>`.

this error type includes a `TrySendError::take_message()` method today that will return an owned instance of the inbound message, should the underlying dispatch have been closed before serialization of the message ever began.

this commit introduces a new method that allows callers to inspect the message, e.g. to update metrics, without needing to take ownership of the message.

