### PR TITLE
fix(date): improve caching accuracy

### DIFF
--- a/src/common/date.rs
+++ b/src/common/date.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::fmt::{self, Write};
 use std::str;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[cfg(feature = "http2")]
 use http::header::HeaderValue;
@@ -68,8 +68,13 @@ impl CachedDate {
     }
 
     fn update(&mut self, now: SystemTime) {
+        let nanos = now
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos();
+
         self.render(now);
-        self.next_update = now + Duration::new(1, 0);
+        self.next_update = now + Duration::new(1, 0) - Duration::from_nanos(nanos as u64);
     }
 
     fn render(&mut self, now: SystemTime) {


### PR DESCRIPTION
`CachedDate` gets updated every second, but the current logic doesn't take into account milliseconds and nanoseconds - if the application starts at `12:00:00.600`, hyper will report `date: ...T120000` up until `12:00:01.600`, which is overzealous.

We can sidestep this by subtracting the nanoseconds part (which includes milliseconds) from the time passed to `CachedDate::update()`, essentially rounding `self.next_update` to the beginning of the next closest second.
