### PR TITLE
chore: drop pin-utils dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ httparse = { version = "1.9", optional = true }
 httpdate = { version = "1.0", optional = true }
 itoa = { version = "1", optional = true }
 pin-project-lite = { version = "0.2.4", optional = true }
-pin-utils = { version = "0.1", optional = true } # TODO: replace with std::pin::pin! once MSRV >= 1.68
 smallvec = { version = "1.12", features = ["const_generics", "const_new"], optional = true }
 tracing = { version = "0.1", default-features = false, features = ["std"], optional = true }
 want = { version = "0.3", optional = true }
@@ -80,7 +79,7 @@ full = [
 ]
 
 # HTTP versions
-http1 = ["dep:atomic-waker", "dep:futures-channel", "dep:futures-core", "dep:httparse", "dep:itoa", "dep:pin-utils"]
+http1 = ["dep:atomic-waker", "dep:futures-channel", "dep:futures-core", "dep:httparse", "dep:itoa"]
 http2 = ["dep:futures-channel", "dep:futures-core", "dep:h2"]
 
 # Client/Server

--- a/src/common/task.rs
+++ b/src/common/task.rs
@@ -36,8 +36,8 @@ fn noop_waker() -> Waker {
 pub(crate) fn now_or_never<F: std::future::Future>(fut: F) -> Option<F::Output> {
     let waker = noop_waker();
     let mut cx = Context::from_waker(&waker);
-    // TODO: replace with std::pin::pin! and drop pin-utils once MSRV >= 1.68
-    pin_utils::pin_mut!(fut);
+    // TODO: replace with std::pin::pin! once MSRV >= 1.68
+    tokio::pin!(fut);
     match fut.poll(&mut cx) {
         Poll::Ready(res) => Some(res),
         Poll::Pending => None,


### PR DESCRIPTION
Drops the `pin-utils` dependency.