### PR TITLE
Fix the ptr_as_ptr lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,6 @@ needless_continue = "allow"
 needless_pass_by_value = "allow"
 panic = "allow"
 pattern_type_mismatch = "allow"
-ptr_as_ptr = "allow"
 question_mark = "allow" # TODO: probably easy fix
 redundant_closure_for_method_calls = "allow"
 redundant_else = "allow"

--- a/src/ffi/io.rs
+++ b/src/ffi/io.rs
@@ -147,7 +147,7 @@ impl Read for hyper_io {
         cx: &mut Context<'_>,
         mut buf: crate::rt::ReadBufCursor<'_>,
     ) -> Poll<std::io::Result<()>> {
-        let buf_ptr = unsafe { buf.as_mut() }.as_mut_ptr() as *mut u8;
+        let buf_ptr = unsafe { buf.as_mut() }.as_mut_ptr().cast::<u8>();
         let buf_len = buf.remaining();
 
         match (self.read)(self.userdata, hyper_context::wrap(cx), buf_ptr, buf_len) {

--- a/src/ffi/task.rs
+++ b/src/ffi/task.rs
@@ -415,7 +415,7 @@ ffi_fn! {
         let task = non_null!(&mut *task ?= ptr::null_mut());
 
         if let Some(val) = task.output.take() {
-            let p = Box::into_raw(val) as *mut c_void;
+            let p = Box::into_raw(val).cast();
             // protect from returning fake pointers to empty types
             if p == std::ptr::NonNull::<c_void>::dangling().as_ptr() {
                 ptr::null_mut()

--- a/src/rt/timer.rs
+++ b/src/rt/timer.rs
@@ -119,7 +119,7 @@ impl dyn Sleep {
             unsafe {
                 let inner = Pin::into_inner_unchecked(self);
                 Some(Pin::new_unchecked(
-                    &mut *(&mut *inner as *mut dyn Sleep as *mut T),
+                    &mut *(&mut *inner as *mut dyn Sleep).cast(),
                 ))
             }
         } else {

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -307,7 +307,7 @@ impl dyn Io + Send {
             // Taken from `std::error::Error::downcast()`.
             unsafe {
                 let raw: *mut dyn Io = Box::into_raw(self);
-                Ok(Box::from_raw(raw as *mut T))
+                Ok(Box::from_raw(raw.cast()))
             }
         } else {
             Err(self)


### PR DESCRIPTION
Removing `clippy::ptr_as_ptr` lint.
Replacing raw pointer casting via `as` with `.cast()`.

## Related Issue
Fixes #4071

---

This is my first PR to an open-source project!  
I hope everything is correct, but if there are any mistakes or things I should improve, please let me know.  
 Any feedback would be greatly appreciated! 🙏