### PR TITLE
fix(h1): append duplicate trailer values when encoding (match #4107)

### DIFF
--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -181,7 +181,7 @@ impl Encoder {
 
                     if allowed_set.contains(name) {
                         if is_valid_trailer_field(name) {
-                            allowed_trailers.insert(name, value);
+                            allowed_trailers.append(name, value);
                         } else {
                             debug!("trailer field is not valid: {}", &name);
                         }
@@ -564,6 +564,32 @@ mod tests {
         assert_eq!(
             dst,
             b"0\r\nchunky-trailer: header data\r\nchunky-trailer-2: more header data\r\n\r\n"
+        );
+    }
+
+    #[test]
+    fn chunked_with_duplicate_trailer_values() {
+        let encoder = Encoder::chunked();
+        let trailers = vec![HeaderName::from_static("chunky-trailer")];
+        let encoder = encoder.into_chunked_with_trailing_fields(trailers);
+
+        let mut headers = HeaderMap::new();
+        headers.append(
+            HeaderName::from_static("chunky-trailer"),
+            HeaderValue::from_static("first"),
+        );
+        headers.append(
+            HeaderName::from_static("chunky-trailer"),
+            HeaderValue::from_static("second"),
+        );
+
+        let buf1 = encoder.encode_trailers::<&[u8]>(headers, false).unwrap();
+
+        let mut dst = Vec::new();
+        dst.put(buf1);
+        assert_eq!(
+            dst,
+            b"0\r\nchunky-trailer: first\r\nchunky-trailer: second\r\n\r\n"
         );
     }
 


### PR DESCRIPTION
#4107 fixed the decode side: `decode_trailers` switched from `HeaderMap::insert` to `append`, so repeated trailer values received on the wire are preserved. The encode side is the unfixed sibling: `Encoder::encode_trailers` (`src/proto/h1/encode.rs`) builds `allowed_trailers` with `insert`, so when a user sets the same trailer field multiple times, only the last value reaches the wire.

The one-line fix mirrors #4107 (`insert` → `append`). Verified both ways with `cargo test --features full`: a regression test fails on the old code (only the second value reaches the wire) and passes after; encode module 10/10, full lib suite 100 passed, 0 regression.