### PR TITLE
chore(rt): preserve executor caller locations

### DIFF
--- a/src/rt/bounds.rs
+++ b/src/rt/bounds.rs
@@ -18,6 +18,7 @@ mod h2_common {
 
     pub trait Http2UpgradedExec<B> {
         #[doc(hidden)]
+        #[track_caller]
         fn execute_upgrade(&self, fut: UpgradedSendStreamTask<B>);
     }
 
@@ -26,6 +27,7 @@ mod h2_common {
     where
         E: Executor<UpgradedSendStreamTask<B>>,
     {
+        #[track_caller]
         fn execute_upgrade(&self, fut: UpgradedSendStreamTask<B>) {
             self.execute(fut)
         }
@@ -56,6 +58,7 @@ mod h2_client {
         T: Read + Write + Unpin,
     {
         #[doc(hidden)]
+        #[track_caller]
         fn execute_h2_future(&mut self, future: H2ClientFuture<B, T, Self>);
     }
 
@@ -69,6 +72,7 @@ mod h2_client {
         H2ClientFuture<B, T, E>: Future<Output = ()>,
         T: Read + Write + Unpin,
     {
+        #[track_caller]
         fn execute_h2_future(&mut self, future: H2ClientFuture<B, T, E>) {
             self.execute(future)
         }
@@ -110,6 +114,7 @@ mod h2_server {
         super::Http2UpgradedExec<B::Data> + sealed::Sealed<(F, B)> + Clone
     {
         #[doc(hidden)]
+        #[track_caller]
         fn execute_h2stream(&mut self, fut: H2Stream<F, B, Self>);
     }
 
@@ -122,6 +127,7 @@ mod h2_server {
         H2Stream<F, B, E>: Future<Output = ()>,
         B: Body,
     {
+        #[track_caller]
         fn execute_h2stream(&mut self, fut: H2Stream<F, B, E>) {
             self.execute(fut)
         }

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -44,5 +44,6 @@ pub use self::timer::{Sleep, Timer};
 /// ```
 pub trait Executor<Fut> {
     /// Place the future into the executor to be run.
+    #[track_caller]
     fn execute(&self, fut: Fut);
 }


### PR DESCRIPTION
Tokio task hooks report the source location of the tokio::spawn call. When runtime executor glue performs that spawn, the recorded location can point at the executor implementation itself. That is technically correct, but it hides the more useful callsite: the code path that asked the executor to create background work.

Mark Executor::execute and the HTTP/2 executor forwarding traits with track_caller so task instrumentation can attribute spawned tasks to the caller that requested execution rather than to generic executor forwarding glue.

