### PR TITLE
fix(http1): allow up to max_headers trailers

### DIFF
--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -201,13 +201,6 @@ impl Decoder {
                         if trailers_buf.is_some() {
                             trace!("found possible trailers");
 
-                            // decoder enforces that trailers count will not exceed h1_max_headers
-                            if *trailers_cnt >= h1_max_headers {
-                                return Poll::Ready(Err(io::Error::new(
-                                    io::ErrorKind::InvalidData,
-                                    "chunk trailers count overflow",
-                                )));
-                            }
                             match decode_trailers(
                                 &mut trailers_buf.take().expect("Trailer is None"),
                                 *trailers_cnt,
@@ -1161,7 +1154,7 @@ mod tests {
         let h1_max_headers = 10;
         let mut scratch = vec![];
         scratch.extend(b"10\r\n1234567890abcdef\r\n0\r\n");
-        for i in 0..h1_max_headers {
+        for i in 0..=h1_max_headers {
             scratch.extend(format!("trailer{}: {}\r\n", i, i).as_bytes());
         }
         scratch.extend(b"\r\n");
@@ -1184,6 +1177,36 @@ mod tests {
             .await
             .expect_err("trailer fields over limit");
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn test_trailer_max_headers_allows_exact_limit() {
+        let h1_max_headers = 10;
+        let mut scratch = vec![];
+        scratch.extend(b"10\r\n1234567890abcdef\r\n0\r\n");
+        for i in 0..h1_max_headers {
+            scratch.extend(format!("trailer{}: {}\r\n", i, i).as_bytes());
+        }
+        scratch.extend(b"\r\n");
+        let mut mock_buf = Bytes::from(scratch);
+
+        let mut decoder = Decoder::chunked(Some(h1_max_headers), None);
+
+        let buf = decoder
+            .decode_fut(&mut mock_buf)
+            .await
+            .unwrap()
+            .into_data()
+            .expect("unknown frame type");
+        assert_eq!(16, buf.len());
+
+        let trailers = decoder
+            .decode_fut(&mut mock_buf)
+            .await
+            .expect("trailers at limit")
+            .into_trailers()
+            .expect("unknown frame type");
+        assert_eq!(trailers.len(), h1_max_headers);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Previously, an off-by-one error made it so only `max_headers - 1` trailers were allowed.