### PR TITLE
refactor(ffi): specify "C" ABI explicitly in ffi_fn! macro

### DIFF
--- a/src/ffi/macros.rs
+++ b/src/ffi/macros.rs
@@ -2,7 +2,7 @@ macro_rules! ffi_fn {
     ($(#[$doc:meta])* fn $name:ident($($arg:ident: $arg_ty:ty),*) -> $ret:ty $body:block ?= $default:expr) => {
         $(#[$doc])*
         #[no_mangle]
-        pub extern fn $name($($arg: $arg_ty),*) -> $ret {
+        pub extern "C" fn $name($($arg: $arg_ty),*) -> $ret {
             use std::panic::{self, AssertUnwindSafe};
 
             match panic::catch_unwind(AssertUnwindSafe(move || $body)) {


### PR DESCRIPTION
- Eliminates deprecation warnings
- Follows modern Rust best practices
- Prevents potential issues with ABI compatibility across different compilers and platforms