### PR TITLE
style(proto): fix `decimal_literal_representation` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ arbitrary_source_item_ordering = "allow" # order: std, deps, crate
 blanket_clippy_restriction_lints = "allow" # allowlist is better
 clone_on_ref_ptr = "allow" # Arc::clone(blah) is needlessly noisy
 cognitive_complexity = "allow" # is this ever useful?
+decimal_literal_representation = "allow" # arguably more human-readable
 default_numeric_fallback = "allow" # too many false positives
 expect_used = "allow" # expect is self-documenting
 error_impl_error = "allow" # mod::Error is a fine name

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,6 @@ cast_possible_truncation = "allow" # TODO: consider
 cast_precision_loss = "allow" # TODO: consider
 checked_conversions = "allow"
 collapsible_match = "allow"
-decimal_literal_representation = "allow" # TODO: consider
 else_if_without_else = "allow"
 enum_glob_use = "allow"
 float_arithmetic = "allow"

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -27,7 +27,7 @@ cfg_server! {
 }
 
 /// Default initial stream window size defined in HTTP2 spec.
-pub(crate) const SPEC_WINDOW_SIZE: u32 = 65_535;
+pub(crate) const SPEC_WINDOW_SIZE: u32 = 0xFFFF; // 65,535
 
 // List of connection headers from RFC 9110 Section 7.6.1
 //

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -27,7 +27,7 @@ cfg_server! {
 }
 
 /// Default initial stream window size defined in HTTP2 spec.
-pub(crate) const SPEC_WINDOW_SIZE: u32 = 0xFFFF; // 65,535
+pub(crate) const SPEC_WINDOW_SIZE: u32 = 65_535;
 
 // List of connection headers from RFC 9110 Section 7.6.1
 //


### PR DESCRIPTION
Part of https://github.com/hyperium/hyper/issues/4071

> What it does
Warns if there is a better representation for a numeric literal.

> Why restrict this?
Especially for big powers of 2, a hexadecimal representation is usually more readable than a decimal representation.

from the [docs](https://rust-lang.github.io/rust-clippy/master/index.html#decimal_literal_representation) though TBH I think `65_535` is more readable here