### PR TITLE
style(lib): remove `uninlined_format_args` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,6 @@ single_char_lifetime_names = "allow"
 single_match_else = "allow" # TODO: easy fix
 struct_excessive_bools = "allow" # TODO: bogus lint?
 trivially_copy_pass_by_ref = "allow"
-uninlined_format_args = "allow" # TODO: easy fix
 unnecessary_semicolon = "allow" # TODO: easy fix
 unnecessary_trailing_comma = "allow"
 unnested_or_patterns = "allow"

--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -102,7 +102,7 @@ impl fmt::Display for DecodedLength {
             DecodedLength::CLOSE_DELIMITED => f.write_str("close-delimited"),
             DecodedLength::CHUNKED => f.write_str("chunked encoding"),
             DecodedLength::ZERO => f.write_str("empty"),
-            DecodedLength(n) => write!(f, "content-length ({} bytes)", n),
+            DecodedLength(n) => write!(f, "content-length ({n} bytes)"),
         }
     }
 }

--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -77,7 +77,7 @@ impl Time {
                 Time::Timer(..) => Some(dur),
             },
             Dur::Configured(Some(dur)) => match self {
-                Time::Empty => panic!("timeout `{}` set, but no timer set", name,),
+                Time::Empty => panic!("timeout `{name}` set, but no timer set",),
                 Time::Timer(..) => Some(dur),
             },
             Dur::Default(None) | Dur::Configured(None) => None,

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -352,7 +352,7 @@ impl ChunkSize {
             pos: 0,
             len: 0,
         };
-        write!(&mut size, "{:X}\r\n", len).expect("CHUNK_SIZE_MAX_BYTES should fit any usize");
+        write!(&mut size, "{len:X}\r\n").expect("CHUNK_SIZE_MAX_BYTES should fit any usize");
         size
     }
 }

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -86,8 +86,7 @@ where
     pub(crate) fn set_max_buf_size(&mut self, max: usize) {
         assert!(
             max >= MINIMUM_MAX_BUFFER_SIZE,
-            "The max_buf_size cannot be smaller than {}.",
-            MINIMUM_MAX_BUFFER_SIZE,
+            "The max_buf_size cannot be smaller than {MINIMUM_MAX_BUFFER_SIZE}.",
         );
         self.read_buf_strategy = ReadStrategy::with_max(max);
         self.write_buf.max_buf_size = max;

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -421,7 +421,7 @@ impl Http1Transaction for Server {
                     debug!("response with HTTP2 version coerced to HTTP/1.1");
                     extend(dst, b"HTTP/1.1 ");
                 }
-                other => panic!("unexpected response version: {:?}", other),
+                other => panic!("unexpected response version: {other:?}"),
             }
 
             extend(dst, msg.head.subject.as_str().as_bytes());
@@ -712,9 +712,7 @@ impl Server {
                                     if msg.req_method != &Some(Method::HEAD) || known_len != 0 {
                                         assert!(
                                         len == known_len,
-                                        "payload claims content-length of {}, custom content-length header claims {}",
-                                        known_len,
-                                        len,
+                                        "payload claims content-length of {known_len}, custom content-length header claims {len}",
                                     );
                                     }
                                 }
@@ -896,8 +894,7 @@ impl Server {
             // non-special write Name and Value
             debug_assert!(
                 !is_name_written,
-                "{:?} set is_name_written and didn't continue loop",
-                name,
+                "{name:?} set is_name_written and didn't continue loop",
             );
             header_name_writer.write_header_name(dst, name);
             extend(dst, b": ");
@@ -1212,7 +1209,7 @@ impl Http1Transaction for Client {
                 debug!("request with HTTP2 version coerced to HTTP/1.1");
                 extend(dst, b"HTTP/1.1");
             }
-            other => panic!("unexpected request version: {:?}", other),
+            other => panic!("unexpected request version: {other:?}"),
         }
         extend(dst, b"\r\n");
 


### PR DESCRIPTION
Part of https://github.com/hyperium/hyper/issues/4071