### PR TITLE
feat(http2/client): expose reset_stream_duration option

### DIFF
--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -503,6 +503,36 @@ where
         self
     }
 
+    /// Sets the duration to remember locally reset streams.
+    ///
+    /// When a stream is explicitly reset by either the client or the server,
+    /// the HTTP/2 specification requires that any further frames received for
+    /// that stream must be ignored for "some time".
+    ///
+    /// In order to satisfy the specification, internal state must be maintained
+    /// to implement the behavior. This state grows linearly with the number of
+    /// streams that are locally reset.
+    ///
+    /// The `reset_stream_duration` setting configures the max amount of time
+    /// this state will be maintained in memory. Once the duration elapses, the
+    /// stream state is purged from memory.
+    ///
+    /// Once the stream has been fully purged from memory, any additional frames
+    /// received for that stream will result in a connection level protocol
+    /// error, forcing the connection to terminate.
+    ///
+    /// The default value is determined by the `h2` crate, and is currently
+    /// 1 second.
+    ///
+    /// See the documentation of [`h2::client::Builder::reset_stream_duration`] for more
+    /// details.
+    ///
+    /// [`h2::client::Builder::reset_stream_duration`]: https://docs.rs/h2/client/struct.Builder.html#method.reset_stream_duration
+    pub fn reset_stream_duration(&mut self, dur: Duration) -> &mut Self {
+        self.h2_builder.reset_stream_duration = Some(dur);
+        self
+    }
+
     /// Constructs a connection with the configured options and IO.
     /// See [`client::conn`](crate::client::conn) for more.
     ///

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -77,6 +77,7 @@ pub(crate) struct Config {
     pub(crate) max_local_error_reset_streams: Option<usize>,
     pub(crate) header_table_size: Option<u32>,
     pub(crate) max_concurrent_streams: Option<u32>,
+    pub(crate) reset_stream_duration: Option<Duration>,
 }
 
 impl Default for Config {
@@ -97,6 +98,7 @@ impl Default for Config {
             max_local_error_reset_streams: Some(1024),
             header_table_size: None,
             max_concurrent_streams: None,
+            reset_stream_duration: None,
         }
     }
 }
@@ -125,6 +127,9 @@ fn new_builder(config: &Config) -> Builder {
     }
     if let Some(max) = config.max_concurrent_streams {
         builder.max_concurrent_streams(max);
+    }
+    if let Some(dur) = config.reset_stream_duration {
+        builder.reset_stream_duration(dur);
     }
     builder
 }


### PR DESCRIPTION
## Summary
- Expose h2's `reset_stream_duration` setting through the hyper HTTP/2 client builder
- This allows configuring how long reset streams are retained before being evicted, useful for tuning memory usage in high-throughput HTTP/2 connections

Fixes #2599

## Test plan
- Builder method compiles and forwards to the underlying h2 configuration
- Existing HTTP/2 tests pass unchanged