### PR TITLE
Introduce QUIC traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,8 @@ nightly = []
 level = "warn"
 check-cfg = [
     'cfg(hyper_unstable_tracing)',
-    'cfg(hyper_unstable_ffi)'
+    'cfg(hyper_unstable_ffi)',
+    'cfg(hyper_unstable_quic)',
 ]
 
 [lints.clippy]

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -17,6 +17,10 @@ pub mod bounds;
 mod io;
 mod timer;
 
+#[cfg(hyper_unstable_quic)]
+#[cfg_attr(docsrs, doc(cfg(hyper_unstable_quic)))]
+pub mod quic;
+
 pub use self::io::{Read, ReadBuf, ReadBufCursor, Write};
 pub use self::timer::{Sleep, Timer};
 

--- a/src/rt/quic.rs
+++ b/src/rt/quic.rs
@@ -1,0 +1,91 @@
+//! Generic QUIC support
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::Buf;
+
+// TODO: Should this be gated by an `http3` feature?
+
+/// A QUIC connection.
+pub trait Connection<B> {
+    /// Send streams that can be opened by this connection.
+    type SendStream: SendStream<B>;
+    /// Receive streams that can be accepted by this connection.
+    type RecvStream: RecvStream;
+    /// Bidirectional streams that can be opened or accepted by this connection.
+    type BidiStream: SendStream<B> + RecvStream;
+    /// Errors that may occur opening or accepting streams.
+    type Error;
+
+    // Accepting streams
+
+    // Q: shorten to bidi?
+    /// Accept a bidirection stream.
+    fn poll_accept_bidirectional_stream(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<Self::BidiStream>, Self::Error>>;
+
+    /// Accept a unidirectional receive stream.
+    fn poll_accept_recv_stream(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<Self::RecvStream>, Self::Error>>;
+
+    // Creating streams
+
+    // Q: shorten to bidi?
+    /// Open a bidirectional stream.
+    fn poll_open_bidirectional_stream(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Self::BidiStream, Self::Error>>;
+
+    /// Open a unidirectional send stream.
+    fn poll_open_send_stream(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Self::SendStream, Self::Error>>;
+}
+
+/// The send portion of a QUIC stream.
+pub trait SendStream<B> {
+    /// Errors that may happen trying to send data.
+    type Error; // bounds?
+    /// Polls that the stream is ready to send more data.
+    // Q: Should this be Pin<&mut Self>?
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+    /// Send data on the stream.
+    fn send_data(&mut self, data: B) -> Result<(), Self::Error>;
+    // fn poll_flush?
+    /// finish?
+    fn poll_finish(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+    /// Close the stream with an error code.
+    fn reset(&mut self, reset_code: u64);
+}
+
+/// The receive portion of a QUIC stream.
+pub trait RecvStream {
+    /// Buffers of data that can be received.
+    type Buf: Buf;
+    /// Errors that may be received.
+    type Error; // bounds?
+
+    // Q: should this be Pin?
+    /// Poll for more data received from the remote on this stream.
+    fn poll_data(&mut self, cx: &mut Context<'_>) -> Poll<Result<Option<Self::Buf>, Self::Error>>;
+    /// Signal to the remote peer to stop sending data.
+    fn stop_sending(&mut self, error_code: u64);
+}
+
+/// An optional trait if a QUIC stream can be split into two sides.
+pub trait BidiStream<B>: SendStream<B> + RecvStream {
+    /// The send side of a stream.
+    type SendStream: SendStream<B>;
+    /// The receive side of a stream.
+    type RecvStream: RecvStream;
+
+    /// Split this stream into two sides.
+    fn split(self) -> (Self::SendStream, Self::RecvStream);
+}


### PR DESCRIPTION
This adds initial support for QUIC to hyper, a prerequisite for HTTP/3 support.

This adds a new module, `hyper::rt::quic`, and new traits which largely match what was [originally proposed for the h3 crate](https://github.com/hyperium/h3/blob/master/docs/PROPOSAL.md). The idea is similar to the other transport traits in `hyper::rt`, which is that a user can describe to hyper how their QUIC implementation works, and then hyper will be able to use that for HTTP/3.

While the `h3` crate has drifted some from the original proposal, I wasn't sure the additional complexity that had been added was necessary to expose at the hyper level. If during the implementation process it proves we do need it, we can make the change.

These traits are put behind a `cfg(hyper_unstable_quic)` flag, until they are stabilized.

This should likely stay as a PR proposal until a separate PR is ready to merge that integrates these traits with HTTP/3 glue in `hyper::proto::h3`.

**Please keep comments to implementation details.**

cc #1818 