### PR TITLE
style(lib): remove `default_trait_access` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,6 @@ cast_precision_loss = "allow" # TODO: consider
 checked_conversions = "allow"
 collapsible_match = "allow"
 decimal_literal_representation = "allow" # TODO: consider
-default_trait_access = "allow"
 else_if_without_else = "allow"
 enum_glob_use = "allow"
 float_arithmetic = "allow"

--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -332,7 +332,7 @@ impl Builder {
             h09_responses: false,
             h1_writev: None,
             h1_read_buf_exact_size: None,
-            h1_parser_config: Default::default(),
+            h1_parser_config: ParserConfig::default(),
             h1_title_case_headers: false,
             h1_preserve_header_case: false,
             h1_max_headers: None,

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -298,7 +298,7 @@ where
         Builder {
             exec,
             timer: Time::Empty,
-            h2_builder: Default::default(),
+            h2_builder: proto::h2::client::Config::default(),
         }
     }
 

--- a/src/ext/mod.rs
+++ b/src/ext/mod.rs
@@ -181,7 +181,7 @@ impl HeaderCaseMap {
 
     #[cfg(any(feature = "client", feature = "server"))]
     pub(crate) fn default() -> Self {
-        Self(Default::default())
+        Self(HeaderMap::default())
     }
 
     #[cfg(any(test, feature = "ffi"))]

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -12,6 +12,7 @@ use crate::rt::{Read, Write};
 use crate::upgrade::Upgraded;
 use bytes::Bytes;
 use futures_core::ready;
+use httparse::ParserConfig;
 
 use crate::body::{Body, Incoming as IncomingBody};
 use crate::proto;
@@ -69,7 +70,7 @@ pin_project_lite::pin_project! {
 /// to bind the built connection to a service.
 #[derive(Clone, Debug)]
 pub struct Builder {
-    h1_parser_config: httparse::ParserConfig,
+    h1_parser_config: ParserConfig,
     timer: Time,
     h1_half_close: bool,
     h1_keep_alive: bool,
@@ -239,7 +240,7 @@ impl Builder {
     /// Create a new connection builder.
     pub fn new() -> Self {
         Self {
-            h1_parser_config: Default::default(),
+            h1_parser_config: ParserConfig::default(),
             timer: Time::Empty,
             h1_half_close: false,
             h1_keep_alive: true,

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -116,7 +116,7 @@ impl<E> Builder<E> {
         Self {
             exec,
             timer: Time::Empty,
-            h2_builder: Default::default(),
+            h2_builder: proto::h2::server::Config::default(),
         }
     }
 


### PR DESCRIPTION
## Overview
This PR removes `default_trait_access = "allow"` from `Cargo.toml` and updates the code to explicitly call type-specific default methods (e.g., `ParserConfig::default()`) instead of `Default::default()`.

## Changes
- Removed `default_trait_access = "allow"` from `Cargo.toml`.
- Replaced `Default::default()` with explicit type-default calls in code.
- Refactored the httparse import in `src/server/conn/http1.rs` to align with the client-side style.

## Questions
### Full path for h2 config
In `src/client/conn/http2.rs` and `src/server/conn/http2.rs`, I used fully qualified paths to avoid `Default::default()` while preventing name conflicts:
```rust
h2_builder: proto::h2::client::Config::default(),
```
*Question*:   
Does this look good to you, or  would you prefer introducing type aliases (e.g., `use proto::h2::client::Config as H2ClientConfig`) at the top of the file to keep it shorter?

### Import refactoring in `src/server/conn/http1.rs`
I changed `use httparse;` to `use httparse::ParserConfig;` 

If you prefer keeping the original import style to minimize the diff, please let me know. I will revert this specific part.

### Untouched test codes
I noticed that there are still many `Default::default()` occurrences in the test codes (e.g., `src/proto/h1/role.rs`).   Currently, the CI clippy job does not check test targets because it runs without --all-targets:

```YAML
cargo clippy --features full -- -D warnings
```
As a result, the CI passes with this PR.

*Question*:  
 Should I also update the test codes, or should we keep this PR focused only on the library code?

## Related issue
Part of a #4071 

Sorry for the long description! 
If there are any changes needed, please let me know. Otherwise, feel free to merge this PR if everything looks good to you.🙏