### PR TITLE
fix(http1): add http10_disable_keep_alive() for server and client

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -1002,6 +1002,21 @@ impl Builder {
         self
     }
 
+    /// Set whether to disable keep alive for HTTP/1.0.
+    ///
+    /// Currently, keep alive for HTTP/1.0 is supported if Connection: keep-alive is set for
+    /// either `Request` or `Response`. If this is enabled, enforcing Connection: close for
+    /// HTTP/1.0 `Request` or `Response` to make sure HTTP/1.0 connection drops and will not be
+    /// put back to H1 connection pool.
+    ///
+    /// Note that this setting does not affect HTTP/2.
+    ///
+    /// Default is false.
+    pub fn http10_disable_keep_alive(&mut self, disable: bool) -> &mut Self {
+        self.conn_builder.http10_disable_keep_alive(disable);
+        self
+    }
+
     // HTTP/1 options
 
     /// Sets the exact size of the read buffer to *always* use.

--- a/src/client/conn.rs
+++ b/src/client/conn.rs
@@ -194,6 +194,7 @@ pub struct Builder {
     h1_max_buf_size: Option<usize>,
     #[cfg(feature = "ffi")]
     h1_headers_raw: bool,
+    h10_disable_keep_alive: bool,
     #[cfg(feature = "http2")]
     h2_builder: proto::h2::client::Config,
     version: Proto,
@@ -605,6 +606,7 @@ impl Builder {
             h1_max_buf_size: None,
             #[cfg(feature = "ffi")]
             h1_headers_raw: false,
+            h10_disable_keep_alive: false,
             #[cfg(feature = "http2")]
             h2_builder: Default::default(),
             #[cfg(feature = "http1")]
@@ -817,6 +819,21 @@ impl Builder {
         self
     }
 
+    /// Set whether to disable keep alive for HTTP/1.0.
+    ///
+    /// Currently, keep alive for HTTP/1.0 is supported if Connection: keep-alive is set for
+    /// either `Request` or `Response`. If this is enabled, enforcing Connection: close for
+    /// HTTP/1.0 `Request` or `Response` to make sure HTTP/1.0 connection drops and will not be
+    /// put back to H1 connection pool.
+    ///
+    /// Note that this setting does not affect HTTP/2.
+    ///
+    /// Default is false.
+    pub fn http10_disable_keep_alive(&mut self, disable: bool) -> &mut Self {
+        self.h10_disable_keep_alive = disable;
+        self
+    }
+
     /// Sets whether HTTP2 is required.
     ///
     /// Default is false.
@@ -1019,6 +1036,7 @@ impl Builder {
                             conn.set_write_strategy_flatten();
                         }
                     }
+                    conn.set_http10_disable_keep_alive(opts.h10_disable_keep_alive);
                     if opts.h1_title_case_headers {
                         conn.set_title_case_headers();
                     }

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -119,6 +119,7 @@ pub struct Builder {
     h1_preserve_header_order: bool,
     h1_read_buf_exact_size: Option<usize>,
     h1_max_buf_size: Option<usize>,
+    h10_disable_keep_alive: bool,
 }
 
 /// Returns a handshake future over some IO.
@@ -305,6 +306,7 @@ impl Builder {
             #[cfg(feature = "ffi")]
             h1_preserve_header_order: false,
             h1_max_buf_size: None,
+            h10_disable_keep_alive: false,
         }
     }
 
@@ -508,6 +510,7 @@ impl Builder {
                     conn.set_write_strategy_flatten();
                 }
             }
+            conn.set_http10_disable_keep_alive(opts.h10_disable_keep_alive);
             if opts.h1_title_case_headers {
                 conn.set_title_case_headers();
             }

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -201,6 +201,7 @@ where
                     #[cfg(feature = "ffi")]
                     preserve_header_order: parse_ctx.preserve_header_order,
                     h09_responses: parse_ctx.h09_responses,
+                    h10_disable_keep_alive: parse_ctx.h10_disable_keep_alive,
                     #[cfg(feature = "ffi")]
                     on_informational: parse_ctx.on_informational,
                     #[cfg(feature = "ffi")]
@@ -755,6 +756,7 @@ mod tests {
                 #[cfg(feature = "ffi")]
                 preserve_header_order: false,
                 h09_responses: false,
+                h10_disable_keep_alive: false,
                 #[cfg(feature = "ffi")]
                 on_informational: &mut None,
                 #[cfg(feature = "ffi")]

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -86,6 +86,7 @@ pub(crate) struct ParseContext<'a> {
     #[cfg(feature = "ffi")]
     preserve_header_order: bool,
     h09_responses: bool,
+    h10_disable_keep_alive: bool,
     #[cfg(feature = "ffi")]
     on_informational: &'a mut Option<crate::ffi::OnInformational>,
     #[cfg(feature = "ffi")]

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -257,6 +257,24 @@ impl<I, E> Builder<I, E> {
         self
     }
 
+    /// Set whether to disable keep alive for HTTP/1.0.
+    ///
+    /// Currently, keep alive for HTTP/1.0 is supported if Connection: keep-alive is set for
+    /// either `Request` or `Response`. If this is enabled, enforcing Connection: close for
+    /// HTTP/1.0 `Request` or `Response` to make sure HTTP/1.0 connection drops and will not be
+    /// put back to H1 connection pool.
+    ///
+    /// Note that this setting does not affect HTTP/2.
+    ///
+    /// Default is false.
+    #[cfg(feature = "http1")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http1")))]
+    pub fn http10_disable_keep_alive(mut self, disable: bool) -> Self {
+        self.protocol.http10_disable_keep_alive(disable);
+        self
+    }
+
+
     /// Set whether HTTP/1 connections should support half-closures.
     ///
     /// Clients can chose to shutdown their write-side while waiting


### PR DESCRIPTION
add http10_disable_keep_alive() for server and client to disable keep_alive connections for HTTP/1.0 requests and response

Server and Client can optionally disable HTTP/1.0 keepalive. If it's set, for http1.0 request and response, connection: keep-alive will be ignored and overridden with connection: close. Connections' state.keepalive is maintained accordingly.

@seanmonstar this is our vendored patch to fix following issues. Do you think if it is appropriate to merge into upstream?
fix #3588 and https://github.com/hyperium/hyper/security/advisories/GHSA-85g5-4q7m-6cgx

