### PR TITLE
feat(http2/client): add `max_local_error_reset_streams` option

### DIFF
--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -467,10 +467,12 @@ where
 
     /// Configures the maximum number of local resets due to protocol errors made by the remote end.
     ///
-    /// This will default to the default value set by the [`h2` crate](https://crates.io/crates/h2).
-    /// As of v0.4.13, it is 1024.
-    pub fn max_local_error_reset_streams(&mut self, max: Option<usize>) -> &mut Self {
-        self.h2_builder.max_local_error_reset_streams = Some(max);
+    /// See the documentation of [`h2::client::Builder::max_local_error_reset_streams`] for more
+    /// details.
+    ///
+    /// The default value is 1024.
+    pub fn max_local_error_reset_streams(&mut self, max: impl Into<Option<usize>>) -> &mut Self {
+        self.h2_builder.max_local_error_reset_streams = max.into();
         self
     }
 

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -74,7 +74,7 @@ pub(crate) struct Config {
     pub(crate) max_concurrent_reset_streams: Option<usize>,
     pub(crate) max_send_buffer_size: usize,
     pub(crate) max_pending_accept_reset_streams: Option<usize>,
-    pub(crate) max_local_error_reset_streams: Option<Option<usize>>,
+    pub(crate) max_local_error_reset_streams: Option<usize>,
     pub(crate) header_table_size: Option<u32>,
     pub(crate) max_concurrent_streams: Option<u32>,
 }
@@ -94,7 +94,7 @@ impl Default for Config {
             max_concurrent_reset_streams: None,
             max_send_buffer_size: DEFAULT_MAX_SEND_BUF_SIZE,
             max_pending_accept_reset_streams: None,
-            max_local_error_reset_streams: None,
+            max_local_error_reset_streams: Some(1024),
             header_table_size: None,
             max_concurrent_streams: None,
         }
@@ -109,6 +109,7 @@ fn new_builder(config: &Config) -> Builder {
         .initial_connection_window_size(config.initial_conn_window_size)
         .max_header_list_size(config.max_header_list_size)
         .max_send_buffer_size(config.max_send_buffer_size)
+        .max_local_error_reset_streams(config.max_local_error_reset_streams)
         .enable_push(false);
     if let Some(max) = config.max_frame_size {
         builder.max_frame_size(max);
@@ -118,9 +119,6 @@ fn new_builder(config: &Config) -> Builder {
     }
     if let Some(max) = config.max_pending_accept_reset_streams {
         builder.max_pending_accept_reset_streams(max);
-    }
-    if let Some(max) = config.max_local_error_reset_streams {
-        builder.max_local_error_reset_streams(max);
     }
     if let Some(size) = config.header_table_size {
         builder.header_table_size(size);


### PR DESCRIPTION
Adds `max_local_error_reset_streams` option to HTTP/2 client builder.

We faced [this issue][too_many_internal_resets] in Qdrant, when we initiate and then cancel multiple gRPC requests, and it would be nice to be able to tweak this parameter. We plan to open a similar PR to expose this option in `tonic` client later.

[too_many_internal_resets]: https://github.com/hyperium/h2/issues/856#issuecomment-3413696981