### PR TITLE
feat(client/dispatch): `try_poll_ready()` methods

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -323,6 +323,36 @@ impl<T> TrySendError<T> {
     }
 }
 
+impl<B> crate::client::conn::http1::SendRequest<B> {
+    /// Polls to determine whether this sender can be used yet for a request.
+    ///
+    /// If the associated connection is closed, this returns a [`TrySendError<T>`].
+    pub fn try_poll_ready(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), TrySendError<Request<B>>>> {
+        self.poll_ready(cx).map_err(|error| TrySendError {
+            error,
+            message: None,
+        })
+    }
+}
+
+impl<B> crate::client::conn::http2::SendRequest<B> {
+    /// Polls to determine whether this sender can be used yet for a request.
+    ///
+    /// If the associated connection is closed, this returns a [`TrySendError<T>`].
+    pub fn try_poll_ready(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), TrySendError<Request<B>>>> {
+        self.poll_ready(cx).map_err(|error| TrySendError {
+            error,
+            message: None,
+        })
+    }
+}
+
 #[cfg(feature = "http2")]
 pin_project! {
     pub struct SendWhen<B>


### PR DESCRIPTION
this change is motivated by aiming to use interfaces like `hyper::client::conn::http2::SendRequest::try_send_request()` or `hyper::client::conn::http1::SendRequest::try_send_request()` in the context of tower middleware; the `Service<T>` trait's signature is such that the same error type be returned from `Service::poll_ready()` and `Service::call()`.

this means that services that might resolve to a recovered message may call `try_poll_ready` when polling for readiness.

this avoids making `TrySendError<T>` constructable externally, see #3883 as an alternate approach that was considered.

