### PR TITLE
feat(client/dispatch): `TrySendError<T>: std::error::Error`

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -1,3 +1,5 @@
+use std::error::Error as StdError;
+use std::fmt;
 use std::task::{Context, Poll};
 #[cfg(feature = "http2")]
 use std::{future::Future, pin::Pin};
@@ -320,6 +322,22 @@ impl<T> TrySendError<T> {
     /// Returns a reference to the inner error.
     pub fn error(&self) -> &crate::Error {
         &self.error
+    }
+}
+
+impl<T> fmt::Display for TrySendError<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { error, message: _ } = self;
+        write!(f, "{}", error)
+    }
+}
+
+impl<T> StdError for TrySendError<T>
+where
+    T: std::fmt::Debug,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
     }
 }
 


### PR DESCRIPTION
this commit introduces a `std::error::Error` implementation for `hyper::client::conn::TrySendError`.

this allows callers of
`hyper::client::conn::http2::SendRequest::try_send_request()` or `hyper::client::conn::http1::SendRequest::try_send_request()` to box a `TrySendError<T>` without discarding a potentially recovered message.

a `std::fmt::Display` implementation is added in this commit, because it is a prerequisite for implementations of `std::error::Error`.

for some previous discussion on this topic, see "_other options_" here: https://github.com/hyperium/hyper/pull/3883#issuecomment-2860212062.

see also:
* https://github.com/hyperium/hyper/pull/3883
* https://github.com/hyperium/hyper/pull/3892

