### PR TITLE
fix(http2): add decriptive error for non-zero connect request

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -132,7 +132,7 @@ pub(super) enum User {
     ))]
     BodyWriteAborted,
     /// User tried to send a connect request with a nonzero body
-    #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
+    #[cfg(all(feature = "client", feature = "http2"))]
     InvalidConnectWithBody,
     /// Error from future of user's Service.
     #[cfg(any(
@@ -398,7 +398,7 @@ impl Error {
         Error::new_user(User::Body).with(cause)
     }
 
-    #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
+    #[cfg(all(feature = "client", feature = "http2"))]
     pub(super) fn new_user_invalid_connect() -> Error {
         Error::new_user(User::InvalidConnectWithBody)
     }
@@ -500,7 +500,7 @@ impl Error {
                 feature = "ffi"
             ))]
             Kind::User(User::BodyWriteAborted) => "user body write aborted",
-            #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
+            #[cfg(all(feature = "client", feature = "http2"))]
             Kind::User(User::InvalidConnectWithBody) => {
                 "user sent CONNECT request with non-zero body"
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -511,7 +511,7 @@ impl Error {
                 any(feature = "client", feature = "server"),
                 feature = "http2"
             ))]
-            Kind::User(User::InvalidConnectWithBody) => " user sent connect request with non-zero body via HTTP/2",
+            Kind::User(User::InvalidConnectWithBody) => "user sent CONNECT request with non-zero body",
             Kind::User(User::Service) => "error from user's Service",
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "server")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -131,6 +131,12 @@ pub(super) enum User {
         feature = "ffi"
     ))]
     BodyWriteAborted,
+    /// User tried to send a connect request with a nonzero body
+    #[cfg(all(
+        any(feature = "client", feature = "server"),
+        feature = "http2"
+    ))]
+    InvalidConnectWithBody,
     /// Error from future of user's Service.
     #[cfg(any(
         all(any(feature = "client", feature = "server"), feature = "http1"),
@@ -395,6 +401,11 @@ impl Error {
         Error::new_user(User::Body).with(cause)
     }
 
+    #[cfg(all( any(feature = "client", feature = "server"), feature = "http2"))]
+    pub(super) fn new_user_invalid_connect() -> Error {
+        Error::new_user(User::InvalidConnectWithBody)
+    }
+
     #[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
     pub(super) fn new_shutdown(cause: std::io::Error) -> Error {
         Error::new(Kind::Shutdown).with(cause)
@@ -496,6 +507,11 @@ impl Error {
                 all(any(feature = "client", feature = "server"), feature = "http1"),
                 all(feature = "server", feature = "http2")
             ))]
+            #[cfg(all(
+                any(feature = "client", feature = "server"),
+                feature = "http2"
+            ))]
+            Kind::User(User::InvalidConnectWithBody) => " user sent connect request with non-zero body via HTTP/2",
             Kind::User(User::Service) => "error from user's Service",
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "server")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -132,10 +132,7 @@ pub(super) enum User {
     ))]
     BodyWriteAborted,
     /// User tried to send a connect request with a nonzero body
-    #[cfg(all(
-        any(feature = "client", feature = "server"),
-        feature = "http2"
-    ))]
+    #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
     InvalidConnectWithBody,
     /// Error from future of user's Service.
     #[cfg(any(
@@ -401,7 +398,7 @@ impl Error {
         Error::new_user(User::Body).with(cause)
     }
 
-    #[cfg(all( any(feature = "client", feature = "server"), feature = "http2"))]
+    #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
     pub(super) fn new_user_invalid_connect() -> Error {
         Error::new_user(User::InvalidConnectWithBody)
     }
@@ -507,11 +504,10 @@ impl Error {
                 all(any(feature = "client", feature = "server"), feature = "http1"),
                 all(feature = "server", feature = "http2")
             ))]
-            #[cfg(all(
-                any(feature = "client", feature = "server"),
-                feature = "http2"
-            ))]
-            Kind::User(User::InvalidConnectWithBody) => "user sent CONNECT request with non-zero body",
+            #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
+            Kind::User(User::InvalidConnectWithBody) => {
+                "user sent CONNECT request with non-zero body"
+            }
             Kind::User(User::Service) => "error from user's Service",
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "server")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -500,14 +500,14 @@ impl Error {
                 feature = "ffi"
             ))]
             Kind::User(User::BodyWriteAborted) => "user body write aborted",
-            #[cfg(any(
-                all(any(feature = "client", feature = "server"), feature = "http1"),
-                all(feature = "server", feature = "http2")
-            ))]
             #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
             Kind::User(User::InvalidConnectWithBody) => {
                 "user sent CONNECT request with non-zero body"
             }
+            #[cfg(any(
+                all(any(feature = "client", feature = "server"), feature = "http1"),
+                all(feature = "server", feature = "http2")
+            ))]
             Kind::User(User::Service) => "error from user's Service",
             #[cfg(any(feature = "http1", feature = "http2"))]
             #[cfg(feature = "server")]

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -676,7 +676,7 @@ where
                         debug!("h2 connect request with non-zero body not supported");
                         cb.send(Err(TrySendError {
                             error: crate::Error::new_user_invalid_connect(),
-                            message: None
+                            message: None,
                         }));
                         continue;
                     }

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -673,10 +673,10 @@ where
                         && headers::content_length_parse_all(req.headers())
                             .map_or(false, |len| len != 0)
                     {
-                        warn!("h2 connect request with non-zero body not supported");
+                        debug!("h2 connect request with non-zero body not supported");
                         cb.send(Err(TrySendError {
-                            error: crate::Error::new_h2(h2::Reason::INTERNAL_ERROR.into()),
-                            message: None,
+                            error: crate::Error::new_user_invalid_connect(),
+                            message: None
                         }));
                         continue;
                     }


### PR DESCRIPTION
fixes #3858 : add error type for http/2 connect requests with non-zero body.


