### PR TITLE
feat: add initialized_unfilled to ReadBufCursor

### DIFF
--- a/src/rt/io.rs
+++ b/src/rt/io.rs
@@ -382,6 +382,46 @@ impl ReadBufCursor<'_> {
         }
         self.buf.filled = end;
     }
+
+    /// Returns a mutable reference to the unfilled part of the buffer, ensuring it is fully initialized.
+    #[inline]
+    pub fn initialize_unfilled(&mut self) -> &mut [u8] {
+        self.initialize_unfilled_to(self.remaining())
+    }
+
+    /// Returns a mutable reference to the first `n` bytes of the unfilled part of the buffer, ensuring it is
+    /// fully initialized.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.remaining()` is less than `n`.
+    #[inline]
+    pub fn initialize_unfilled_to(&mut self, n: usize) -> &mut [u8] {
+        assert!(self.remaining() >= n, "n overflows remaining");
+
+        // This can't overflow as the assert above would have panicked otherwise.
+        let end = self.buf.filled + n;
+
+        if self.buf.init < end {
+            // SAFETY:
+            // 1. The raw pointer is not null and not dangling either as the slice outlives the
+            // pointer's usage. The pointer is also properly aligned.
+            // 2. Further, `end - self.buf.init` is inbounds and hence safe to write
+            // to.
+            unsafe {
+                self.buf.raw[self.buf.init..end]
+                    .as_mut_ptr()
+                    .write_bytes(0, end - self.buf.init);
+            }
+            self.buf.init = end;
+        }
+
+        let slice = &mut self.buf.raw[self.buf.filled..end];
+
+        // SAFETY: `MaybeUninit<u8>` has the same memory layout as u8 and we properly initialized
+        // the slice above.
+        unsafe { &mut *(slice as *mut [MaybeUninit<u8>] as *mut [u8]) }
+    }
 }
 
 macro_rules! deref_async_read {


### PR DESCRIPTION
This PR adds `initialize_unfilled` and `initialize_unfilled_to` APIs to `ReadBufCursor` similar to the ones provided by `tokio::io::ReadBuf`.  The caller still will have to maintain the responsibility to advance the cursor.

The requirement stems from the inability to zero initialize only the uninitialized part of `ReadBuf`. When implementing `hyper::rt::Read` for a type that implements `futures::io::AsyncRead`, in order to ensure that the buffer is fully initialized, we are left with no other option than to write 
```rust
        let uninit = unsafe { buf.as_mut() };
        uninit.fill(MaybeUninit::new(0));
```
which has to pay the cost of re-initializing the part of the buffer that might have already been initialized previously and it becomes completely non-useful if the buffer was already completely initialized in the first place.

I analyzed a use case wherein the I found that the `WebSocket` type from `tungstenite` crate uses an internally managed `BytesMut` buffer which is zero initialized before reading from the type implementing `io::Read` that it is generic over. 
The `async_tungstenite` crate provides such a type `AllowStd<S>` where `S: futures::io::AsyncRead`, and the `io::Read` impl for this type just calls into the `poll_read` of `S`. 

When implementing a `FuturesIo<T>` type similar to `hyper_util::rt::tokio::TokioIo`, we implement `futures::io::AsyncRead` for it where `T: hyper::rt::Read` and call into the `poll_read` of T by calling `ReadBuf::new` on the buffer and passing `buffer.unfilled()` to it. 
This circles back to our original impl of `hyper::rt::Read` for the `HyperStream` which does not have a way to zero initialize only the uninitialized portion of the buffer and hence has to zero out an already zeroed out buffer paying double the cost.
 
With the addition of this API, this problem can be avoided.