### PR TITLE
feat(http1): add allow_multiple_spaces_in_request_line_delimiters h1 builder config method

### DIFF
--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -276,6 +276,13 @@ impl Builder {
         self
     }
 
+    // Set whether multiple spaces are allowed as delimiters in request lines.
+    pub fn allow_multiple_spaces_in_request_line_delimiters(&mut self, enabled: bool) -> &mut Self {
+        self.h1_parser_config
+            .allow_multiple_spaces_in_request_line_delimiters(enabled);
+        self
+    }
+
     /// Set whether HTTP/1 connections will silently ignored malformed header lines.
     ///
     /// If this is enabled and a header line does not start with a valid header

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -276,7 +276,7 @@ impl Builder {
         self
     }
 
-    // Set whether multiple spaces are allowed as delimiters in request lines.
+    /// Set whether multiple spaces are allowed as delimiters in request lines.
     pub fn allow_multiple_spaces_in_request_line_delimiters(&mut self, enabled: bool) -> &mut Self {
         self.h1_parser_config
             .allow_multiple_spaces_in_request_line_delimiters(enabled);


### PR DESCRIPTION
Adds an `allow_multiple_spaces_in_request_line_delimiters` config method to the http1 server `Builder` as requested in #3923 