### PR TITLE
WIP: Add HTTP/3 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ futures-channel = { version = "0.3", optional = true }
 futures-core = { version = "0.3.31", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 h2 = { version = "0.4.14", optional = true }
+h3 = { version = "0.0.8", optional = true }
 http-body-util = { version = "0.1", optional = true }
 httparse = { version = "1.9", optional = true }
 httpdate = { version = "1.0", optional = true }
@@ -70,7 +71,7 @@ tokio-util = "0.7.10"
 
 [features]
 # Nothing by default
-default = []
+default = ["http3", "server"]
 
 # Easily turn it all on
 full = [
@@ -83,6 +84,7 @@ full = [
 # HTTP versions
 http1 = ["dep:atomic-waker", "dep:futures-channel", "dep:futures-core", "dep:httparse", "dep:itoa"]
 http2 = ["dep:futures-channel", "dep:futures-core", "dep:h2"]
+http3 = ["dep:h3"]
 
 # Client/Server
 client = ["dep:want", "dep:pin-project-lite", "dep:smallvec"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ futures-channel = { version = "0.3", optional = true }
 futures-core = { version = "0.3.31", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 h2 = { version = "0.4.14", optional = true }
+h3 = { version = "0.0.8", optional = true }
 http-body-util = { version = "0.1", optional = true }
 httparse = { version = "1.9", optional = true }
 httpdate = { version = "1.0", optional = true }
@@ -70,7 +71,7 @@ tokio-util = "0.7.10"
 
 [features]
 # Nothing by default
-default = []
+default = ["http3", "server"]
 
 # Easily turn it all on
 full = [
@@ -83,6 +84,7 @@ full = [
 # HTTP versions
 http1 = ["dep:atomic-waker", "dep:futures-channel", "dep:futures-core", "dep:httparse", "dep:itoa"]
 http2 = ["dep:atomic-waker", "dep:futures-channel", "dep:futures-core", "dep:h2"]
+http3 = ["dep:h3"]
 
 # Client/Server
 client = ["dep:want", "dep:pin-project-lite", "dep:smallvec"]

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -15,7 +15,7 @@ macro_rules! cfg_proto {
     ($($item:item)*) => {
         cfg_feature! {
             #![all(
-                any(feature = "http1", feature = "http2"),
+                any(feature = "http1", feature = "http2", feature = "http3"),
                 any(feature = "client", feature = "server"),
             )]
             $($item)*

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod either;
 #[cfg(any(
     all(feature = "client", any(feature = "http1", feature = "http2")),
     all(feature = "server", feature = "http1"),
+    all(feature = "server", feature = "http3"),
 ))]
 pub(crate) mod future;
 pub(crate) mod io;

--- a/src/proto/h3/glue.rs
+++ b/src/proto/h3/glue.rs
@@ -1,0 +1,165 @@
+use std::task::{Context, Poll};
+
+use bytes::Buf;
+
+pub(super) struct Conn<Q>(Q);
+
+pub(super) struct BidiStream<S>(S);
+pub(super) struct SendStream<S>(S);
+pub(super) struct RecvStream<S>(S);
+
+impl<Q, B> h3::quic::Connection<B> for Conn<Q>
+where
+    Q: crate::rt::quic::Connection<B>,
+    B: Buf,
+{
+    type RecvStream = RecvStream<Q::RecvStream>;
+    type OpenStreams = Self;
+
+    fn poll_accept_recv(&mut self, _cx: &mut Context<'_>)
+        -> Poll<Result<Self::RecvStream, h3::quic::ConnectionErrorIncoming>>
+    {
+        todo!();
+    }
+
+    fn poll_accept_bidi(&mut self, _cx: &mut Context<'_>)
+        -> Poll<Result<Self::BidiStream, h3::quic::ConnectionErrorIncoming>>
+    {
+        todo!();
+    }
+
+    fn opener(&self) -> Self::OpenStreams {
+        todo!();
+    }
+}
+
+impl<Q, B> h3::quic::OpenStreams<B> for Conn<Q>
+where
+    Q: crate::rt::quic::Connection<B>,
+    B: Buf,
+{
+    type BidiStream = BidiStream<Q::BidiStream>;
+    type SendStream = SendStream<Q::SendStream>;
+
+    fn poll_open_send(&mut self, _cx: &mut Context<'_>)
+        -> Poll<Result<Self::SendStream, h3::quic::StreamErrorIncoming>>
+    {
+        todo!();
+    }
+
+    fn poll_open_bidi(&mut self, _cx: &mut Context<'_>)
+        -> Poll<Result<Self::BidiStream, h3::quic::StreamErrorIncoming>>
+    {
+        todo!();
+    }
+
+    fn close(&mut self, _: h3::error::Code, _: &[u8]) {
+
+    }
+}
+
+impl<S, B> h3::quic::SendStream<B> for BidiStream<S>
+where
+    S: crate::rt::quic::SendStream<B>,
+    B: Buf,
+{
+    // Required methods
+    fn poll_ready(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), h3::quic::StreamErrorIncoming>> {
+        todo!();
+    }
+    fn send_data<T: Into<h3::quic::WriteBuf<B>>>(
+        &mut self,
+        data: T,
+    ) -> Result<(), h3::quic::StreamErrorIncoming> {
+        todo!();
+    }
+    fn poll_finish(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), h3::quic::StreamErrorIncoming>> {
+        todo!();
+    }
+    fn reset(&mut self, reset_code: u64) {
+        todo!();
+    }
+    fn send_id(&self) -> h3::quic::StreamId {
+        todo!()
+    }
+}
+
+impl<S, B> h3::quic::SendStream<B> for SendStream<S>
+where
+    S: crate::rt::quic::SendStream<B>,
+    B: Buf,
+{
+    // Required methods
+    fn poll_ready(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), h3::quic::StreamErrorIncoming>> {
+        todo!();
+    }
+    fn send_data<T: Into<h3::quic::WriteBuf<B>>>(
+        &mut self,
+        data: T,
+    ) -> Result<(), h3::quic::StreamErrorIncoming> {
+        todo!();
+    }
+    fn poll_finish(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), h3::quic::StreamErrorIncoming>> {
+        todo!();
+    }
+    fn reset(&mut self, reset_code: u64) {
+        todo!();
+    }
+    fn send_id(&self) -> h3::quic::StreamId {
+        todo!()
+    }
+}
+
+impl<S> h3::quic::RecvStream for BidiStream<S>
+where
+    S: crate::rt::quic::RecvStream,
+{
+    type Buf = S::Buf;
+
+    // Required methods
+    fn poll_data(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<Self::Buf>, h3::quic::StreamErrorIncoming>> {
+        todo!();
+    }
+    fn stop_sending(&mut self, error_code: u64) {
+        todo!();
+    }
+    fn recv_id(&self) -> h3::quic::StreamId {
+        todo!();
+    }
+}
+
+impl<S> h3::quic::RecvStream for RecvStream<S>
+where
+    S: crate::rt::quic::RecvStream,
+{
+    type Buf = S::Buf;
+
+    // Required methods
+    fn poll_data(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<Self::Buf>, h3::quic::StreamErrorIncoming>> {
+        todo!();
+    }
+    fn stop_sending(&mut self, error_code: u64) {
+        todo!();
+    }
+    fn recv_id(&self) -> h3::quic::StreamId {
+        todo!();
+    }
+}

--- a/src/proto/h3/mod.rs
+++ b/src/proto/h3/mod.rs
@@ -1,0 +1,34 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::Buf;
+use h3::server::Connection;
+
+use pin_project_lite::pin_project;
+
+mod glue;
+
+pin_project! {
+    pub(crate) struct Server<Q, S, B, E>
+    where
+        Q: crate::rt::quic::Connection<B>,
+        B: Buf,
+    {
+        exec: E,
+        q: Connection<glue::Conn<Q>, B>,
+        s: S,
+    }
+}
+
+impl<Q, S, B, E> Future for Server<Q, S, B, E>
+where
+    Q: crate::rt::quic::Connection<B>,
+    B: Buf,
+{
+    type Output = crate::Result<()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        todo!()
+    }
+}

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -16,6 +16,9 @@ cfg_feature! {
 #[cfg(feature = "http2")]
 pub(crate) mod h2;
 
+#[cfg(feature = "http3")]
+pub(crate) mod h3;
+
 /// An Incoming Message head. Includes request/status line, and headers.
 #[cfg(feature = "http1")]
 #[derive(Debug, Default)]

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -17,7 +17,7 @@ pub mod bounds;
 mod io;
 mod timer;
 
-#[cfg(hyper_unstable_quic)]
+//#[cfg(hyper_unstable_quic)]
 #[cfg_attr(docsrs, doc(cfg(hyper_unstable_quic)))]
 pub mod quic;
 

--- a/src/server/conn/http3.rs
+++ b/src/server/conn/http3.rs
@@ -1,0 +1,58 @@
+//! HTTP/3 Server Connections
+
+use std::error::Error as StdError;
+
+use pin_project_lite::pin_project;
+
+use crate::body::{Body, Incoming as IncomingBody};
+use crate::rt::quic;
+use crate::service::HttpService;
+
+pin_project! {
+    /// A Future representing an HTTP/3 connection.
+    #[must_use = "futures do nothing unless polled"]
+    pub struct Connection<Q, S, E> {
+        _i: (Q, S, E),
+    }
+}
+
+/// A configuration builder for HTTP/3 server connections.
+///
+/// **Note**: The default values of options are *not considered stable*. They
+/// are subject to change at any time.
+#[derive(Clone, Debug)]
+pub struct Builder<E> {
+    exec: E,
+}
+
+// ===== impl Connection =====
+
+// ===== impl Builder =====
+
+impl<E> Builder<E> {
+    /// Create a new connection builder.
+    pub fn new(exec: E) -> Self {
+        Self {
+            exec,
+        }
+    }
+
+    /// Bind a connection together with a [`Service`](crate::service::Service).
+    ///
+    /// This returns a Future that must be polled in order for HTTP to be
+    /// driven on the connection.
+    pub fn serve_connection<S, Q, Bd>(&self, quic: Q, service: S) -> Connection<Q, S, E>
+    where
+        S: HttpService<IncomingBody, ResBody = Bd>,
+        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        Bd: Body + 'static,
+        Bd::Error: Into<Box<dyn StdError + Send + Sync>>,
+        Q: quic::Connection<Bd>,
+        //E: Http2ServerConnExec<S::Future, Bd>,
+        E: Clone,
+    {
+        Connection {
+            _i: (quic, service, self.exec.clone()),
+        }
+    }
+}

--- a/src/server/conn/mod.rs
+++ b/src/server/conn/mod.rs
@@ -18,3 +18,5 @@
 pub mod http1;
 #[cfg(feature = "http2")]
 pub mod http2;
+//#[cfg(feature = "http3")]
+pub mod http3;


### PR DESCRIPTION
This _starts_ HTTP/3 support, making use of the traits in #3924, and integrating `h3` into `hyper::proto::h3`.

It is not complete or working. I have divided attention, but figured I'd publish what I have working _so far_, in an effort to allow others to add on top of it. I'll keep this as a draft until it's close to working.

To make the diff easier to see, I'm making the target the `quic` branch. **Note to self**: switch it back before merging.

cc #1818 