### PR TITLE
Fix the borrow_as_ptr lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,6 @@ restriction = { level = "warn", priority = -2 }
 
 arithmetic_side_effects = "allow" # TODO: consider
 as_conversions = "allow" # TODO: tricky
-borrow_as_ptr = "allow"
 cast_possible_truncation = "allow" # TODO: consider
 cast_precision_loss = "allow" # TODO: consider
 checked_conversions = "allow"

--- a/src/rt/io.rs
+++ b/src/rt/io.rs
@@ -258,7 +258,7 @@ impl<'data> ReadBuf<'data> {
     #[inline]
     pub fn filled(&self) -> &[u8] {
         // SAFETY: We only slice the filled part of the buffer, which is always valid
-        unsafe { &*(&self.raw[0..self.filled] as *const [MaybeUninit<u8>] as *const [u8]) }
+        unsafe { &*(std::ptr::addr_of!(self.raw[0..self.filled]) as *const [u8]) }
     }
 
     /// Get a cursor to the unfilled portion of the buffer.


### PR DESCRIPTION
I was hoping this one might be meatier than the last one I tried but nope another `cargo clippy --fix` seemingly sorted it :sweat_smile: 

Part of #4071