### PR TITLE
fix(lib): avoid implicit cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ client = ["dep:want", "dep:pin-project-lite", "dep:smallvec"]
 server = ["dep:httpdate", "dep:pin-project-lite", "dep:smallvec"]
 
 # C-API support (currently unstable (no semver))
-ffi = ["dep:http-body-util", "futures-util"]
+ffi = ["dep:http-body-util", "dep:futures-util"]
 capi = []
 
 # Utilize tracing (currently unstable)


### PR DESCRIPTION
Fix a mistake in commit e11b2ad (PR #3890): use the 'dep:' syntax for futures-util, so that Cargo won't implicitly create a feature called 'futures-util'. Removing features is semver-breaking, but said commit hasn't been in any release yet, so it can still be fixed now.