### PR TITLE
docs(client): document Drop behavior for Connection types

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -50,6 +50,13 @@ pub struct Parts<T> {
 /// can process incoming and outgoing messages, notice hangups, and the like.
 ///
 /// Instances of this type are typically created via the [`handshake`] function
+///
+/// # Drop behavior
+///
+/// Dropping the `Connection` will close the underlying IO resource.
+/// Any in-flight requests that have not received a response will be
+/// interrupted. If graceful shutdown is desired, poll the connection
+/// until it completes instead of dropping.
 #[must_use = "futures do nothing unless polled"]
 pub struct Connection<T, B>
 where

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -39,6 +39,13 @@ impl<B> Clone for SendRequest<B> {
 /// can process incoming and outgoing messages, notice hangups, and the like.
 ///
 /// Instances of this type are typically created via the [`handshake`] function
+///
+/// # Drop behavior
+///
+/// Dropping the `Connection` will close the underlying IO resource.
+/// Any in-flight requests that have not received a response will be
+/// interrupted. If graceful shutdown is desired, poll the connection
+/// until it completes instead of dropping.
 #[must_use = "futures do nothing unless polled"]
 pub struct Connection<T, B, E>
 where


### PR DESCRIPTION
## Summary

Adds documentation for the Drop behavior of Connection types in both http1 and http2 client connection modules.

Currently, the docs explain that Connection should be polled, but do not mention what happens if it is dropped. This PR clarifies that dropping the Connection closes the underlying IO resource and interrupts in-flight requests.

Closes #3192

## Changes

- Added Drop behavior section to http1::Connection doc comments
- Added Drop behavior section to http2::Connection doc comments