### PR TITLE
docs: document cancel safety for client send_request futures

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -195,6 +195,15 @@ where
     ///
     /// This is however not enforced or validated and it is up to the user
     /// of this method to ensure the `Uri` is correct for their intended purpose.
+    ///
+    /// # Cancel safety
+    ///
+    /// Dropping the returned future is the supported way to cancel an
+    /// in-flight HTTP/1 request. Because HTTP/1 has no in-protocol way to
+    /// abort a single request without affecting the shared connection,
+    /// hyper closes the underlying connection when a request future is
+    /// dropped before completion. Any subsequent calls on the same
+    /// [`SendRequest`] will return a `canceled` error.
     pub fn send_request(
         &mut self,
         req: Request<B>,

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -138,6 +138,15 @@ where
     ///
     /// Absolute-form `Uri`s are not required. If received, they will be serialized
     /// as-is.
+    ///
+    /// # Cancel safety
+    ///
+    /// Dropping the returned future is the supported way to cancel an
+    /// in-flight HTTP/2 request. The stream is reset with `RST_STREAM`
+    /// (`CANCEL` error code); the shared connection remains usable for
+    /// other in-flight and future requests. The peer is notified
+    /// immediately rather than continuing to send a response body that
+    /// would be discarded.
     pub fn send_request(
         &mut self,
         req: Request<B>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,14 @@
 //! If looking for just a convenient HTTP client, consider the
 //! [reqwest](https://crates.io/crates/reqwest) crate.
 //!
+//! # Cancel safety
+//!
+//! Futures returned by hyper are cancel safe: dropping a future before it
+//! completes is the supported way to cancel the operation. See the
+//! documentation on individual futures — for example `SendRequest::send_request`
+//! in `client::conn::http1` and `client::conn::http2` — for the protocol-
+//! specific behavior on cancellation.
+//!
 //! # Optional Features
 //!
 //! hyper uses a set of [feature flags] to reduce the amount of compiled code.


### PR DESCRIPTION
## Summary

Refs #4054. Documents hyper's cancellation behavior on the two client `send_request` futures, plus a small crate-level pointer.

Per seanmonstar's suggestion in the issue:
> ...would it be better to have a small section on the relevant futures about cancellation? Or maybe in combination with a small mention at the crate level, "futures are cancel safe, see individual features for behavior when canceled"

This PR does both.

## Changes

`src/client/conn/http1.rs` — adds `# Cancel safety` to `SendRequest::send_request`:

> Dropping the returned future is the supported way to cancel an in-flight HTTP/1 request. Because HTTP/1 has no in-protocol way to abort a single request without affecting the shared connection, hyper closes the underlying connection when a request future is dropped before completion. Any subsequent calls on the same `SendRequest` will return a `canceled` error.

`src/client/conn/http2.rs` — adds `# Cancel safety` to `SendRequest::send_request`:

> Dropping the returned future is the supported way to cancel an in-flight HTTP/2 request. The stream is reset with `RST_STREAM` (`CANCEL` error code); the shared connection remains usable for other in-flight and future requests. The peer is notified immediately rather than continuing to send a response body that would be discarded.

`src/lib.rs` — brief crate-level mention pointing at the per-future docs.

## Notes

- Plain code spans (no intra-doc links) in the crate-level note to avoid broken-link warnings when `cargo doc` runs without `--features client`.
- Issue author (@jorendorff) said they'd "look into this when I have a chance" 12 days ago — happy to defer or merge this as a starting point. The wording follows the technical content they already laid out in the issue body.
- Scope limited to the client-side cancellation paths the issue author was confident about; server-side behavior left for a follow-up since the issue author noted they hadn't verified it.
