### PR TITLE
fix(http1): return 414 when request line overflows max_buf_size

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -372,6 +372,11 @@ impl Error {
         Error::new(Kind::Parse(Parse::TooLarge))
     }
 
+    #[cfg(all(feature = "server", feature = "http1"))]
+    pub(super) fn new_uri_too_long() -> Error {
+        Error::new(Kind::Parse(Parse::UriTooLong))
+    }
+
     #[cfg(all(any(feature = "client", feature = "server"), feature = "http1"))]
     pub(super) fn new_version_h2() -> Error {
         Error::new(Kind::Parse(Parse::VersionH2))

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -199,6 +199,14 @@ where
                 let curr_len = self.read_buf.len();
                 if curr_len >= max {
                     debug!("max_buf_size ({}) reached, closing", max);
+                    // When parsing a request and the start-line (request
+                    // line) hasn't even finished — i.e. no newline has been
+                    // seen yet — the overflow is caused by an oversized URI
+                    // rather than the header fields, so report `414 URI Too
+                    // Long` instead of `431 Request Header Fields Too Large`.
+                    if S::is_server() && !self.read_buf.contains(&b'\n') {
+                        return Poll::Ready(Err(crate::Error::new_uri_too_long()));
+                    }
                     return Poll::Ready(Err(crate::Error::new_too_large()));
                 }
                 if curr_len > 0 {
@@ -968,4 +976,93 @@ mod tests {
     //         write_buf.headers.bytes.clear();
     //     })
     // }
+
+    #[cfg(not(miri))]
+    #[cfg(feature = "server")]
+    #[tokio::test]
+    async fn parse_overlong_uri_is_uri_too_long() {
+        use crate::proto::h1::ServerTransaction;
+
+        let _ = pretty_env_logger::try_init();
+
+        // A request line whose URI overflows `max_buf_size` before any line
+        // terminator is seen should be reported as `414 URI Too Long` rather
+        // than `431 Request Header Fields Too Large`.
+        let max = MINIMUM_MAX_BUFFER_SIZE;
+        let mut req = b"GET /".to_vec();
+        req.resize(max, b'a');
+
+        let mock = Mock::new().read(&req).build();
+
+        let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(Compat::new(mock));
+        buffered.set_max_buf_size(max);
+
+        let err = futures_util::future::poll_fn(|cx| {
+            let parse_ctx = ParseContext {
+                cached_headers: &mut None,
+                req_method: &mut None,
+                h1_parser_config: Default::default(),
+                h1_max_headers: None,
+                preserve_header_case: false,
+                #[cfg(feature = "ffi")]
+                preserve_header_order: false,
+                h09_responses: false,
+                #[cfg(feature = "client")]
+                on_informational: &mut None,
+            };
+            buffered.parse::<ServerTransaction>(cx, parse_ctx)
+        })
+        .await
+        .expect_err("parse should fail");
+
+        assert!(
+            matches!(err.kind(), crate::error::Kind::Parse(crate::error::Parse::UriTooLong)),
+            "expected UriTooLong, got {:?}",
+            err,
+        );
+    }
+
+    #[cfg(not(miri))]
+    #[cfg(feature = "server")]
+    #[tokio::test]
+    async fn parse_overlong_headers_is_too_large() {
+        use crate::proto::h1::ServerTransaction;
+
+        let _ = pretty_env_logger::try_init();
+
+        // A complete request line followed by header fields that overflow
+        // `max_buf_size` should remain a `431` (`TooLarge`) error.
+        let max = MINIMUM_MAX_BUFFER_SIZE;
+        let mut req = b"GET / HTTP/1.1\r\nHost: x\r\nX: ".to_vec();
+        req.resize(max, b'a');
+
+        let mock = Mock::new().read(&req).build();
+
+        let mut buffered = Buffered::<_, Cursor<Vec<u8>>>::new(Compat::new(mock));
+        buffered.set_max_buf_size(max);
+
+        let err = futures_util::future::poll_fn(|cx| {
+            let parse_ctx = ParseContext {
+                cached_headers: &mut None,
+                req_method: &mut None,
+                h1_parser_config: Default::default(),
+                h1_max_headers: None,
+                preserve_header_case: false,
+                #[cfg(feature = "ffi")]
+                preserve_header_order: false,
+                h09_responses: false,
+                #[cfg(feature = "client")]
+                on_informational: &mut None,
+            };
+            buffered.parse::<ServerTransaction>(cx, parse_ctx)
+        })
+        .await
+        .expect_err("parse should fail");
+
+        assert!(
+            matches!(err.kind(), crate::error::Kind::Parse(crate::error::Parse::TooLarge)),
+            "expected TooLarge, got {:?}",
+            err,
+        );
+    }
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2739,7 +2739,9 @@ async fn max_buf_size() {
         let mut buf = [0; 256];
         tcp.read(&mut buf).expect("read 1");
 
-        let expected = "HTTP/1.1 431 ";
+        // The request line overflows the buffer before it is even complete,
+        // so this is reported as `414 URI Too Long`, not `431`.
+        let expected = "HTTP/1.1 414 ";
         assert_eq!(s(&buf[..expected.len()]), expected);
     });
 
@@ -2749,7 +2751,7 @@ async fn max_buf_size() {
         .max_buf_size(MAX)
         .serve_connection(socket, HelloWorld)
         .await
-        .expect_err("should TooLarge error");
+        .expect_err("should UriTooLong error");
 }
 
 #[cfg(feature = "http1")]


### PR DESCRIPTION
## Summary

When an HTTP/1 server is configured with `http1_max_buf_size` and receives a request whose start-line (method + URI + version) is so large that it fills the read buffer **before a newline is even seen**, hyper reported the failure as `431 Request Header Fields Too Large`. Per [RFC 7231 §6.5.12](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.12), the more specific status for an oversized URI is `414 URI Too Long`.

Closes #3874.

## Root cause

In `Buffered::parse` (`src/proto/h1/io.rs`), when `max_buf_size` is reached the code unconditionally returns `Error::new_too_large()` → `Parse::TooLarge` → `431`. There is no distinction between "the request line itself is too long" and "the header fields are too large."

This is exactly the fix direction @seanmonstar sketched in the issue:

> It's possible hyper could add some more code to better determine if the Start-Line never finished, when seeing a `TooLarge` error. Is that sufficient?

## Fix

Detect the case in `Buffered::parse`: when `max_buf_size` is reached on a **server** and **no `\n`** has appeared in the buffer yet, the overflow is caused by the request line (typically the URI) rather than the header fields. Return `Parse::UriTooLong` (→ `414`) instead of `Parse::TooLarge` (→ `431`).

The existing `Parse::UriTooLong` variant already maps to `StatusCode::URI_TOO_LONG` in `Server::on_error` (`src/proto/h1/role.rs`), and its `Display` string ("URI too long") and `is_parse_too_large()` already cover it — so no status-code mapping or display changes are needed.

### Changes

- **`src/error.rs`** — add `Error::new_uri_too_long()` constructor (gated `#[cfg(all(feature = "server", feature = "http1"))]`, matching the `Parse::UriTooLong` variant's cfg).
- **`src/proto/h1/io.rs`** — in `parse()`, when `max_buf_size` is hit on a server with no `\n` in the buffer, return `new_uri_too_long()` instead of `new_too_large()`. Added two unit tests:
  - `parse_overlong_uri_is_uri_too_long` — request line with no newline overflows buffer → expects `UriTooLong`.
  - `parse_overlong_headers_is_too_large` — complete request line + oversized headers → still expects `TooLarge` (regression guard).
- **`tests/server.rs`** — updated the `max_buf_size` integration test: it sends `POST /` + a large payload (no newline), so the expected response is now `414` instead of `431`.

The existing `max_buf_size_split_header_boundary` test (which sends a complete request line *then* overflows on headers) continues to expect `431` and is unaffected.

## AI disclosure

This change was developed with AI assistance. The human author reviewed every line, verified the root cause against the source code, and owns the change.
