### PR TITLE
feat(client): add a `TrySendError::error()` method

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -317,6 +317,11 @@ impl<T> TrySendError<T> {
     pub fn into_error(self) -> crate::Error {
         self.error
     }
+
+    /// Returns a reference to the inner error.
+    pub fn error(&self) -> &crate::Error {
+        &self.error
+    }
 }
 
 #[cfg(feature = "http2")]


### PR DESCRIPTION
this commit introduces a new inherent method to
`hyper::client::conn::TrySendError<T>`.

this error type includes a `TrySendError::into_error()` method today that will consume the `TrySendError<T>`, returning the inner error. this commit introduces a new method that allows callers to inspect the error, e.g. to update metrics, without needing to consume the error.

this is akin to #3884, which added the `TrySendError::message()` method that returns a reference to the `T`-typed message when applicable.

