### PR TITLE
Preserve URI parse error info in error source chain

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -92,7 +92,7 @@ pub(super) enum Parse {
     Version,
     #[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
     VersionH2,
-    Uri,
+    Uri(Option<Cause>),
     #[cfg(all(feature = "http1", feature = "server"))]
     UriTooLong,
     #[cfg(feature = "http1")]
@@ -459,7 +459,7 @@ impl Error {
             Kind::Parse(Parse::Version) => "invalid HTTP version parsed",
             #[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
             Kind::Parse(Parse::VersionH2) => "invalid HTTP version parsed (found HTTP2 preface)",
-            Kind::Parse(Parse::Uri) => "invalid URI",
+            Kind::Parse(Parse::Uri(_)) => "invalid URI",
             #[cfg(all(feature = "http1", feature = "server"))]
             Kind::Parse(Parse::UriTooLong) => "URI too long",
             #[cfg(feature = "http1")]
@@ -582,7 +582,10 @@ impl StdError for Error {
 #[doc(hidden)]
 impl From<Parse> for Error {
     fn from(err: Parse) -> Error {
-        Error::new(Kind::Parse(err))
+        match err {
+            Parse::Uri(Some(cause)) => Error::new(Kind::Parse(Parse::Uri(None))).with(cause),
+            other => Error::new(Kind::Parse(other)),
+        }
     }
 }
 
@@ -632,14 +635,14 @@ impl From<http::status::InvalidStatusCode> for Parse {
 }
 
 impl From<http::uri::InvalidUri> for Parse {
-    fn from(_: http::uri::InvalidUri) -> Parse {
-        Parse::Uri
+    fn from(err: http::uri::InvalidUri) -> Parse {
+        Parse::Uri(Some(Box::new(err)))
     }
 }
 
 impl From<http::uri::InvalidUriParts> for Parse {
-    fn from(_: http::uri::InvalidUriParts) -> Parse {
-        Parse::Uri
+    fn from(err: http::uri::InvalidUriParts) -> Parse {
+        Parse::Uri(Some(Box::new(err)))
     }
 }
 
@@ -691,5 +694,28 @@ mod tests {
         // Suppose a user were proxying the received error
         let svc_err = Error::new_user_service(recvd);
         assert_eq!(svc_err.h2_reason(), h2::Reason::HTTP_1_1_REQUIRED);
+    }
+
+    #[test]
+    fn uri_error_preserves_source() {
+        use std::error::Error as _;
+
+        // Parse an invalid URI through the http crate
+        let invalid: std::result::Result<http::Uri, _> = "dangling whitespace ".parse();
+        let uri_err: http::uri::InvalidUri = invalid.unwrap_err();
+
+        // Convert through the same path hyper uses: InvalidUri -> Parse -> Error
+        let parse: Parse = Parse::from(uri_err);
+        let error: Error = Error::from(parse);
+
+        // The error should have a source
+        assert!(error.source().is_some(), "URI error should preserve source");
+
+        // The source should be the original InvalidUri
+        let source = error.source().unwrap();
+        assert!(
+            source.downcast_ref::<http::uri::InvalidUri>().is_some(),
+            "source should be http::uri::InvalidUri"
+        );
     }
 }

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -199,7 +199,7 @@ impl Http1Transaction for Server {
                             Parse::Method
                         } else {
                             debug_assert!(req.path.is_none());
-                            Parse::Uri
+                            Parse::Uri(None)
                         }
                     })
                 }
@@ -467,7 +467,7 @@ impl Http1Transaction for Server {
         let status = match *err.kind() {
             Kind::Parse(Parse::Method)
             | Kind::Parse(Parse::Header(_))
-            | Kind::Parse(Parse::Uri)
+            | Kind::Parse(Parse::Uri(_))
             | Kind::Parse(Parse::Version) => StatusCode::BAD_REQUEST,
             Kind::Parse(Parse::TooLarge) => StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
             Kind::Parse(Parse::UriTooLong) => StatusCode::URI_TOO_LONG,


### PR DESCRIPTION
Fixes #3043

When hyper parsed an HTTP request with an invalid URI, it would create a `Parse(Uri)` error but discard the original `http::uri::InvalidUri` error. This meant `error.source()` returned `None`, making it impossible to get the actual reason the URI was invalid.

Changed `Parse::Uri` to carry an `Option<Cause>` so the original `InvalidUri` or `InvalidUriParts` error flows through to `Error::source()`. The error message and `Display` output are unchanged - the improvement is only visible through the `Error::source()` chain.

Added a test that verifies `error.source()` returns the original `http::uri::InvalidUri`:

```
running 86 tests
...
test error::tests::uri_error_preserves_source ... ok
...
test result: ok. 86 passed; 0 failed; 0 ignored
```