### PR TITLE
refactor(client): Typed futures for `SendRequest`

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -3,7 +3,6 @@
 use std::error::Error as StdError;
 use std::fmt;
 use std::future::Future;
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -212,15 +211,12 @@ where
     /// hyper closes the underlying connection when a request future is
     /// dropped before completion. Any subsequent calls on the same
     /// [`SendRequest`] will return a `canceled` error.
-    pub fn send_request(&mut self, req: Request<B>) -> SendFut<B> {
+    pub fn send_request(&mut self, req: Request<B>) -> SendFut {
         let state = match self.dispatch.send(req) {
             Ok(rx) => SendFutState::Fut { rx },
             Err(_) => SendFutState::Err,
         };
-        SendFut {
-            state,
-            body: PhantomData,
-        }
+        SendFut { state }
     }
 
     /// Sends a `Request` on the associated connection.
@@ -255,21 +251,17 @@ enum SendFutState {
 
 /// Future returned by [`SendRequest::send_request`], see the method definition
 /// for more details.
-pub struct SendFut<B> {
+pub struct SendFut {
     state: SendFutState,
-    body: PhantomData<B>,
 }
 
-impl<B> fmt::Debug for SendFut<B> {
+impl fmt::Debug for SendFut {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SendFut").finish()
     }
 }
 
-// `SendFut` never structurally pins any of its fields
-impl<B> Unpin for SendFut<B> {}
-
-impl<B> Future for SendFut<B> {
+impl Future for SendFut {
     type Output = crate::Result<Response<IncomingBody>>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use futures_core::ready;
 use http::{Request, Response};
 use httparse::ParserConfig;
+use tokio::sync::oneshot::Receiver;
 
 use super::super::dispatch::{self, TrySendError};
 use crate::body::{Body, Incoming as IncomingBody};
@@ -210,26 +211,12 @@ where
     /// hyper closes the underlying connection when a request future is
     /// dropped before completion. Any subsequent calls on the same
     /// [`SendRequest`] will return a `canceled` error.
-    pub fn send_request(
-        &mut self,
-        req: Request<B>,
-    ) -> impl Future<Output = crate::Result<Response<IncomingBody>>> {
-        let sent = self.dispatch.send(req);
-
-        async move {
-            match sent {
-                Ok(rx) => match rx.await {
-                    Ok(Ok(resp)) => Ok(resp),
-                    Ok(Err(err)) => Err(err),
-                    // this is definite bug if it happens, but it shouldn't happen!
-                    Err(_canceled) => panic!("dispatch dropped without returning error"),
-                },
-                Err(_req) => {
-                    debug!("connection was not ready");
-                    Err(crate::Error::new_canceled().with("connection was not ready"))
-                }
-            }
-        }
+    pub fn send_request(&mut self, req: Request<B>) -> SendFut<B> {
+        let state = match self.dispatch.send(req) {
+            Ok(rx) => SendFutState::Fut { rx },
+            Err(req) => SendFutState::Err { req },
+        };
+        SendFut { state }
     }
 
     /// Sends a `Request` on the associated connection.
@@ -240,35 +227,109 @@ where
     ///
     /// If there was an error before trying to serialize the request to the
     /// connection, the message will be returned as part of this error.
-    pub fn try_send_request(
-        &mut self,
-        req: Request<B>,
-    ) -> impl Future<Output = Result<Response<IncomingBody>, TrySendError<Request<B>>>> {
-        let sent = self.dispatch.try_send(req);
-        async move {
-            match sent {
-                Ok(rx) => match rx.await {
-                    Ok(Ok(res)) => Ok(res),
-                    Ok(Err(err)) => Err(err),
-                    // this is definite bug if it happens, but it shouldn't happen!
-                    Err(_) => panic!("dispatch dropped without returning error"),
-                },
-                Err(req) => {
-                    debug!("connection was not ready");
-                    let error = crate::Error::new_canceled().with("connection was not ready");
-                    Err(TrySendError {
-                        error,
-                        message: Some(req),
-                    })
-                }
-            }
-        }
+    pub fn try_send_request(&mut self, req: Request<B>) -> TrySendFut<B> {
+        let state = match self.dispatch.try_send(req) {
+            Ok(rx) => TrySendFutState::Fut { rx },
+            Err(req) => TrySendFutState::Err { req: Some(req) },
+        };
+        TrySendFut { state }
     }
 }
 
 impl<B> fmt::Debug for SendRequest<B> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SendRequest").finish()
+    }
+}
+
+enum SendFutState<B> {
+    Fut {
+        rx: Receiver<crate::Result<Response<IncomingBody>>>,
+    },
+    Err {
+        req: Request<B>,
+    },
+}
+
+/// Future returned by [`SendRequest::send_request`], see the method definition
+/// for more details.
+pub struct SendFut<B> {
+    state: SendFutState<B>,
+}
+
+impl<B> fmt::Debug for SendFut<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SendFut").finish()
+    }
+}
+
+// `SendFut` never structurally pins any of its fields
+impl<B> Unpin for SendFut<B> {}
+
+impl<B> Future for SendFut<B> {
+    type Output = crate::Result<Response<IncomingBody>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let res = match &mut self.state {
+            SendFutState::Fut { rx } => match ready!(Pin::new(rx).poll(cx)) {
+                Ok(Ok(resp)) => Ok(resp),
+                Ok(Err(err)) => Err(err),
+                // this is definite bug if it happens, but it shouldn't happen!
+                Err(_) => panic!("dispatch dropped without returning error"),
+            },
+            SendFutState::Err { req: _req } => {
+                debug!("connection was not ready");
+                Err(crate::Error::new_canceled().with("connection was not ready"))
+            }
+        };
+        Poll::Ready(res)
+    }
+}
+
+enum TrySendFutState<B> {
+    Fut {
+        rx: Receiver<Result<Response<IncomingBody>, TrySendError<Request<B>>>>,
+    },
+    Err {
+        req: Option<Request<B>>,
+    },
+}
+
+/// Future returned by [`SendRequest::try_send_request`], see the method
+/// definition for more details.
+pub struct TrySendFut<B> {
+    state: TrySendFutState<B>,
+}
+
+impl<B> fmt::Debug for TrySendFut<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TrySendFut").finish()
+    }
+}
+
+// `TrySendFut` never structurally pins any of its fields
+impl<B> Unpin for TrySendFut<B> {}
+
+impl<B> Future for TrySendFut<B> {
+    type Output = Result<Response<IncomingBody>, TrySendError<Request<B>>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let res = match &mut self.state {
+            TrySendFutState::Fut { rx } => match ready!(Pin::new(rx).poll(cx)) {
+                Ok(Ok(resp)) => Ok(resp),
+                Ok(Err(err)) => Err(err),
+                // this is definite bug if it happens, but it shouldn't happen!
+                Err(_) => panic!("dispatch dropped without returning error"),
+            },
+            TrySendFutState::Err { req } => {
+                debug!("connection was not ready");
+                Err(TrySendError {
+                    error: crate::Error::new_canceled().with("connection was not ready"),
+                    message: Some(req.take().expect("future already resolved")),
+                })
+            }
+        };
+        Poll::Ready(res)
     }
 }
 

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -230,7 +230,9 @@ where
     pub fn try_send_request(&mut self, req: Request<B>) -> TrySendFut<B> {
         let state = match self.dispatch.try_send(req) {
             Ok(rx) => TrySendFutState::Fut { rx },
-            Err(req) => TrySendFutState::Err { req: Some(req) },
+            Err(req) => TrySendFutState::Err {
+                req: Box::new(Some(req)),
+            },
         };
         TrySendFut { state }
     }
@@ -286,7 +288,7 @@ enum TrySendFutState<B> {
         rx: Receiver<Result<Response<IncomingBody>, TrySendError<Request<B>>>>,
     },
     Err {
-        req: Option<Request<B>>,
+        req: Box<Option<Request<B>>>,
     },
 }
 
@@ -301,9 +303,6 @@ impl<B> fmt::Debug for TrySendFut<B> {
         f.debug_struct("TrySendFut").finish()
     }
 }
-
-// `TrySendFut` never structurally pins any of its fields
-impl<B> Unpin for TrySendFut<B> {}
 
 impl<B> Future for TrySendFut<B> {
     type Output = Result<Response<IncomingBody>, TrySendError<Request<B>>>;

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -3,6 +3,7 @@
 use std::error::Error as StdError;
 use std::fmt;
 use std::future::Future;
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -214,9 +215,12 @@ where
     pub fn send_request(&mut self, req: Request<B>) -> SendFut<B> {
         let state = match self.dispatch.send(req) {
             Ok(rx) => SendFutState::Fut { rx },
-            Err(req) => SendFutState::Err { req },
+            Err(_) => SendFutState::Err,
         };
-        SendFut { state }
+        SendFut {
+            state,
+            body: PhantomData,
+        }
     }
 
     /// Sends a `Request` on the associated connection.
@@ -242,19 +246,18 @@ impl<B> fmt::Debug for SendRequest<B> {
     }
 }
 
-enum SendFutState<B> {
+enum SendFutState {
     Fut {
         rx: Receiver<crate::Result<Response<IncomingBody>>>,
     },
-    Err {
-        req: Request<B>,
-    },
+    Err,
 }
 
 /// Future returned by [`SendRequest::send_request`], see the method definition
 /// for more details.
 pub struct SendFut<B> {
-    state: SendFutState<B>,
+    state: SendFutState,
+    body: PhantomData<B>,
 }
 
 impl<B> fmt::Debug for SendFut<B> {
@@ -277,7 +280,7 @@ impl<B> Future for SendFut<B> {
                 // this is definite bug if it happens, but it shouldn't happen!
                 Err(_) => panic!("dispatch dropped without returning error"),
             },
-            SendFutState::Err { req: _req } => {
+            SendFutState::Err => {
                 debug!("connection was not ready");
                 Err(crate::Error::new_canceled().with("connection was not ready"))
             }

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -151,9 +151,12 @@ where
     pub fn send_request(&mut self, req: Request<B>) -> SendFut<B> {
         let state = match self.dispatch.send(req) {
             Ok(rx) => SendFutState::Fut { rx },
-            Err(req) => SendFutState::Err { req },
+            Err(_) => SendFutState::Err,
         };
-        SendFut { state }
+        SendFut {
+            state,
+            body: PhantomData,
+        }
     }
 
     /// Sends a `Request` on the associated connection.
@@ -179,19 +182,18 @@ impl<B> fmt::Debug for SendRequest<B> {
     }
 }
 
-enum SendFutState<B> {
+enum SendFutState {
     Fut {
         rx: Receiver<crate::Result<Response<IncomingBody>>>,
     },
-    Err {
-        req: Request<B>,
-    },
+    Err,
 }
 
 /// Future returned by [`SendRequest::send_request`], see the method definition
 /// for more details.
 pub struct SendFut<B> {
-    state: SendFutState<B>,
+    state: SendFutState,
+    body: PhantomData<B>,
 }
 
 impl<B> fmt::Debug for SendFut<B> {
@@ -214,7 +216,7 @@ impl<B> Future for SendFut<B> {
                 // this is definite bug if it happens, but it shouldn't happen!
                 Err(_) => panic!("dispatch dropped without returning error"),
             },
-            SendFutState::Err { req: _req } => {
+            SendFutState::Err => {
                 debug!("connection was not ready");
                 Err(crate::Error::new_canceled().with("connection was not ready"))
             }

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -167,7 +167,9 @@ where
     pub fn try_send_request(&mut self, req: Request<B>) -> TrySendFut<B> {
         let state = match self.dispatch.try_send(req) {
             Ok(rx) => TrySendFutState::Fut { rx },
-            Err(req) => TrySendFutState::Err { req: Some(req) },
+            Err(req) => TrySendFutState::Err {
+                req: Box::new(Some(req)),
+            },
         };
         TrySendFut { state }
     }
@@ -223,7 +225,7 @@ enum TrySendFutState<B> {
         rx: Receiver<Result<Response<IncomingBody>, TrySendError<Request<B>>>>,
     },
     Err {
-        req: Option<Request<B>>,
+        req: Box<Option<Request<B>>>,
     },
 }
 
@@ -238,9 +240,6 @@ impl<B> fmt::Debug for TrySendFut<B> {
         f.debug_struct("TrySendFut").finish()
     }
 }
-
-// `TrySendFut` never structurally pins any of its fields
-impl<B> Unpin for TrySendFut<B> {}
 
 impl<B> Future for TrySendFut<B> {
     type Output = Result<Response<IncomingBody>, TrySendError<Request<B>>>;

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -148,15 +148,12 @@ where
     /// other in-flight and future requests. The peer is notified
     /// immediately rather than continuing to send a response body that
     /// would be discarded.
-    pub fn send_request(&mut self, req: Request<B>) -> SendFut<B> {
+    pub fn send_request(&mut self, req: Request<B>) -> SendFut {
         let state = match self.dispatch.send(req) {
             Ok(rx) => SendFutState::Fut { rx },
             Err(_) => SendFutState::Err,
         };
-        SendFut {
-            state,
-            body: PhantomData,
-        }
+        SendFut { state }
     }
 
     /// Sends a `Request` on the associated connection.
@@ -191,21 +188,17 @@ enum SendFutState {
 
 /// Future returned by [`SendRequest::send_request`], see the method definition
 /// for more details.
-pub struct SendFut<B> {
+pub struct SendFut {
     state: SendFutState,
-    body: PhantomData<B>,
 }
 
-impl<B> fmt::Debug for SendFut<B> {
+impl fmt::Debug for SendFut {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SendFut").finish()
     }
 }
 
-// `SendFut` never structurally pins any of its fields
-impl<B> Unpin for SendFut<B> {}
-
-impl<B> Future for SendFut<B> {
+impl Future for SendFut {
     type Output = crate::Result<Response<IncomingBody>>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use crate::rt::{Read, Write};
 use futures_core::ready;
 use http::{Request, Response};
+use tokio::sync::oneshot::Receiver;
 
 use super::super::dispatch::{self, TrySendError};
 use crate::body::{Body, Incoming as IncomingBody};
@@ -147,27 +148,12 @@ where
     /// other in-flight and future requests. The peer is notified
     /// immediately rather than continuing to send a response body that
     /// would be discarded.
-    pub fn send_request(
-        &mut self,
-        req: Request<B>,
-    ) -> impl Future<Output = crate::Result<Response<IncomingBody>>> {
-        let sent = self.dispatch.send(req);
-
-        async move {
-            match sent {
-                Ok(rx) => match rx.await {
-                    Ok(Ok(resp)) => Ok(resp),
-                    Ok(Err(err)) => Err(err),
-                    // this is definite bug if it happens, but it shouldn't happen!
-                    Err(_canceled) => panic!("dispatch dropped without returning error"),
-                },
-                Err(_req) => {
-                    debug!("connection was not ready");
-
-                    Err(crate::Error::new_canceled().with("connection was not ready"))
-                }
-            }
-        }
+    pub fn send_request(&mut self, req: Request<B>) -> SendFut<B> {
+        let state = match self.dispatch.send(req) {
+            Ok(rx) => SendFutState::Fut { rx },
+            Err(req) => SendFutState::Err { req },
+        };
+        SendFut { state }
     }
 
     /// Sends a `Request` on the associated connection.
@@ -178,35 +164,109 @@ where
     ///
     /// If there was an error before trying to serialize the request to the
     /// connection, the message will be returned as part of this error.
-    pub fn try_send_request(
-        &mut self,
-        req: Request<B>,
-    ) -> impl Future<Output = Result<Response<IncomingBody>, TrySendError<Request<B>>>> {
-        let sent = self.dispatch.try_send(req);
-        async move {
-            match sent {
-                Ok(rx) => match rx.await {
-                    Ok(Ok(res)) => Ok(res),
-                    Ok(Err(err)) => Err(err),
-                    // this is definite bug if it happens, but it shouldn't happen!
-                    Err(_) => panic!("dispatch dropped without returning error"),
-                },
-                Err(req) => {
-                    debug!("connection was not ready");
-                    let error = crate::Error::new_canceled().with("connection was not ready");
-                    Err(TrySendError {
-                        error,
-                        message: Some(req),
-                    })
-                }
-            }
-        }
+    pub fn try_send_request(&mut self, req: Request<B>) -> TrySendFut<B> {
+        let state = match self.dispatch.try_send(req) {
+            Ok(rx) => TrySendFutState::Fut { rx },
+            Err(req) => TrySendFutState::Err { req: Some(req) },
+        };
+        TrySendFut { state }
     }
 }
 
 impl<B> fmt::Debug for SendRequest<B> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SendRequest").finish()
+    }
+}
+
+enum SendFutState<B> {
+    Fut {
+        rx: Receiver<crate::Result<Response<IncomingBody>>>,
+    },
+    Err {
+        req: Request<B>,
+    },
+}
+
+/// Future returned by [`SendRequest::send_request`], see the method definition
+/// for more details.
+pub struct SendFut<B> {
+    state: SendFutState<B>,
+}
+
+impl<B> fmt::Debug for SendFut<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SendFut").finish()
+    }
+}
+
+// `SendFut` never structurally pins any of its fields
+impl<B> Unpin for SendFut<B> {}
+
+impl<B> Future for SendFut<B> {
+    type Output = crate::Result<Response<IncomingBody>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let res = match &mut self.state {
+            SendFutState::Fut { rx } => match ready!(Pin::new(rx).poll(cx)) {
+                Ok(Ok(resp)) => Ok(resp),
+                Ok(Err(err)) => Err(err),
+                // this is definite bug if it happens, but it shouldn't happen!
+                Err(_) => panic!("dispatch dropped without returning error"),
+            },
+            SendFutState::Err { req: _req } => {
+                debug!("connection was not ready");
+                Err(crate::Error::new_canceled().with("connection was not ready"))
+            }
+        };
+        Poll::Ready(res)
+    }
+}
+
+enum TrySendFutState<B> {
+    Fut {
+        rx: Receiver<Result<Response<IncomingBody>, TrySendError<Request<B>>>>,
+    },
+    Err {
+        req: Option<Request<B>>,
+    },
+}
+
+/// Future returned by [`SendRequest::try_send_request`], see the method
+/// definition for more details.
+pub struct TrySendFut<B> {
+    state: TrySendFutState<B>,
+}
+
+impl<B> fmt::Debug for TrySendFut<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TrySendFut").finish()
+    }
+}
+
+// `TrySendFut` never structurally pins any of its fields
+impl<B> Unpin for TrySendFut<B> {}
+
+impl<B> Future for TrySendFut<B> {
+    type Output = Result<Response<IncomingBody>, TrySendError<Request<B>>>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let res = match &mut self.state {
+            TrySendFutState::Fut { rx } => match ready!(Pin::new(rx).poll(cx)) {
+                Ok(Ok(resp)) => Ok(resp),
+                Ok(Err(err)) => Err(err),
+                // this is definite bug if it happens, but it shouldn't happen!
+                Err(_) => panic!("dispatch dropped without returning error"),
+            },
+            TrySendFutState::Err { req } => {
+                debug!("connection was not ready");
+                Err(TrySendError {
+                    error: crate::Error::new_canceled().with("connection was not ready"),
+                    message: Some(req.take().expect("future already resolved")),
+                })
+            }
+        };
+        Poll::Ready(res)
     }
 }
 


### PR DESCRIPTION
Re-implements `http1::SendRequest` and `http2::SendRequest` methods to return typed futures.

1. Allow building custom state machines around responses without relying on building around `impl Future` signatures.
2. There appears to be meaningful memory savings by removing the `impl Future` signature.
3. `SendFutState` and `TrySendFutState` are `Unpin` as opposed to the derived `async` block.

Here are the memory size comparisons:

```
master
size_of::<send_request -> impl Future>     = 240
size_of::<try_send_request -> impl Future> = 240
```

Replacing `impl Future` with `SendFutState<B>` and `TrySendFutState<B>`:
```
5086145c8a3a5058e9780d4ce5364a95ef7d7a0d
size_of::<SendFut<B>>()    = 224
size_of::<TrySendFut<B>>() = 224
```

Remove `Request<B>` from `SendFutState::Err`:
```
22a1d3e745ebb6d54560da243f38f2b5ed883e5a
size_of::<SendFut>() = 16
```

Box `TrySendFutState::Err` variant:
```
19a084ca82c937dd10c0b97641fedbe897e423e7
size_of::<TrySendFut<B>>() = 16
```