### PR TITLE
refactor(upgrade): explicitly specify type parameter in downcast method

### DIFF
--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -150,7 +150,7 @@ impl Upgraded {
     /// `Upgraded` back.
     pub fn downcast<T: Read + Write + Unpin + 'static>(self) -> Result<Parts<T>, Self> {
         let (io, buf) = self.io.into_inner();
-        match io.__hyper_downcast() {
+        match io.__hyper_downcast::<T>() {
             Ok(t) => Ok(Parts {
                 io: *t,
                 read_buf: buf,


### PR DESCRIPTION
Make the type parameter passing more explicit by changing
`io.__hyper_downcast()` to `io.__hyper_downcast::<T>()` in the
downcast method. This improves code clarity and avoids potential
type inference ambiguities in multi-generic scenarios.