### PR TITLE
Removing wildcard_imports lint allowance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,6 @@ unused_trait_names = "allow" # TODO: kinda annoying, but might be good to deny
 unwrap_in_result = "allow"
 useless_borrows_in_formatting = "allow"
 wildcard_enum_match_arm = "allow"
-wildcard_imports = "allow" # TODO: never, except for tests
 
 # explicitly allowed
 absolute_paths = "allow" # sometimes its cleaner

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -591,10 +591,11 @@ impl Builder {
 }
 
 mod upgrades {
+    use super::{Connection, Context, Future, Parts, Pin, Poll, Read, StdError, Write};
+    use crate::body::Body;
+    use crate::proto::Dispatched;
     use crate::upgrade::Upgraded;
-
-    use super::*;
-
+    use futures_core::ready;
     // A future binding a connection with a Service with Upgrade support.
     //
     // This type is unnameable outside the crate.
@@ -628,8 +629,8 @@ mod upgrades {
             )
             .poll(cx))
             {
-                Ok(proto::Dispatched::Shutdown) => Poll::Ready(Ok(())),
-                Ok(proto::Dispatched::Upgrade(pending)) => {
+                Ok(Dispatched::Shutdown) => Poll::Ready(Ok(())),
+                Ok(Dispatched::Upgrade(pending)) => {
                     let Parts { io, read_buf } = self
                         .inner
                         .take()


### PR DESCRIPTION
The wildcard_imports used in http1.rs is replaced with explict type imports. This is related to #4071 .

