### PR TITLE
perf(h1): pass ParserConfig by reference instead of cloning per parse call

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -239,7 +239,7 @@ where
             ParseContext {
                 cached_headers: &mut self.state.cached_headers,
                 req_method: &mut self.state.method,
-                h1_parser_config: self.state.h1_parser_config.clone(),
+                h1_parser_config: &self.state.h1_parser_config,
                 h1_max_headers: self.state.h1_max_headers,
                 preserve_header_case: self.state.preserve_header_case,
                 #[cfg(feature = "ffi")]

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -182,7 +182,7 @@ where
                 ParseContext {
                     cached_headers: parse_ctx.cached_headers,
                     req_method: parse_ctx.req_method,
-                    h1_parser_config: parse_ctx.h1_parser_config.clone(),
+                    h1_parser_config: parse_ctx.h1_parser_config,
                     h1_max_headers: parse_ctx.h1_max_headers,
                     preserve_header_case: parse_ctx.preserve_header_case,
                     #[cfg(feature = "ffi")]
@@ -704,7 +704,7 @@ mod tests {
             let parse_ctx = ParseContext {
                 cached_headers: &mut None,
                 req_method: &mut None,
-                h1_parser_config: Default::default(),
+                h1_parser_config: &Default::default(),
                 h1_max_headers: None,
                 preserve_header_case: false,
                 #[cfg(feature = "ffi")]

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -71,7 +71,7 @@ pub(crate) struct ParsedMessage<T> {
 pub(crate) struct ParseContext<'a> {
     cached_headers: &'a mut Option<HeaderMap>,
     req_method: &'a mut Option<Method>,
-    h1_parser_config: ParserConfig,
+    h1_parser_config: &'a ParserConfig,
     h1_max_headers: Option<usize>,
     preserve_header_case: bool,
     #[cfg(feature = "ffi")]

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1674,7 +1674,7 @@ mod tests {
             ParseContext {
                 cached_headers: &mut None,
                 req_method: &mut method,
-                h1_parser_config: Default::default(),
+                h1_parser_config: &Default::default(),
                 h1_max_headers: None,
                 preserve_header_case: false,
                 #[cfg(feature = "ffi")]
@@ -1702,7 +1702,7 @@ mod tests {
         let ctx = ParseContext {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
-            h1_parser_config: Default::default(),
+            h1_parser_config: &Default::default(),
             h1_max_headers: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1726,7 +1726,7 @@ mod tests {
         let ctx = ParseContext {
             cached_headers: &mut None,
             req_method: &mut None,
-            h1_parser_config: Default::default(),
+            h1_parser_config: &Default::default(),
             h1_max_headers: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1747,7 +1747,7 @@ mod tests {
         let ctx = ParseContext {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
-            h1_parser_config: Default::default(),
+            h1_parser_config: &Default::default(),
             h1_max_headers: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1770,7 +1770,7 @@ mod tests {
         let ctx = ParseContext {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
-            h1_parser_config: Default::default(),
+            h1_parser_config: &Default::default(),
             h1_max_headers: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1797,7 +1797,7 @@ mod tests {
         let ctx = ParseContext {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
-            h1_parser_config,
+            h1_parser_config: &h1_parser_config,
             h1_max_headers: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1821,7 +1821,7 @@ mod tests {
         let ctx = ParseContext {
             cached_headers: &mut None,
             req_method: &mut Some(crate::Method::GET),
-            h1_parser_config: Default::default(),
+            h1_parser_config: &Default::default(),
             h1_max_headers: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1849,7 +1849,7 @@ mod tests {
         let ctx = ParseContext {
             cached_headers: &mut None,
             req_method: &mut method,
-            h1_parser_config,
+            h1_parser_config: &h1_parser_config,
             h1_max_headers: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1876,7 +1876,7 @@ mod tests {
         let ctx = ParseContext {
             cached_headers: &mut None,
             req_method: &mut None,
-            h1_parser_config: Default::default(),
+            h1_parser_config: &Default::default(),
             h1_max_headers: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
@@ -1896,7 +1896,7 @@ mod tests {
         let ctx = ParseContext {
             cached_headers: &mut None,
             req_method: &mut None,
-            h1_parser_config: Default::default(),
+            h1_parser_config: &Default::default(),
             h1_max_headers: None,
             preserve_header_case: true,
             #[cfg(feature = "ffi")]
@@ -1935,7 +1935,7 @@ mod tests {
                 ParseContext {
                     cached_headers: &mut None,
                     req_method: &mut None,
-                    h1_parser_config: Default::default(),
+                    h1_parser_config: &Default::default(),
                     h1_max_headers: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -1956,7 +1956,7 @@ mod tests {
                 ParseContext {
                     cached_headers: &mut None,
                     req_method: &mut None,
-                    h1_parser_config: Default::default(),
+                    h1_parser_config: &Default::default(),
                     h1_max_headers: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -2186,7 +2186,7 @@ mod tests {
                 ParseContext {
                     cached_headers: &mut None,
                     req_method: &mut Some(Method::GET),
-                    h1_parser_config: Default::default(),
+                    h1_parser_config: &Default::default(),
                     h1_max_headers: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -2207,7 +2207,7 @@ mod tests {
                 ParseContext {
                     cached_headers: &mut None,
                     req_method: &mut Some(m),
-                    h1_parser_config: Default::default(),
+                    h1_parser_config: &Default::default(),
                     h1_max_headers: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -2228,7 +2228,7 @@ mod tests {
                 ParseContext {
                     cached_headers: &mut None,
                     req_method: &mut Some(Method::GET),
-                    h1_parser_config: Default::default(),
+                    h1_parser_config: &Default::default(),
                     h1_max_headers: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -2798,7 +2798,7 @@ mod tests {
             ParseContext {
                 cached_headers: &mut None,
                 req_method: &mut Some(Method::GET),
-                h1_parser_config: Default::default(),
+                h1_parser_config: &Default::default(),
                 h1_max_headers: None,
                 preserve_header_case: false,
                 #[cfg(feature = "ffi")]
@@ -2842,7 +2842,7 @@ mod tests {
                     ParseContext {
                         cached_headers: &mut None,
                         req_method: &mut None,
-                        h1_parser_config: Default::default(),
+                        h1_parser_config: &Default::default(),
                         h1_max_headers: max_headers,
                         preserve_header_case: false,
                         #[cfg(feature = "ffi")]
@@ -2866,7 +2866,7 @@ mod tests {
                     ParseContext {
                         cached_headers: &mut None,
                         req_method: &mut None,
-                        h1_parser_config: Default::default(),
+                        h1_parser_config: &Default::default(),
                         h1_max_headers: max_headers,
                         preserve_header_case: false,
                         #[cfg(feature = "ffi")]
@@ -3035,7 +3035,7 @@ mod tests {
                 ParseContext {
                     cached_headers: &mut headers,
                     req_method: &mut None,
-                    h1_parser_config: Default::default(),
+                    h1_parser_config: &Default::default(),
                     h1_max_headers: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
@@ -3080,7 +3080,7 @@ mod tests {
                 ParseContext {
                     cached_headers: &mut headers,
                     req_method: &mut None,
-                    h1_parser_config: Default::default(),
+                    h1_parser_config: &Default::default(),
                     h1_max_headers: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]


### PR DESCRIPTION
**Description:**

`ParseContext` owned a full `ParserConfig` value. Every HTTP/1 parse iteration cloned it from the connection state, even though the config never changes mid-connection.

This PR changes `h1_parser_config` from `ParserConfig` to `&'a ParserConfig`. The clone disappears and the borrow checker guarantees the reference stays valid for the parse call.

**What changed**

- `ParseContext.h1_parser_config`: owned `ParserConfig` → `&'a ParserConfig`
- `conn.rs`: removed `.clone()` when building `ParseContext`
- `io.rs`: same removal in the buffered I/O parse path
- `role.rs`: updated 20 test call sites to pass references

No public API changes, no behavioral changes. All existing tests pass.