### PR TITLE
Add `header_table_size` method to server builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ atomic-waker = { version = "1.1.2", optional = true }
 futures-channel = { version = "0.3", optional = true }
 futures-core = { version = "0.3.31", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
-h2 = { version = "0.4.6", optional = true }
+h2 = { version = "0.4.14", optional = true }
 http-body-util = { version = "0.1", optional = true }
 httparse = { version = "1.9", optional = true }
 httpdate = { version = "1.0", optional = true }

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -53,6 +53,7 @@ pub(crate) struct Config {
     pub(crate) keep_alive_interval: Option<Duration>,
     pub(crate) keep_alive_timeout: Duration,
     pub(crate) max_send_buffer_size: usize,
+    pub(crate) header_table_size: Option<u32>,
     pub(crate) max_header_list_size: u32,
     pub(crate) date_header: bool,
 }
@@ -68,6 +69,7 @@ impl Default for Config {
             max_concurrent_streams: Some(200),
             max_pending_accept_reset_streams: None,
             max_local_error_reset_streams: Some(DEFAULT_MAX_LOCAL_ERROR_RESET_STREAMS),
+            header_table_size: None,
             keep_alive_interval: None,
             keep_alive_timeout: Duration::from_secs(20),
             max_send_buffer_size: DEFAULT_MAX_SEND_BUF_SIZE,
@@ -141,6 +143,9 @@ where
         }
         if let Some(max) = config.max_pending_accept_reset_streams {
             builder.max_pending_accept_reset_streams(max);
+        }
+        if let Some(size) = config.header_table_size {
+            builder.header_table_size(size);
         }
         if config.enable_connect_protocol {
             builder.enable_connect_protocol();

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -260,6 +260,18 @@ impl<E> Builder<E> {
         self
     }
 
+    /// Sets the header table size.
+    ///
+    /// This setting informs the peer of the maximum size of the header compression
+    /// table used to encode header blocks, in octets. The encoder may select any value
+    /// equal to or less than the header table size specified by the sender.
+    ///
+    /// The default value of crate `h2` is 4,096.
+    pub fn header_table_size(&mut self, size: impl Into<Option<u32>>) -> &mut Self {
+        self.h2_builder.header_table_size = size.into();
+        self
+    }
+
     /// Sets the max size of received header frames.
     ///
     /// Default is currently 16KB, but can change.


### PR DESCRIPTION
Following up on: https://github.com/hyperium/h2/pull/888

I want to expose this to `tonic`. This is part 2/4. Next up is `hyper-util`, and then `tonic` itself.
