### PR TITLE
docs: fix comment in `put_slice()`

### DIFF
--- a/src/rt/io.rs
+++ b/src/rt/io.rs
@@ -253,7 +253,7 @@ impl ReadBufCursor<'_> {
         self.buf.remaining()
     }
 
-    /// Transfer bytes into `self`` from `src` and advance the cursor
+    /// Transfer bytes into `self` from `src` and advance the cursor
     /// by the number of bytes written.
     ///
     /// # Panics


### PR DESCRIPTION
Nitpicky, I know, but renders poorly in the docs.

