### PR TITLE
Drop dependency on futures-channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ tokio = { version = "1", features = ["sync"] }
 # Optional
 
 atomic-waker = { version = "1.1.2", optional = true }
-futures-channel = { version = "0.3", optional = true }
 futures-core = { version = "0.3.31", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 h2 = { version = "0.4.2", optional = true }
@@ -44,7 +43,6 @@ want = { version = "0.3", optional = true }
 
 [dev-dependencies]
 form_urlencoded = "1"
-futures-channel = { version = "0.3", features = ["sink"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc", "sink"] }
 http-body-util = "0.1"
 pretty_env_logger = "0.5"
@@ -80,8 +78,8 @@ full = [
 ]
 
 # HTTP versions
-http1 = ["dep:atomic-waker", "dep:futures-channel", "dep:futures-core", "dep:httparse", "dep:itoa", "dep:pin-utils"]
-http2 = ["dep:futures-channel", "dep:futures-core", "dep:h2"]
+http1 = ["dep:atomic-waker", "dep:futures-core", "dep:httparse", "dep:itoa", "dep:pin-utils"]
+http2 = ["dep:futures-core", "dep:h2"]
 
 # Client/Server
 client = ["dep:want", "dep:pin-project-lite", "dep:smallvec"]

--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -341,7 +341,7 @@ impl Opts {
         let make_request = || {
             let chunk_cnt = self.request_chunks;
             let body = if chunk_cnt > 0 {
-                let (mut tx, rx) = futures_channel::mpsc::channel(0);
+                let (mut tx, rx) = tokio::sync::mpsc::channel(0);
 
                 let chunk = self
                     .request_body

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -17,10 +17,10 @@ use hyper::header::{HeaderMap, HeaderName, HeaderValue};
 use hyper::{Method, Request, StatusCode, Uri, Version};
 
 use bytes::Bytes;
-use futures_channel::oneshot;
 use futures_util::future::{self, FutureExt, TryFuture, TryFutureExt};
 use support::TokioIo;
 use tokio::net::TcpStream;
+use tokio::sync::oneshot;
 mod support;
 
 fn s(buf: &[u8]) -> &str {
@@ -1494,12 +1494,12 @@ mod conn {
     use std::time::Duration;
 
     use bytes::{Buf, Bytes};
-    use futures_channel::{mpsc, oneshot};
     use futures_util::future::{self, poll_fn, FutureExt, TryFutureExt};
     use http_body_util::{BodyExt, Empty, Full, StreamBody};
     use hyper::rt::Timer;
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _, DuplexStream};
     use tokio::net::{TcpListener as TkTcpListener, TcpStream};
+    use tokio::sync::{mpsc, oneshot};
 
     use hyper::body::{Body, Frame};
     use hyper::client::conn;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -14,7 +14,6 @@ use std::thread;
 use std::time::Duration;
 
 use bytes::Bytes;
-use futures_channel::oneshot;
 use futures_util::future::{self, Either, FutureExt};
 use h2::client::SendRequest;
 use h2::{RecvStream, SendStream};
@@ -25,6 +24,7 @@ use hyper::rt::{Read as AsyncRead, Write as AsyncWrite};
 use support::{TokioExecutor, TokioIo, TokioTimer};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener as TkTcpListener, TcpListener, TcpStream as TkTcpStream};
+use tokio::sync::oneshot;
 
 use hyper::body::{Body, Incoming as IncomingBody};
 use hyper::server::conn::{http1, http2};


### PR DESCRIPTION
Tokio already provides mpsc and oneshot, and it is an unconditional dependency. Use those implementations and drop a superfluous dependency.

