### PR TITLE
chore(ci): update to cargo-check-external-types-0.3.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -280,12 +280,12 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-05-01 # Compatible version for cargo-check-external-types
+          toolchain: nightly-2025-08-06 # Compatible version for cargo-check-external-types
 
       - name: Install cargo-check-external-types
         uses: taiki-e/cache-cargo-install-action@v2
         with:
-          tool: cargo-check-external-types@0.1.12
+          tool: cargo-check-external-types@0.3.0
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
Update to cargo-check-external-types 0.3.0.