### PR TITLE
perf(h1): pre-allocate read buffer instead of starting at zero

### DIFF
--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -68,7 +68,7 @@ where
             io,
             partial_len: None,
             read_blocked: false,
-            read_buf: BytesMut::with_capacity(0),
+            read_buf: BytesMut::with_capacity(INIT_BUFFER_SIZE),
             read_buf_strategy: ReadStrategy::default(),
             write_buf,
         }


### PR DESCRIPTION
**Description:**

The H1 read buffer was created with `BytesMut::with_capacity(0)`. On the first read, the adaptive strategy immediately grows it to `INIT_BUFFER_SIZE` (8192 bytes). The H1 read buffer was created with BytesMut::with_capacity(0). On the first read, the adaptive strategy grows it to INIT_BUFFER_SIZE (8 KiB). By pre-allocating at that size directly, we skip the deferred-growth code path.

This PR initializes the buffer directly at `INIT_BUFFER_SIZE`. One allocation instead of two. The adaptive read strategy still controls growth from there.

**What changed**

- `io.rs` line 71: `BytesMut::with_capacity(0)` → `BytesMut::with_capacity(INIT_BUFFER_SIZE)`

One line, no API changes.
