### PR TITLE
fix(http1): fix reading large bodies on 32-bit systems

### DIFF
--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -152,7 +152,7 @@ impl Decoder {
                 if *remaining == 0 {
                     Poll::Ready(Ok(Frame::data(Bytes::new())))
                 } else {
-                    let to_read = *remaining as usize;
+                    let to_read = usize::try_from(*remaining).unwrap_or(usize::MAX);
                     let buf = ready!(body.read_mem(cx, to_read))?;
                     let num = buf.as_ref().len() as u64;
                     if num > *remaining {
@@ -489,12 +489,7 @@ impl ChunkedState {
         trace!("Chunked read, remaining={:?}", rem);
 
         // cap remaining bytes at the max capacity of usize
-        let rem_cap = match *rem {
-            r if r > usize::MAX as u64 => usize::MAX,
-            r => r as usize,
-        };
-
-        let to_read = rem_cap;
+        let to_read = usize::try_from(*rem).unwrap_or(usize::MAX);
         let slice = ready!(rdr.read_mem(cx, to_read))?;
         let count = slice.len();
 


### PR DESCRIPTION
On 32-bit systems, the cast of the length to read from a u64 to a usize could
truncate, and cause less to be read. If the length was larger than usize::MAX,
the end could not be read.

To fix this, we use a saturating cast pattern instead.

Closes #4055

