### PR TITLE
Fix manual_assert lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,6 @@ integer_division = "allow"
 integer_division_remainder_used = "allow"
 large_enum_variant = "allow"
 let_unit_value = "allow"
-manual_assert = "allow" # TODO: easy fix
 manual_assert_eq = "allow" # TODO: easy fix
 map_err_ignore = "allow"
 map_unwrap_or = "allow"

--- a/src/ext/h1_reason_phrase.rs
+++ b/src/ext/h1_reason_phrase.rs
@@ -42,9 +42,10 @@ impl ReasonPhrase {
     /// Converts a static byte slice to a reason phrase.
     pub const fn from_static(reason: &'static [u8]) -> Self {
         // TODO: this can be made const once MSRV is >= 1.57.0
-        if find_invalid_byte(reason).is_some() {
-            panic!("invalid byte in static reason phrase");
-        }
+        assert!(
+            find_invalid_byte(reason).is_none(),
+            "invalid byte in static reason phrase"
+        );
         Self(Bytes::from_static(reason))
     }
 


### PR DESCRIPTION
As per #4071 fix instances where the manual_assert lint triggered on the code. This was able to be done with a `clippy --fix` with further cleanup to change `!<expr>.is_some()` in the assert to `<expr>.is_none()`.

