### PR TITLE
fix(http2): fix internals of HTTP/2 CONNECT upgrades

### DIFF
--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -642,44 +642,6 @@ mod tests {
 
     #[tokio::test]
     #[ignore] // only compilation is checked
-    async fn not_send_not_sync_executor_of_send_futures() {
-        #[derive(Clone)]
-        struct TokioExecutor {
-            // !Send, !Sync
-            _x: std::marker::PhantomData<std::rc::Rc<()>>,
-        }
-
-        impl<F> crate::rt::Executor<F> for TokioExecutor
-        where
-            F: std::future::Future + 'static + Send,
-            F::Output: Send + 'static,
-        {
-            fn execute(&self, fut: F) {
-                tokio::task::spawn(fut);
-            }
-        }
-
-        #[allow(unused)]
-        async fn run(io: impl crate::rt::Read + crate::rt::Write + Send + Unpin + 'static) {
-            let (_sender, conn) =
-                crate::client::conn::http2::handshake::<_, _, http_body_util::Empty<bytes::Bytes>>(
-                    TokioExecutor {
-                        _x: Default::default(),
-                    },
-                    io,
-                )
-                .await
-                .unwrap();
-
-            tokio::task::spawn_local(async move {
-                // can't use spawn here because when executor is !Send
-                conn.await.unwrap();
-            });
-        }
-    }
-
-    #[tokio::test]
-    #[ignore] // only compilation is checked
     async fn send_not_sync_executor_of_send_futures() {
         #[derive(Clone)]
         struct TokioExecutor {

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -325,22 +325,23 @@ impl<T> TrySendError<T> {
 
 #[cfg(feature = "http2")]
 pin_project! {
-    pub struct SendWhen<B>
+    pub struct SendWhen<B, E>
     where
         B: Body,
         B: 'static,
     {
         #[pin]
-        pub(crate) when: ResponseFutMap<B>,
+        pub(crate) when: ResponseFutMap<B, E>,
         #[pin]
         pub(crate) call_back: Option<Callback<Request<B>, Response<Incoming>>>,
     }
 }
 
 #[cfg(feature = "http2")]
-impl<B> Future for SendWhen<B>
+impl<B, E> Future for SendWhen<B, E>
 where
     B: Body + 'static,
+    E: crate::rt::bounds::Http2UpgradedExec<B::Data>,
 {
     type Output = ();
 

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -1,22 +1,20 @@
 use std::error::Error as StdError;
 use std::future::Future;
 use std::io::{Cursor, IoSlice};
-use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use bytes::{Buf, Bytes};
+use bytes::Buf;
 use futures_core::ready;
-use h2::{Reason, RecvStream, SendStream};
+use h2::SendStream;
 use http::header::{HeaderName, CONNECTION, TE, TRANSFER_ENCODING, UPGRADE};
 use http::HeaderMap;
 use pin_project_lite::pin_project;
 
 use crate::body::Body;
-use crate::proto::h2::ping::Recorder;
-use crate::rt::{Read, ReadBufCursor, Write};
 
 pub(crate) mod ping;
+pub(crate) mod upgrade;
 
 cfg_client! {
     pub(crate) mod client;
@@ -257,190 +255,5 @@ impl<B: Buf> Buf for SendBuf<B> {
             Self::Cursor(ref c) => c.chunks_vectored(dst),
             Self::None => 0,
         }
-    }
-}
-
-struct H2Upgraded<B>
-where
-    B: Buf,
-{
-    ping: Recorder,
-    send_stream: UpgradedSendStream<B>,
-    recv_stream: RecvStream,
-    buf: Bytes,
-}
-
-impl<B> Read for H2Upgraded<B>
-where
-    B: Buf,
-{
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        mut read_buf: ReadBufCursor<'_>,
-    ) -> Poll<Result<(), std::io::Error>> {
-        if self.buf.is_empty() {
-            self.buf = loop {
-                match ready!(self.recv_stream.poll_data(cx)) {
-                    None => return Poll::Ready(Ok(())),
-                    Some(Ok(buf)) if buf.is_empty() && !self.recv_stream.is_end_stream() => {
-                        continue
-                    }
-                    Some(Ok(buf)) => {
-                        self.ping.record_data(buf.len());
-                        break buf;
-                    }
-                    Some(Err(e)) => {
-                        return Poll::Ready(match e.reason() {
-                            Some(Reason::NO_ERROR) | Some(Reason::CANCEL) => Ok(()),
-                            Some(Reason::STREAM_CLOSED) => {
-                                Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, e))
-                            }
-                            _ => Err(h2_to_io_error(e)),
-                        })
-                    }
-                }
-            };
-        }
-        let cnt = std::cmp::min(self.buf.len(), read_buf.remaining());
-        read_buf.put_slice(&self.buf[..cnt]);
-        self.buf.advance(cnt);
-        let _ = self.recv_stream.flow_control().release_capacity(cnt);
-        Poll::Ready(Ok(()))
-    }
-}
-
-impl<B> Write for H2Upgraded<B>
-where
-    B: Buf,
-{
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<Result<usize, std::io::Error>> {
-        if buf.is_empty() {
-            return Poll::Ready(Ok(0));
-        }
-        self.send_stream.reserve_capacity(buf.len());
-
-        // We ignore all errors returned by `poll_capacity` and `write`, as we
-        // will get the correct from `poll_reset` anyway.
-        let cnt = match ready!(self.send_stream.poll_capacity(cx)) {
-            None => Some(0),
-            Some(Ok(cnt)) => self
-                .send_stream
-                .write(&buf[..cnt], false)
-                .ok()
-                .map(|()| cnt),
-            Some(Err(_)) => None,
-        };
-
-        if let Some(cnt) = cnt {
-            return Poll::Ready(Ok(cnt));
-        }
-
-        Poll::Ready(Err(h2_to_io_error(
-            match ready!(self.send_stream.poll_reset(cx)) {
-                Ok(Reason::NO_ERROR) | Ok(Reason::CANCEL) | Ok(Reason::STREAM_CLOSED) => {
-                    return Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into()))
-                }
-                Ok(reason) => reason.into(),
-                Err(e) => e,
-            },
-        )))
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_shutdown(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), std::io::Error>> {
-        if self.send_stream.write(&[], true).is_ok() {
-            return Poll::Ready(Ok(()));
-        }
-
-        Poll::Ready(Err(h2_to_io_error(
-            match ready!(self.send_stream.poll_reset(cx)) {
-                Ok(Reason::NO_ERROR) => return Poll::Ready(Ok(())),
-                Ok(Reason::CANCEL) | Ok(Reason::STREAM_CLOSED) => {
-                    return Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into()))
-                }
-                Ok(reason) => reason.into(),
-                Err(e) => e,
-            },
-        )))
-    }
-}
-
-fn h2_to_io_error(e: h2::Error) -> std::io::Error {
-    if e.is_io() {
-        e.into_io().unwrap()
-    } else {
-        std::io::Error::new(std::io::ErrorKind::Other, e)
-    }
-}
-
-struct UpgradedSendStream<B>(SendStream<SendBuf<Neutered<B>>>);
-
-impl<B> UpgradedSendStream<B>
-where
-    B: Buf,
-{
-    unsafe fn new(inner: SendStream<SendBuf<B>>) -> Self {
-        assert_eq!(mem::size_of::<B>(), mem::size_of::<Neutered<B>>());
-        Self(mem::transmute(inner))
-    }
-
-    fn reserve_capacity(&mut self, cnt: usize) {
-        unsafe { self.as_inner_unchecked().reserve_capacity(cnt) }
-    }
-
-    fn poll_capacity(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<usize, h2::Error>>> {
-        unsafe { self.as_inner_unchecked().poll_capacity(cx) }
-    }
-
-    fn poll_reset(&mut self, cx: &mut Context<'_>) -> Poll<Result<h2::Reason, h2::Error>> {
-        unsafe { self.as_inner_unchecked().poll_reset(cx) }
-    }
-
-    fn write(&mut self, buf: &[u8], end_of_stream: bool) -> Result<(), std::io::Error> {
-        let send_buf = SendBuf::Cursor(Cursor::new(buf.into()));
-        unsafe {
-            self.as_inner_unchecked()
-                .send_data(send_buf, end_of_stream)
-                .map_err(h2_to_io_error)
-        }
-    }
-
-    unsafe fn as_inner_unchecked(&mut self) -> &mut SendStream<SendBuf<B>> {
-        &mut *(&mut self.0 as *mut _ as *mut _)
-    }
-}
-
-#[repr(transparent)]
-struct Neutered<B> {
-    _inner: B,
-    impossible: Impossible,
-}
-
-enum Impossible {}
-
-unsafe impl<B> Send for Neutered<B> {}
-
-impl<B> Buf for Neutered<B> {
-    fn remaining(&self) -> usize {
-        match self.impossible {}
-    }
-
-    fn chunk(&self) -> &[u8] {
-        match self.impossible {}
-    }
-
-    fn advance(&mut self, _cnt: usize) {
-        match self.impossible {}
     }
 }

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -19,9 +19,8 @@ use crate::common::time::Time;
 use crate::ext::Protocol;
 use crate::headers;
 use crate::proto::h2::ping::Recorder;
-use crate::proto::h2::{H2Upgraded, UpgradedSendStream};
 use crate::proto::Dispatched;
-use crate::rt::bounds::Http2ServerConnExec;
+use crate::rt::bounds::{Http2ServerConnExec, Http2UpgradedExec};
 use crate::rt::{Read, Write};
 use crate::service::HttpService;
 
@@ -308,6 +307,7 @@ where
                             connect_parts,
                             respond,
                             self.date_header,
+                            exec.clone(),
                         );
 
                         exec.execute_h2stream(fut);
@@ -357,7 +357,7 @@ where
 
 pin_project! {
     #[allow(missing_debug_implementations)]
-    pub struct H2Stream<F, B>
+    pub struct H2Stream<F, B, E>
     where
         B: Body,
     {
@@ -365,6 +365,7 @@ pin_project! {
         #[pin]
         state: H2StreamState<F, B>,
         date_header: bool,
+        exec: E,
     }
 }
 
@@ -392,7 +393,7 @@ struct ConnectParts {
     recv_stream: RecvStream,
 }
 
-impl<F, B> H2Stream<F, B>
+impl<F, B, E> H2Stream<F, B, E>
 where
     B: Body,
 {
@@ -401,11 +402,13 @@ where
         connect_parts: Option<ConnectParts>,
         respond: SendResponse<SendBuf<B::Data>>,
         date_header: bool,
-    ) -> H2Stream<F, B> {
+        exec: E,
+    ) -> H2Stream<F, B, E> {
         H2Stream {
             reply: respond,
             state: H2StreamState::Service { fut, connect_parts },
             date_header,
+            exec,
         }
     }
 }
@@ -423,16 +426,17 @@ macro_rules! reply {
     }};
 }
 
-impl<F, B, E> H2Stream<F, B>
+impl<F, B, Ex, E> H2Stream<F, B, Ex>
 where
     F: Future<Output = Result<Response<B>, E>>,
     B: Body,
     B::Data: 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    Ex: Http2UpgradedExec<B::Data>,
     E: Into<Box<dyn StdError + Send + Sync>>,
 {
-    fn poll2(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
-        let mut me = self.project();
+    fn poll2(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<crate::Result<()>> {
+        let mut me = self.as_mut().project();
         loop {
             let next = match me.state.as_mut().project() {
                 H2StreamStateProj::Service {
@@ -488,15 +492,15 @@ where
                                 warn!("successful response to CONNECT request disallows content-length header");
                             }
                             let send_stream = reply!(me, res, false);
-                            connect_parts.pending.fulfill(Upgraded::new(
-                                H2Upgraded {
-                                    ping: connect_parts.ping,
-                                    recv_stream: connect_parts.recv_stream,
-                                    send_stream: unsafe { UpgradedSendStream::new(send_stream) },
-                                    buf: Bytes::new(),
-                                },
-                                Bytes::new(),
-                            ));
+                            let (h2_up, up_task) = super::upgrade::pair(
+                                send_stream,
+                                connect_parts.recv_stream,
+                                connect_parts.ping,
+                            );
+                            connect_parts
+                                .pending
+                                .fulfill(Upgraded::new(h2_up, Bytes::new()));
+                            self.exec.execute_upgrade(up_task);
                             return Poll::Ready(Ok(()));
                         }
                     }
@@ -525,12 +529,13 @@ where
     }
 }
 
-impl<F, B, E> Future for H2Stream<F, B>
+impl<F, B, Ex, E> Future for H2Stream<F, B, Ex>
 where
     F: Future<Output = Result<Response<B>, E>>,
     B: Body,
     B::Data: 'static,
     B::Error: Into<Box<dyn StdError + Send + Sync>>,
+    Ex: Http2UpgradedExec<B::Data>,
     E: Into<Box<dyn StdError + Send + Sync>>,
 {
     type Output = ();

--- a/src/proto/h2/upgrade.rs
+++ b/src/proto/h2/upgrade.rs
@@ -1,0 +1,280 @@
+use std::future::Future;
+use std::io::Cursor;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use bytes::{Buf, Bytes};
+use futures_channel::{mpsc, oneshot};
+use futures_core::{ready, Stream};
+use h2::{Reason, RecvStream, SendStream};
+use pin_project_lite::pin_project;
+
+use super::ping::Recorder;
+use super::SendBuf;
+use crate::rt::{Read, ReadBufCursor, Write};
+
+pub(super) fn pair<B>(
+    send_stream: SendStream<SendBuf<B>>,
+    recv_stream: RecvStream,
+    ping: Recorder,
+) -> (H2Upgraded, UpgradedSendStreamTask<B>) {
+    let (tx, rx) = mpsc::channel(1);
+    let (error_tx, error_rx) = oneshot::channel();
+
+    (
+        H2Upgraded {
+            send_stream: UpgradedSendStreamBridge { tx, error_rx },
+            recv_stream,
+            ping,
+            buf: Bytes::new(),
+        },
+        UpgradedSendStreamTask {
+            h2_tx: send_stream,
+            rx,
+            error_tx: Some(error_tx),
+        },
+    )
+}
+
+pub(super) struct H2Upgraded {
+    ping: Recorder,
+    send_stream: UpgradedSendStreamBridge,
+    recv_stream: RecvStream,
+    buf: Bytes,
+}
+
+struct UpgradedSendStreamBridge {
+    tx: mpsc::Sender<Cursor<Box<[u8]>>>,
+    error_rx: oneshot::Receiver<crate::Error>,
+}
+
+pin_project! {
+    #[must_use = "futures do nothing unless polled"]
+    pub struct UpgradedSendStreamTask<B> {
+        #[pin]
+        h2_tx: SendStream<SendBuf<B>>,
+        #[pin]
+        rx: mpsc::Receiver<Cursor<Box<[u8]>>>,
+        error_tx: Option<oneshot::Sender<crate::Error>>,
+    }
+}
+
+// ===== impl UpgradedSendStreamTask =====
+
+impl<B> UpgradedSendStreamTask<B>
+where
+    B: Buf,
+{
+    fn tick(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), crate::Error>> {
+        let mut me = self.project();
+
+        // this is a manual `select()` over 3 "futures", so we always need
+        // to be sure they are ready and/or we are waiting notification of
+        // one of the sides hanging up, so the task doesn't live around
+        // longer than it's meant to.
+        loop {
+            // we don't have the next chunk of data yet, so just reserve 1 byte to make
+            // sure there's some capacity available. h2 will handle the capacity management
+            // for the actual body chunk.
+            me.h2_tx.reserve_capacity(1);
+
+            if me.h2_tx.capacity() == 0 {
+                // poll_capacity oddly needs a loop
+                'capacity: loop {
+                    match me.h2_tx.poll_capacity(cx) {
+                        Poll::Ready(Some(Ok(0))) => {}
+                        Poll::Ready(Some(Ok(_))) => break,
+                        Poll::Ready(Some(Err(e))) => {
+                            return Poll::Ready(Err(crate::Error::new_body_write(e)))
+                        }
+                        Poll::Ready(None) => {
+                            // None means the stream is no longer in a
+                            // streaming state, we either finished it
+                            // somehow, or the remote reset us.
+                            return Poll::Ready(Err(crate::Error::new_body_write(
+                                "send stream capacity unexpectedly closed",
+                            )));
+                        }
+                        Poll::Pending => break 'capacity,
+                    }
+                }
+            }
+
+            match me.h2_tx.poll_reset(cx) {
+                Poll::Ready(Ok(reason)) => {
+                    trace!("stream received RST_STREAM: {:?}", reason);
+                    return Poll::Ready(Err(crate::Error::new_body_write(::h2::Error::from(
+                        reason,
+                    ))));
+                }
+                Poll::Ready(Err(err)) => {
+                    return Poll::Ready(Err(crate::Error::new_body_write(err)))
+                }
+                Poll::Pending => (),
+            }
+
+            match me.rx.as_mut().poll_next(cx) {
+                Poll::Ready(Some(cursor)) => {
+                    me.h2_tx
+                        .send_data(SendBuf::Cursor(cursor), false)
+                        .map_err(crate::Error::new_body_write)?;
+                }
+                Poll::Ready(None) => {
+                    me.h2_tx
+                        .send_data(SendBuf::None, true)
+                        .map_err(crate::Error::new_body_write)?;
+                    return Poll::Ready(Ok(()));
+                }
+                Poll::Pending => {
+                    return Poll::Pending;
+                }
+            }
+        }
+    }
+}
+
+impl<B> Future for UpgradedSendStreamTask<B>
+where
+    B: Buf,
+{
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.as_mut().tick(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(()),
+            Poll::Ready(Err(err)) => {
+                if let Some(tx) = self.error_tx.take() {
+                    let _oh_well = tx.send(err);
+                }
+                Poll::Ready(())
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+// ===== impl H2Upgraded =====
+
+impl Read for H2Upgraded {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        mut read_buf: ReadBufCursor<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        if self.buf.is_empty() {
+            self.buf = loop {
+                match ready!(self.recv_stream.poll_data(cx)) {
+                    None => return Poll::Ready(Ok(())),
+                    Some(Ok(buf)) if buf.is_empty() && !self.recv_stream.is_end_stream() => {
+                        continue
+                    }
+                    Some(Ok(buf)) => {
+                        self.ping.record_data(buf.len());
+                        break buf;
+                    }
+                    Some(Err(e)) => {
+                        return Poll::Ready(match e.reason() {
+                            Some(Reason::NO_ERROR) | Some(Reason::CANCEL) => Ok(()),
+                            Some(Reason::STREAM_CLOSED) => {
+                                Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, e))
+                            }
+                            _ => Err(h2_to_io_error(e)),
+                        })
+                    }
+                }
+            };
+        }
+        let cnt = std::cmp::min(self.buf.len(), read_buf.remaining());
+        read_buf.put_slice(&self.buf[..cnt]);
+        self.buf.advance(cnt);
+        let _ = self.recv_stream.flow_control().release_capacity(cnt);
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl Write for H2Upgraded {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        match self.send_stream.tx.poll_ready(cx) {
+            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Err(_task_dropped)) => {
+                // if the task dropped, check if there was an error
+                // otherwise i guess its a broken pipe
+                return match Pin::new(&mut self.send_stream.error_rx).poll(cx) {
+                    Poll::Ready(Ok(reason)) => Poll::Ready(Err(io_error(reason))),
+                    Poll::Ready(Err(_task_dropped)) => {
+                        Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into()))
+                    }
+                    Poll::Pending => Poll::Pending,
+                };
+            }
+            Poll::Pending => return Poll::Pending,
+        }
+
+        let n = buf.len();
+        match self.send_stream.tx.start_send(Cursor::new(buf.into())) {
+            Ok(()) => Poll::Ready(Ok(n)),
+            Err(_task_dropped) => {
+                // if the task dropped, check if there was an error
+                // otherwise i guess its a broken pipe
+                match Pin::new(&mut self.send_stream.error_rx).poll(cx) {
+                    Poll::Ready(Ok(reason)) => Poll::Ready(Err(io_error(reason))),
+                    Poll::Ready(Err(_task_dropped)) => {
+                        Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into()))
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            }
+        }
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        match self.send_stream.tx.poll_ready(cx) {
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(_task_dropped)) => {
+                // if the task dropped, check if there was an error
+                // otherwise it was a clean close
+                match Pin::new(&mut self.send_stream.error_rx).poll(cx) {
+                    Poll::Ready(Ok(reason)) => Poll::Ready(Err(io_error(reason))),
+                    Poll::Ready(Err(_task_dropped)) => Poll::Ready(Ok(())),
+                    Poll::Pending => Poll::Pending,
+                }
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        self.send_stream.tx.close_channel();
+        match Pin::new(&mut self.send_stream.error_rx).poll(cx) {
+            Poll::Ready(Ok(reason)) => Poll::Ready(Err(io_error(reason))),
+            Poll::Ready(Err(_task_dropped)) => Poll::Ready(Ok(())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+fn io_error(e: crate::Error) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::Other, e)
+}
+
+fn h2_to_io_error(e: h2::Error) -> std::io::Error {
+    if e.is_io() {
+        e.into_io().unwrap()
+    } else {
+        std::io::Error::new(std::io::ErrorKind::Other, e)
+    }
+}

--- a/src/rt/bounds.rs
+++ b/src/rt/bounds.rs
@@ -3,11 +3,34 @@
 //! Traits in this module ease setting bounds and usually automatically
 //! implemented by implementing another trait.
 
-#[cfg(all(feature = "server", feature = "http2"))]
-pub use self::h2::Http2ServerConnExec;
-
 #[cfg(all(feature = "client", feature = "http2"))]
 pub use self::h2_client::Http2ClientConnExec;
+#[cfg(all(feature = "server", feature = "http2"))]
+pub use self::h2_server::Http2ServerConnExec;
+
+#[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
+pub(crate) use self::h2_common::Http2UpgradedExec;
+
+#[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
+mod h2_common {
+    use crate::proto::h2::upgrade::UpgradedSendStreamTask;
+    use crate::rt::Executor;
+
+    pub trait Http2UpgradedExec<B> {
+        #[doc(hidden)]
+        fn execute_upgrade(&self, fut: UpgradedSendStreamTask<B>);
+    }
+
+    #[doc(hidden)]
+    impl<E, B> Http2UpgradedExec<B> for E
+    where
+        E: Executor<UpgradedSendStreamTask<B>>,
+    {
+        fn execute_upgrade(&self, fut: UpgradedSendStreamTask<B>) {
+            self.execute(fut)
+        }
+    }
+}
 
 #[cfg(all(feature = "client", feature = "http2"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "client", feature = "http2"))))]
@@ -25,35 +48,40 @@ mod h2_client {
     /// This trait is sealed and cannot be implemented for types outside this crate.
     ///
     /// [`Executor`]: crate::rt::Executor
-    pub trait Http2ClientConnExec<B, T>: sealed_client::Sealed<(B, T)>
+    pub trait Http2ClientConnExec<B, T>:
+        super::Http2UpgradedExec<B::Data> + sealed_client::Sealed<(B, T)> + Clone
     where
         B: http_body::Body,
         B::Error: Into<Box<dyn Error + Send + Sync>>,
         T: Read + Write + Unpin,
     {
         #[doc(hidden)]
-        fn execute_h2_future(&mut self, future: H2ClientFuture<B, T>);
+        fn execute_h2_future(&mut self, future: H2ClientFuture<B, T, Self>);
     }
 
     impl<E, B, T> Http2ClientConnExec<B, T> for E
     where
-        E: Executor<H2ClientFuture<B, T>>,
+        E: Clone,
+        E: Executor<H2ClientFuture<B, T, E>>,
+        E: super::Http2UpgradedExec<B::Data>,
         B: http_body::Body + 'static,
         B::Error: Into<Box<dyn Error + Send + Sync>>,
-        H2ClientFuture<B, T>: Future<Output = ()>,
+        H2ClientFuture<B, T, E>: Future<Output = ()>,
         T: Read + Write + Unpin,
     {
-        fn execute_h2_future(&mut self, future: H2ClientFuture<B, T>) {
+        fn execute_h2_future(&mut self, future: H2ClientFuture<B, T, E>) {
             self.execute(future)
         }
     }
 
     impl<E, B, T> sealed_client::Sealed<(B, T)> for E
     where
-        E: Executor<H2ClientFuture<B, T>>,
+        E: Clone,
+        E: Executor<H2ClientFuture<B, T, E>>,
+        E: super::Http2UpgradedExec<B::Data>,
         B: http_body::Body + 'static,
         B::Error: Into<Box<dyn Error + Send + Sync>>,
-        H2ClientFuture<B, T>: Future<Output = ()>,
+        H2ClientFuture<B, T, E>: Future<Output = ()>,
         T: Read + Write + Unpin,
     {
     }
@@ -65,7 +93,7 @@ mod h2_client {
 
 #[cfg(all(feature = "server", feature = "http2"))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "server", feature = "http2"))))]
-mod h2 {
+mod h2_server {
     use crate::{proto::h2::server::H2Stream, rt::Executor};
     use http_body::Body;
     use std::future::Future;
@@ -78,27 +106,33 @@ mod h2 {
     /// This trait is sealed and cannot be implemented for types outside this crate.
     ///
     /// [`Executor`]: crate::rt::Executor
-    pub trait Http2ServerConnExec<F, B: Body>: sealed::Sealed<(F, B)> + Clone {
+    pub trait Http2ServerConnExec<F, B: Body>:
+        super::Http2UpgradedExec<B::Data> + sealed::Sealed<(F, B)> + Clone
+    {
         #[doc(hidden)]
-        fn execute_h2stream(&mut self, fut: H2Stream<F, B>);
+        fn execute_h2stream(&mut self, fut: H2Stream<F, B, Self>);
     }
 
     #[doc(hidden)]
     impl<E, F, B> Http2ServerConnExec<F, B> for E
     where
-        E: Executor<H2Stream<F, B>> + Clone,
-        H2Stream<F, B>: Future<Output = ()>,
+        E: Clone,
+        E: Executor<H2Stream<F, B, E>>,
+        E: super::Http2UpgradedExec<B::Data>,
+        H2Stream<F, B, E>: Future<Output = ()>,
         B: Body,
     {
-        fn execute_h2stream(&mut self, fut: H2Stream<F, B>) {
+        fn execute_h2stream(&mut self, fut: H2Stream<F, B, E>) {
             self.execute(fut)
         }
     }
 
     impl<E, F, B> sealed::Sealed<(F, B)> for E
     where
-        E: Executor<H2Stream<F, B>> + Clone,
-        H2Stream<F, B>: Future<Output = ()>,
+        E: Clone,
+        E: Executor<H2Stream<F, B, E>>,
+        E: super::Http2UpgradedExec<B::Data>,
+        H2Stream<F, B, E>: Future<Output = ()>,
         B: Body,
     {
     }


### PR DESCRIPTION
This refactors the way hyper handles HTTP/2 CONNECT / Extended CONNECT. Before, an uninhabited enum was used to try to prevent sending of the `Buf` type once the STREAM had been upgraded. However, the way it was originally written was incorrect, and will eventually have compilation issues.

The change here is to spawn an extra task and use a channel to bridge the IO operations of the `Upgraded` object to be `Cursor` buffers in the new task.

ref: https://github.com/rust-lang/rust/issues/147588
Closes #3966 

BREAKING CHANGE: The HTTP/2 client connection no longer allows an executor that can not spawn itself.
  
  This was an oversight originally. The client connection will now include spawning a future that keeps a copy of the executor to spawn other futures. Thus, if it is `!Send`, it needs to spawn `!Send` futures. The likelihood of executors that match the previously allowed behavior should be very remote.

  There is also technically a semver break in here, which is that the `Http2ClientConnExec` trait no longer dyn-compatible, because it now expects to be `Clone`. This should not break usage of the `conn` builder, because it already separately had `E: Clone` bounds. If someone were using `dyn Http2ClientConnExec`, that will break. However, there is no purpose for doing so, and it is not usable otherwise, since the trait only exists to propagate bounds into hyper. Thus, the breakage should not affect anyone.

