### PR TITLE
feat(error): make find source pub

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -291,7 +291,8 @@ impl Error {
         &self.inner.kind
     }
 
-    pub(crate) fn find_source<E: StdError + 'static>(&self) -> Option<&E> {
+    /// If downcast matches, returns a reference to the error
+    pub fn find_source<E: StdError + 'static>(&self) -> Option<&E> {
         let mut cause = self.source();
         while let Some(err) = cause {
             if let Some(typed) = err.downcast_ref() {


### PR DESCRIPTION
I'm not sure if you are against broadening the Error API, but this is quite useful from the client side to attempt to retrieve ones own errors. Currently, they get swallowed up by hyper and it's not possible to get them back out AFAIK.