### PR TITLE
style(http2): use an enum instead of bool in strip_connection_headers()

### DIFF
--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -706,7 +706,7 @@ where
                     }
                     let (head, body) = req.into_parts();
                     let mut req = ::http::Request::from_parts(head, ());
-                    super::strip_connection_headers(req.headers_mut(), true);
+                    super::strip_connection_headers(req.headers_mut(), super::MessageKind::Request);
                     if let Some(len) = body.size_hint().exact() {
                         if len != 0 || headers::method_has_defined_payload_semantics(req.method()) {
                             headers::set_content_length_if_missing(req.headers_mut(), len);

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -7,7 +7,7 @@ use std::task::{Context, Poll};
 use bytes::Buf;
 use futures_core::ready;
 use h2::SendStream;
-use http::header::{HeaderName, CONNECTION, TE, TRANSFER_ENCODING, UPGRADE};
+use http::header::{HeaderName, CONNECTION, TRANSFER_ENCODING, UPGRADE};
 use http::HeaderMap;
 use pin_project_lite::pin_project;
 
@@ -40,22 +40,32 @@ static CONNECTION_HEADERS: [HeaderName; 4] = [
     UPGRADE,
 ];
 
-fn strip_connection_headers(headers: &mut HeaderMap, is_request: bool) {
+enum MessageKind {
+    #[cfg(feature = "client")]
+    Request,
+    #[cfg(feature = "server")]
+    Response,
+}
+
+fn strip_connection_headers(headers: &mut HeaderMap, kind: MessageKind) {
     for header in &CONNECTION_HEADERS {
         if headers.remove(header).is_some() {
             warn!("Connection header illegal in HTTP/2: {}", header.as_str());
         }
     }
 
-    if is_request {
+    #[cfg(not(feature = "client"))]
+    let _ = kind;
+    #[cfg(feature = "client")]
+    if matches!(kind, MessageKind::Request) {
         if headers
-            .get(TE)
+            .get(http::header::TE)
             .map_or(false, |te_header| te_header != "trailers")
         {
             warn!("TE headers not set to \"trailers\" are illegal in HTTP/2 requests");
-            headers.remove(TE);
+            headers.remove(http::header::TE);
         }
-    } else if headers.remove(TE).is_some() {
+    } else if headers.remove(http::header::TE).is_some() {
         warn!("TE headers illegal in HTTP/2 responses");
     }
 

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -473,7 +473,10 @@ where
 
                     let (head, body) = res.into_parts();
                     let mut res = ::http::Response::from_parts(head, ());
-                    super::strip_connection_headers(res.headers_mut(), false);
+                    super::strip_connection_headers(
+                        res.headers_mut(),
+                        super::MessageKind::Response,
+                    );
 
                     // set Date header if it isn't already set if instructed
                     if *me.date_header {


### PR DESCRIPTION
Found this `is_request: bool` parameter which I hate. What does `strip_headers(headers, true)` mean? Hard to know with just a boolean. Make it an enum.