### PR TITLE
docs(lib): fixup markdown and grammar in doc comments

### DIFF
--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -31,7 +31,7 @@ impl DecodedLength {
     /// Takes the length as a content-length without other checks.
     ///
     /// Should only be called if previously confirmed this isn't
-    /// CLOSE_DELIMITED or CHUNKED.
+    /// `CLOSE_DELIMITED` or `CHUNKED`.
     #[inline]
     #[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
     pub(crate) fn danger_len(self) -> u64 {

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -1,4 +1,4 @@
-//! Streaming bodies for Requests and Responses
+//! Streaming bodies for Requests and Responses.
 //!
 //! For both [Clients](crate::client) and [Servers](crate::server), requests and
 //! responses use streaming bodies, instead of complete buffering. This

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -1,4 +1,4 @@
-//! HTTP/1 client connections
+//! HTTP/1 client connections.
 
 use std::error::Error as StdError;
 use std::fmt;
@@ -49,7 +49,7 @@ pub struct Parts<T> {
 /// In most cases, this should just be spawned into an executor, so that it
 /// can process incoming and outgoing messages, notice hangups, and the like.
 ///
-/// Instances of this type are typically created via the [`handshake`] function
+/// Instances of this type are typically created via the [`handshake`] function.
 ///
 /// # Drop behavior
 ///
@@ -157,7 +157,7 @@ impl<B> SendRequest<B> {
         self.dispatch.poll_ready(cx)
     }
 
-    /// Waits until the dispatcher is ready
+    /// Waits until the dispatcher is ready.
     ///
     /// If the associated connection is closed, this returns an Error.
     pub async fn ready(&mut self) -> crate::Result<()> {
@@ -431,11 +431,11 @@ impl Builder {
     /// but may also improve performance when an IO transport doesn't
     /// support vectored writes well, such as most TLS implementations.
     ///
-    /// Setting this to true will force hyper to use queued strategy
-    /// which may eliminate unnecessary cloning on some TLS backends
+    /// Setting this to true will force hyper to use queued strategy,
+    /// which may eliminate unnecessary cloning on some TLS backends.
     ///
     /// Default is `auto`. In this mode hyper will try to guess which
-    /// mode to use
+    /// mode to use.
     pub fn writev(&mut self, enabled: bool) -> &mut Builder {
         self.h1_writev = Some(enabled);
         self

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -1,4 +1,4 @@
-//! HTTP/2 client connections
+//! HTTP/2 client connections.
 
 use std::error::Error;
 use std::fmt;
@@ -38,7 +38,7 @@ impl<B> Clone for SendRequest<B> {
 /// In most cases, this should just be spawned into an executor, so that it
 /// can process incoming and outgoing messages, notice hangups, and the like.
 ///
-/// Instances of this type are typically created via the [`handshake`] function
+/// Instances of this type are typically created via the [`handshake`] function.
 ///
 /// # Drop behavior
 ///
@@ -102,7 +102,7 @@ impl<B> SendRequest<B> {
         }
     }
 
-    /// Waits until the dispatcher is ready
+    /// Waits until the dispatcher is ready.
     ///
     /// If the associated connection is closed, this returns an Error.
     pub async fn ready(&mut self) -> crate::Result<()> {
@@ -327,7 +327,7 @@ where
         self
     }
 
-    /// Sets the max connection-level flow control for HTTP2
+    /// Sets the max connection-level flow control for HTTP2.
     ///
     /// Passing `None` will do nothing.
     ///

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -66,7 +66,7 @@ pub(crate) struct Sender<T, U> {
 /// has been dropped. However, this version can be cloned.
 #[cfg(feature = "http2")]
 pub(crate) struct UnboundedSender<T, U> {
-    /// Only used for `is_closed`, since mpsc::UnboundedSender cannot be checked.
+    /// Only used for `is_closed`, since `mpsc::UnboundedSender` cannot be checked.
     giver: want::SharedGiver,
     inner: mpsc::UnboundedSender<Envelope<T, U>>,
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,4 +1,4 @@
-//! HTTP Client
+//! HTTP Client.
 //!
 //! hyper provides HTTP over a single connection. See the [`conn`] module.
 //!

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,7 +61,7 @@ pub(super) enum Kind {
         any(feature = "http1", feature = "http2")
     ))]
     Io,
-    /// User took too long to send headers
+    /// User took too long to send headers.
     #[cfg(all(feature = "http1", feature = "server"))]
     HeaderTimeout,
     /// Error while reading a body from connection.
@@ -76,7 +76,7 @@ pub(super) enum Kind {
         any(feature = "http1", feature = "http2")
     ))]
     BodyWrite,
-    /// Error calling AsyncWrite::shutdown()
+    /// Error calling `AsyncWrite::shutdown()`.
     #[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
     Shutdown,
 
@@ -119,7 +119,7 @@ pub(super) enum Header {
 
 #[derive(Debug)]
 pub(super) enum User {
-    /// Error calling user's Body::poll_data().
+    /// Error calling the user's `Body::poll_data()`.
     #[cfg(all(
         any(feature = "client", feature = "server"),
         any(feature = "http1", feature = "http2")
@@ -131,7 +131,7 @@ pub(super) enum User {
         feature = "ffi"
     ))]
     BodyWriteAborted,
-    /// User tried to send a connect request with a nonzero body
+    /// User tried to send a connect request with a nonzero body.
     #[cfg(all(feature = "client", feature = "http2"))]
     InvalidConnectWithBody,
     /// Error from future of user's Service.

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -911,7 +911,7 @@ impl<I: Unpin, B, T> Unpin for Conn<I, B, T> {}
 
 struct State {
     allow_half_close: bool,
-    /// Re-usable HeaderMap to reduce allocating new ones.
+    /// Re-usable `HeaderMap` to reduce allocating new ones.
     cached_headers: Option<HeaderMap>,
     /// If an error occurs when there wasn't a direct way to return it
     /// back to the user, this is set.
@@ -948,15 +948,15 @@ struct State {
     /// Set to true when the Dispatcher should poll read operations
     /// again. See the `maybe_notify` method for more.
     notify_read: bool,
-    /// State of allowed reads
+    /// State of allowed reads.
     reading: Reading,
-    /// State of allowed writes
+    /// State of allowed writes.
     writing: Writing,
     /// An expected pending HTTP upgrade.
     upgrade: Option<crate::upgrade::Pending>,
-    /// Either HTTP/1.0 or 1.1 connection
+    /// Either HTTP/1.0 or 1.1 connection.
     version: Version,
-    /// Flag to track if trailer fields are allowed to be sent
+    /// Flag to track if trailer fields are allowed to be sent.
     allow_trailer_fields: bool,
 }
 

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -21,7 +21,7 @@ const CHUNKED_EXTENSIONS_LIMIT: u64 = 1024 * 16;
 
 /// Maximum number of bytes allowed for all trailer fields.
 ///
-/// TODO: remove this when we land h1_max_header_size support
+/// TODO: remove this when we land `h1_max_header_size` support.
 const TRAILER_LIMIT: usize = 1024 * 16;
 
 /// Decoders to handle different Transfer-Encodings.

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -457,7 +457,8 @@ where
         self.conn.close_write();
     }
 
-    /// If there is pending data in body_rx, we can make progress writing if the connection is ready.
+    /// If there is pending data in `body_rx`, we can make progress writing if the connection is
+    /// ready.
     fn can_write_again(&mut self) -> bool {
         self.body_rx.is_some()
     }

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -508,10 +508,10 @@ impl<T: AsRef<[u8]>> Buf for Cursor<T> {
 
 // an internal buffer to collect writes before flushes
 pub(super) struct WriteBuf<B> {
-    /// Re-usable buffer that holds message headers
+    /// Re-usable buffer that holds message headers.
     headers: Cursor<Vec<u8>>,
     max_buf_size: usize,
-    /// Deque of user buffers if strategy is Queue
+    /// Deque of user buffers if strategy is `Queue`.
     queue: BufList<B>,
     strategy: WriteStrategy,
 }

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -56,7 +56,7 @@ pub(crate) trait Http1Transaction {
     fn update_date() {}
 }
 
-/// Result newtype for Http1Transaction::parse.
+/// Result newtype for `Http1Transaction::parse`.
 pub(crate) type ParseResult<T> = Result<Option<ParsedMessage<T>>, crate::error::Parse>;
 
 #[derive(Debug)]
@@ -81,7 +81,7 @@ pub(crate) struct ParseContext<'a> {
     on_informational: &'a mut Option<crate::ext::OnInformational>,
 }
 
-/// Passed to Http1Transaction::encode
+/// Passed to `Http1Transaction::encode`.
 pub(crate) struct Encode<'a, T> {
     head: &'a mut MessageHead<T>,
     body: Option<BodyLength>,

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1241,9 +1241,9 @@ impl Http1Transaction for Client {
 
 #[cfg(feature = "client")]
 impl Client {
-    /// Returns Some(length, wants_upgrade) if successful.
+    /// Returns `Some(length, wants_upgrade)` if successful.
     ///
-    /// Returns None if this message head should be skipped (like a 100 status).
+    /// Returns `None` if this message head should be skipped (like a 100 status).
     fn decoder(
         inc: &MessageHead<StatusCode>,
         method: &mut Option<Method>,

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -595,7 +595,7 @@ pin_project! {
 }
 
 impl<B: Body + 'static, E> ResponseFutMap<B, E> {
-    /// Signal the pipe_task to reset the stream (e.g. on client cancellation).
+    /// Signal the `pipe_task` to reset the stream (e.g. on client cancellation).
     pub(crate) fn cancel(self: Pin<&mut Self>) {
         if let Some(cancel_tx) = self.project().cancel_tx.take() {
             let _ = cancel_tx.send(());

--- a/src/proto/h2/ping.rs
+++ b/src/proto/h2/ping.rs
@@ -1,4 +1,4 @@
-//! HTTP2 Ping usage
+//! HTTP2 Ping usage.
 //!
 //! hyper uses HTTP2 pings for two purposes:
 //!
@@ -138,11 +138,11 @@ struct Shared {
 }
 
 struct Bdp {
-    /// Current BDP in bytes
+    /// Current BDP in bytes.
     bdp: u32,
     /// Largest bandwidth we've seen so far.
     max_bandwidth: f64,
-    /// Round trip time in seconds
+    /// Round trip time in seconds.
     rtt: f64,
     /// Delay the next ping by this amount.
     ///

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -45,9 +45,9 @@ pub(crate) type ResponseHead = MessageHead<http::StatusCode>;
 #[derive(Debug)]
 #[cfg(feature = "http1")]
 pub(crate) enum BodyLength {
-    /// Content-Length
+    /// `Content-Length`.
     Known(u64),
-    /// Transfer-Encoding: chunked (if h1)
+    /// `Transfer-Encoding: chunked` (if h1).
     Unknown,
 }
 

--- a/src/rt/bounds.rs
+++ b/src/rt/bounds.rs
@@ -1,6 +1,6 @@
-//! Trait aliases
+//! Trait aliases.
 //!
-//! Traits in this module ease setting bounds and usually automatically
+//! Traits in this module ease setting bounds and are usually automatically
 //! implemented by implementing another trait.
 
 #[cfg(all(feature = "client", feature = "http2"))]

--- a/src/rt/io.rs
+++ b/src/rt/io.rs
@@ -346,7 +346,7 @@ impl ReadBufCursor<'_> {
     /// Returns the number of bytes that can be written from the current
     /// position until the end of the buffer is reached.
     ///
-    /// This value is equal to the length of the slice returned by `as_mut()``.
+    /// This value is equal to the length of the slice returned by `as_mut()`.
     #[inline]
     pub fn remaining(&self) -> usize {
         self.buf.remaining()
@@ -495,8 +495,8 @@ where
     }
 }
 
-/// Polyfill for Pin::as_deref_mut()
-/// TODO: use Pin::as_deref_mut() instead once stabilized
+/// Polyfill for `Pin::as_deref_mut()`.
+/// TODO: use `Pin::as_deref_mut()` instead once stabilized.
 fn pin_as_deref_mut<P: DerefMut>(pin: Pin<&mut Pin<P>>) -> Pin<&mut P::Target> {
     // SAFETY: we go directly from Pin<&mut Pin<P>> to Pin<&mut P::Target>, without moving or
     // giving out the &mut Pin<P> in the process. See Pin::as_deref_mut() for more detail.

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -1,4 +1,4 @@
-//! Runtime components
+//! Runtime components.
 //!
 //! This module provides traits and types that allow hyper to be runtime-agnostic.
 //! By abstracting over async runtimes, hyper can work with different executors, timers, and IO transports.

--- a/src/rt/timer.rs
+++ b/src/rt/timer.rs
@@ -1,4 +1,4 @@
-//! Provides a timer trait with timer-like functions
+//! Provides a timer trait with timer-like functions.
 //!
 //! Example using tokio timer:
 //! ```rust
@@ -90,7 +90,7 @@ pub trait Timer {
 /// A future returned by a `Timer`.
 pub trait Sleep: Send + Sync + Future<Output = ()> {
     #[doc(hidden)]
-    /// This method is private and can not be implemented by downstream crate
+    /// This method is private and can not be implemented by downstream crates.
     fn __type_id(&self, _: private::Sealed) -> TypeId
     where
         Self: 'static,
@@ -100,9 +100,9 @@ pub trait Sleep: Send + Sync + Future<Output = ()> {
 }
 
 impl dyn Sleep {
-    //! This is a re-implementation of downcast methods from std::any::Any
+    // This is a re-implementation of downcast methods from `std::any::Any`.
 
-    /// Check whether the type is the same as `T`
+    /// Check whether the type is the same as `T`.
     pub fn is<T>(&self) -> bool
     where
         T: Sleep + 'static,
@@ -110,7 +110,7 @@ impl dyn Sleep {
         self.__type_id(private::Sealed {}) == TypeId::of::<T>()
     }
 
-    /// Downcast a pinned &mut Sleep object to its original type
+    /// Downcast a pinned `&mut Sleep` object to its original type.
     pub fn downcast_mut_pin<T>(self: Pin<&mut Self>) -> Option<Pin<&mut T>>
     where
         T: Sleep + 'static,

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -1,4 +1,4 @@
-//! HTTP/1 Server Connections
+//! HTTP/1 Server Connections.
 
 use std::error::Error as StdError;
 use std::fmt;
@@ -360,11 +360,11 @@ impl Builder {
     /// but may also improve performance when an IO transport doesn't
     /// support vectored writes well, such as most TLS implementations.
     ///
-    /// Setting this to true will force hyper to use queued strategy
-    /// which may eliminate unnecessary cloning on some TLS backends
+    /// Setting this to true will force hyper to use queued strategy,
+    /// which may eliminate unnecessary cloning on some TLS backends.
     ///
     /// Default is `auto`. In this mode hyper will try to guess which
-    /// mode to use
+    /// mode to use.
     pub fn writev(&mut self, val: bool) -> &mut Self {
         self.h1_writev = Some(val);
         self

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -1,4 +1,4 @@
-//! HTTP/2 Server Connections
+//! HTTP/2 Server Connections.
 
 use std::error::Error as StdError;
 use std::fmt;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,4 +1,4 @@
-//! HTTP Server
+//! HTTP Server.
 //!
 //! A "server" is usually created by listening on a port for new connections,
 //! parse HTTP requests, and hand them off to a `Service`.

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1,4 +1,4 @@
-//! Asynchronous Services
+//! Asynchronous Services.
 //!
 //! A [`Service`] is a trait representing an asynchronous
 //! function of a request to a response. It's similar to
@@ -11,7 +11,7 @@
 //! - `HttpService`: This is blanketly implemented for all types that
 //!   implement `Service<http::Request<B1>, Response = http::Response<B2>>`.
 //!
-//! # HttpService
+//! # `HttpService`
 //!
 //! In hyper, especially in the server setting, a `Service` is usually bound
 //! to a single connection. It defines how to respond to **all** requests that

--- a/src/service/service.rs
+++ b/src/service/service.rs
@@ -37,7 +37,7 @@ pub trait Service<Request> {
     ///
     /// Note: Returning an `Error` to a hyper server, the behavior depends on the
     /// protocol. In most cases, hyper will cause the connection to be abruptly aborted.
-    /// It will abort the request however the protocol allows, either with some sort of RST_STREAM,
+    /// It will abort the request however the protocol allows, either with some sort of `RST_STREAM`,
     /// or killing the connection if that doesn't exist.
     type Error;
 

--- a/src/service/util.rs
+++ b/src/service/util.rs
@@ -38,7 +38,7 @@ where
     }
 }
 
-/// Service returned by [`service_fn`]
+/// Service returned by [`service_fn`].
 pub struct ServiceFn<F, R> {
     f: F,
     _req: PhantomData<fn(R)>,

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,4 +1,4 @@
-//! HTTP Upgrades
+//! HTTP Upgrades.
 //!
 //! This module deals with managing [HTTP Upgrades][mdn] in hyper. Since
 //! several concepts in HTTP allow for first talking HTTP, and then converting


### PR DESCRIPTION
cc #4071 