### PR TITLE
removing `empty_structs_with_brackets` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,6 @@ collapsible_match = "allow"
 decimal_literal_representation = "allow" # TODO: consider
 default_trait_access = "allow"
 else_if_without_else = "allow"
-empty_structs_with_brackets = "allow" # TODO: easy fix
 enum_glob_use = "allow"
 explicit_iter_loop = "allow" # TODO: easy fix
 float_arithmetic = "allow"

--- a/src/rt/timer.rs
+++ b/src/rt/timer.rs
@@ -107,7 +107,7 @@ impl dyn Sleep {
     where
         T: Sleep + 'static,
     {
-        self.__type_id(private::Sealed {}) == TypeId::of::<T>()
+        self.__type_id(private::Sealed) == TypeId::of::<T>()
     }
 
     /// Downcast a pinned `&mut Sleep` object to its original type.
@@ -130,5 +130,5 @@ impl dyn Sleep {
 
 mod private {
     #![allow(missing_debug_implementations)]
-    pub struct Sealed {}
+    pub struct Sealed;
 }


### PR DESCRIPTION
https://github.com/hyperium/hyper/issues/4071

removing `empty_structs_with_brackets` lint, seems like the back ticks don't work well in commit messages