### PR TITLE
Fix typos in comments and documentation

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -911,7 +911,7 @@ impl<I: Unpin, B, T> Unpin for Conn<I, B, T> {}
 
 struct State {
     allow_half_close: bool,
-    /// Re-usable `HeaderMap` to reduce allocating new ones.
+    /// Reusable `HeaderMap` to reduce allocating new ones.
     cached_headers: Option<HeaderMap>,
     /// If an error occurs when there wasn't a direct way to return it
     /// back to the user, this is set.

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -512,7 +512,7 @@ impl<T: AsRef<[u8]>> Buf for Cursor<T> {
 
 // an internal buffer to collect writes before flushes
 pub(super) struct WriteBuf<B> {
-    /// Re-usable buffer that holds message headers.
+    /// Reusable buffer that holds message headers.
     headers: Cursor<Vec<u8>>,
     max_buf_size: usize,
     /// Deque of user buffers if strategy is `Queue`.


### PR DESCRIPTION
Fix several minor typos found by codespell in source comments and documentation strings.