### PR TITLE
refactor(error/upgrade): move from the use of ref patterns to `&` and remove allow for lint `ref_patterns`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,6 @@ panic = "allow"
 pattern_type_mismatch = "allow"
 redundant_closure_for_method_calls = "allow"
 redundant_else = "allow"
-ref_patterns = "allow" # TODO: perhaps deny?
 single_char_lifetime_names = "allow"
 struct_excessive_bools = "allow" # TODO: bogus lint?
 trivially_copy_pass_by_ref = "allow"

--- a/benches/end_to_end.rs
+++ b/benches/end_to_end.rs
@@ -368,13 +368,9 @@ impl Opts {
         };
 
         let mut send_request = |req| {
-            let fut = match client {
-                Client::Http1(ref mut tx) => {
-                    futures_util::future::Either::Left(tx.send_request(req))
-                }
-                Client::Http2(ref mut tx) => {
-                    futures_util::future::Either::Right(tx.send_request(req))
-                }
+            let fut = match &mut client {
+                Client::Http1(tx) => futures_util::future::Either::Left(tx.send_request(req)),
+                Client::Http2(tx) => futures_util::future::Either::Right(tx.send_request(req)),
             };
             async {
                 let res = fut.await.expect("client wait");

--- a/src/body/incoming.rs
+++ b/src/body/incoming.rs
@@ -172,15 +172,12 @@ impl Incoming {
 
     #[cfg(feature = "ffi")]
     pub(crate) fn as_ffi_mut(&mut self) -> &mut crate::ffi::UserBody {
-        match self.kind {
-            Kind::Ffi(ref mut body) => return body,
-            _ => {
-                self.kind = Kind::Ffi(crate::ffi::UserBody::new());
-            }
+        if !matches!(self.kind, Kind::Ffi(_)) {
+            self.kind = Kind::Ffi(crate::ffi::UserBody::new());
         }
 
-        match self.kind {
-            Kind::Ffi(ref mut body) => body,
+        match &mut self.kind {
+            Kind::Ffi(body) => body,
             _ => unreachable!(),
         }
     }
@@ -208,14 +205,14 @@ impl Body for Incoming {
         )]
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        match self.kind {
+        match &mut self.kind {
             Kind::Empty => Poll::Ready(None),
             #[cfg(all(feature = "http1", any(feature = "client", feature = "server")))]
             Kind::Chan {
-                content_length: ref mut len,
-                ref mut data_rx,
-                ref mut want_tx,
-                ref mut trailers_rx,
+                content_length: len,
+                data_rx,
+                want_tx,
+                trailers_rx,
             } => {
                 want_tx.send(WANT_READY);
 
@@ -234,10 +231,10 @@ impl Body for Incoming {
             }
             #[cfg(all(feature = "http2", any(feature = "client", feature = "server")))]
             Kind::H2 {
-                ref mut data_done,
-                ref ping,
-                recv: ref mut h2,
-                content_length: ref mut len,
+                data_done,
+                ping,
+                recv: h2,
+                content_length: len,
             } => {
                 if !*data_done {
                     match ready!(h2.poll_data(cx)) {
@@ -284,17 +281,17 @@ impl Body for Incoming {
             }
 
             #[cfg(feature = "ffi")]
-            Kind::Ffi(ref mut body) => body.poll_data(cx),
+            Kind::Ffi(body) => body.poll_data(cx),
         }
     }
 
     fn is_end_stream(&self) -> bool {
-        match self.kind {
+        match &self.kind {
             Kind::Empty => true,
             #[cfg(all(feature = "http1", any(feature = "client", feature = "server")))]
-            Kind::Chan { content_length, .. } => content_length == DecodedLength::ZERO,
+            Kind::Chan { content_length, .. } => *content_length == DecodedLength::ZERO,
             #[cfg(all(feature = "http2", any(feature = "client", feature = "server")))]
-            Kind::H2 { recv: ref h2, .. } => h2.is_end_stream(),
+            Kind::H2 { recv: h2, .. } => h2.is_end_stream(),
             #[cfg(feature = "ffi")]
             Kind::Ffi(..) => false,
         }
@@ -633,8 +630,8 @@ mod tests {
         drop(rx);
         assert!(tx_ready.is_woken(), "dropping rx wakes tx");
 
-        match tx_ready.poll() {
-            Poll::Ready(Err(ref e)) if e.is_closed() => (),
+        match &tx_ready.poll() {
+            Poll::Ready(Err(e)) if e.is_closed() => (),
             unexpected => panic!("tx poll ready unexpected: {:?}", unexpected),
         }
     }

--- a/src/body/length.rs
+++ b/src/body/length.rs
@@ -67,9 +67,9 @@ impl DecodedLength {
         any(feature = "client", feature = "server")
     ))]
     pub(crate) fn sub_if(&mut self, amt: u64) {
-        match *self {
-            DecodedLength::CHUNKED | DecodedLength::CLOSE_DELIMITED => (),
-            DecodedLength(ref mut known) => {
+        match self {
+            &mut DecodedLength::CHUNKED | &mut DecodedLength::CLOSE_DELIMITED => (),
+            DecodedLength(known) => {
                 *known -= amt;
             }
         }

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -266,30 +266,30 @@ fn dispatch_gone() -> crate::Error {
 impl<T, U> Callback<T, U> {
     #[cfg(feature = "http2")]
     pub(crate) fn is_canceled(&self) -> bool {
-        match *self {
-            Callback::Retry(Some(ref tx)) => tx.is_closed(),
-            Callback::NoRetry(Some(ref tx)) => tx.is_closed(),
+        match self {
+            Callback::Retry(Some(tx)) => tx.is_closed(),
+            Callback::NoRetry(Some(tx)) => tx.is_closed(),
             _ => unreachable!(),
         }
     }
 
     pub(crate) fn poll_canceled(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        match *self {
-            Callback::Retry(Some(ref mut tx)) => tx.poll_closed(cx),
-            Callback::NoRetry(Some(ref mut tx)) => tx.poll_closed(cx),
+        match self {
+            Callback::Retry(Some(tx)) => tx.poll_closed(cx),
+            Callback::NoRetry(Some(tx)) => tx.poll_closed(cx),
             _ => unreachable!(),
         }
     }
 
     pub(crate) fn send(mut self, val: Result<U, TrySendError<T>>) {
-        match self {
-            Callback::Retry(ref mut tx) => {
+        match &mut self {
+            Callback::Retry(tx) => {
                 let _ = tx
                     .take()
                     .expect("callback sender not dropped before send")
                     .send(val);
             }
-            Callback::NoRetry(ref mut tx) => {
+            Callback::NoRetry(tx) => {
                 let _ = tx
                     .take()
                     .expect("callback sender not dropped before send")

--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -32,37 +32,37 @@ impl fmt::Debug for Time {
 impl Time {
     #[cfg(all(any(feature = "client", feature = "server"), feature = "http2"))]
     pub(crate) fn sleep(&self, duration: Duration) -> Pin<Box<dyn Sleep>> {
-        match *self {
+        match &self {
             Time::Empty => {
                 panic!("You must supply a timer.")
             }
-            Time::Timer(ref t) => t.sleep(duration),
+            Time::Timer(t) => t.sleep(duration),
         }
     }
 
     #[cfg(all(feature = "server", feature = "http1"))]
     pub(crate) fn sleep_until(&self, deadline: Instant) -> Pin<Box<dyn Sleep>> {
-        match *self {
+        match &self {
             Time::Empty => {
                 panic!("You must supply a timer.")
             }
-            Time::Timer(ref t) => t.sleep_until(deadline),
+            Time::Timer(t) => t.sleep_until(deadline),
         }
     }
 
     pub(crate) fn now(&self) -> Instant {
-        match *self {
+        match &self {
             Time::Empty => Instant::now(),
-            Time::Timer(ref t) => t.now(),
+            Time::Timer(t) => t.now(),
         }
     }
 
     pub(crate) fn reset(&self, sleep: &mut Pin<Box<dyn Sleep>>, new_deadline: Instant) {
-        match *self {
+        match &self {
             Time::Empty => {
                 panic!("You must supply a timer.")
             }
-            Time::Timer(ref t) => t.reset(sleep, new_deadline),
+            Time::Timer(t) => t.reset(sleep, new_deadline),
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -602,7 +602,7 @@ impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut f = f.debug_tuple("hyper::Error");
         f.field(&self.inner.kind);
-        if let Some(ref cause) = self.inner.cause {
+        if let Some(cause) = &self.inner.cause {
             f.field(cause);
         }
         f.finish()

--- a/src/ffi/client.rs
+++ b/src/ffi/client.rs
@@ -147,9 +147,9 @@ ffi_fn! {
         // Update request with original-case map of headers
         req.finalize_request();
 
-        let fut = match non_null! { &mut *conn ?= ptr::null_mut() }.tx {
-            Tx::Http1(ref mut tx) => futures_util::future::Either::Left(tx.send_request(req.0)),
-            Tx::Http2(ref mut tx) => futures_util::future::Either::Right(tx.send_request(req.0)),
+        let fut = match &mut non_null! { &mut *conn ?= ptr::null_mut() }.tx {
+            Tx::Http1(tx) => futures_util::future::Either::Left(tx.send_request(req.0)),
+            Tx::Http2(tx) => futures_util::future::Either::Right(tx.send_request(req.0)),
         };
 
         let fut = async move {

--- a/src/ffi/task.rs
+++ b/src/ffi/task.rs
@@ -355,9 +355,9 @@ impl hyper_task {
     }
 
     fn output_type(&self) -> hyper_task_return_type {
-        match self.output {
+        match &self.output {
             None => hyper_task_return_type::HYPER_TASK_EMPTY,
-            Some(ref val) => val.as_task_type(),
+            Some(val) => val.as_task_type(),
         }
     }
 }

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -220,8 +220,8 @@ where
             if let Some(h1_header_read_timeout) = self.state.h1_header_read_timeout {
                 let deadline = self.state.timer.now() + h1_header_read_timeout;
                 self.state.h1_header_read_timeout_running = true;
-                match self.state.h1_header_read_timeout_fut {
-                    Some(ref mut h1_header_read_timeout_fut) => {
+                match &mut self.state.h1_header_read_timeout_fut {
+                    Some(h1_header_read_timeout_fut) => {
                         trace!("resetting h1 header read timeout timer");
                         self.state.timer.reset(h1_header_read_timeout_fut, deadline);
                     }
@@ -254,8 +254,8 @@ where
             Poll::Pending => {
                 #[cfg(feature = "server")]
                 if self.state.h1_header_read_timeout_running {
-                    if let Some(ref mut h1_header_read_timeout_fut) =
-                        self.state.h1_header_read_timeout_fut
+                    if let Some(h1_header_read_timeout_fut) =
+                        &mut self.state.h1_header_read_timeout_fut
                     {
                         if Pin::new(h1_header_read_timeout_fut).poll(cx).is_ready() {
                             self.state.h1_header_read_timeout_running = false;
@@ -366,8 +366,8 @@ where
     ) -> Poll<Option<io::Result<Frame<Bytes>>>> {
         debug_assert!(self.can_read_body());
 
-        let (reading, ret) = match self.state.reading {
-            Reading::Body(ref mut decoder) => {
+        let (reading, ret) = match &mut self.state.reading {
+            Reading::Body(decoder) => {
                 match ready!(decoder.decode(cx, &mut self.io)) {
                     Ok(frame) => {
                         if frame.is_data() {
@@ -406,7 +406,7 @@ where
                     }
                 }
             }
-            Reading::Continue(ref decoder) => {
+            Reading::Continue(decoder) => {
                 // Write the 100 Continue if not already responded...
                 if let Writing::Init = self.state.writing {
                     trace!("automatically sending 100 Continue");
@@ -715,8 +715,8 @@ where
         // empty chunks should be discarded at Dispatcher level
         debug_assert!(chunk.remaining() != 0);
 
-        let state = match self.state.writing {
-            Writing::Body(ref mut encoder) => {
+        let state = match &mut self.state.writing {
+            Writing::Body(encoder) => {
                 self.io.buffer(encoder.encode(chunk));
 
                 if !encoder.is_eof() {
@@ -742,8 +742,8 @@ where
         }
         debug_assert!(self.can_write_body() && self.can_buffer_body());
 
-        match self.state.writing {
-            Writing::Body(ref encoder) => {
+        match &mut self.state.writing {
+            Writing::Body(encoder) => {
                 if let Some(enc_buf) =
                     encoder.encode_trailers(trailers, self.state.title_case_headers)
                 {
@@ -765,8 +765,8 @@ where
         // empty chunks should be discarded at Dispatcher level
         debug_assert!(chunk.remaining() != 0);
 
-        let state = match self.state.writing {
-            Writing::Body(ref encoder) => {
+        let state = match &mut self.state.writing {
+            Writing::Body(encoder) => {
                 let can_keep_alive = encoder.encode_and_end(chunk, self.io.write_buf());
                 if can_keep_alive {
                     Writing::KeepAlive
@@ -783,8 +783,8 @@ where
     pub(crate) fn end_body(&mut self) -> crate::Result<()> {
         debug_assert!(self.can_write_body());
 
-        let encoder = match self.state.writing {
-            Writing::Body(ref mut enc) => enc,
+        let encoder = match &mut self.state.writing {
+            Writing::Body(enc) => enc,
             _ => return Ok(()),
         };
 
@@ -856,7 +856,7 @@ where
 
     /// If the read side can be cheaply drained, do so. Otherwise, close.
     pub(super) fn poll_drain_or_close_read(&mut self, cx: &mut Context<'_>) {
-        if let Reading::Continue(ref decoder) = self.state.reading {
+        if let Reading::Continue(decoder) = &mut self.state.reading {
             // skip sending the 100-continue
             // just move forward to a read, in case a tiny body was included
             self.state.reading = Reading::Body(decoder.clone());
@@ -994,7 +994,7 @@ impl fmt::Debug for State {
             .field("keep_alive", &self.keep_alive);
 
         // Only show error field if it's interesting...
-        if let Some(ref error) = self.error {
+        if let Some(error) = &self.error {
             builder.field("error", error);
         }
 
@@ -1010,9 +1010,9 @@ impl fmt::Debug for State {
 
 impl fmt::Debug for Writing {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
+        match self {
             Writing::Init => f.write_str("Init"),
-            Writing::Body(ref enc) => f.debug_tuple("Body").field(enc).finish(),
+            Writing::Body(enc) => f.debug_tuple("Body").field(enc).finish(),
             Writing::KeepAlive => f.write_str("KeepAlive"),
             Writing::Closed => f.write_str("Closed"),
         }

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -147,8 +147,8 @@ impl Decoder {
         body: &mut R,
     ) -> Poll<Result<Frame<Bytes>, io::Error>> {
         trace!("decode; state={:?}", self.kind);
-        match self.kind {
-            Length(ref mut remaining) => {
+        match &mut self.kind {
+            Length(remaining) => {
                 if *remaining == 0 {
                     Poll::Ready(Ok(Frame::data(Bytes::new())))
                 } else {
@@ -169,13 +169,13 @@ impl Decoder {
                 }
             }
             Chunked {
-                ref mut state,
-                ref mut chunk_len,
-                ref mut extensions_cnt,
-                ref mut trailers_buf,
-                ref mut trailers_cnt,
-                ref h1_max_headers,
-                ref h1_max_header_size,
+                state,
+                chunk_len,
+                extensions_cnt,
+                trailers_buf,
+                trailers_cnt,
+                h1_max_headers,
+                h1_max_header_size,
             } => {
                 let h1_max_headers = h1_max_headers.unwrap_or(DEFAULT_MAX_HEADERS);
                 let h1_max_header_size = h1_max_header_size.unwrap_or(TRAILER_LIMIT);
@@ -221,7 +221,7 @@ impl Decoder {
                     }
                 }
             }
-            Eof(ref mut is_eof) => {
+            Eof(is_eof) => {
                 if *is_eof {
                     Poll::Ready(Ok(Frame::data(Bytes::new())))
                 } else {
@@ -604,7 +604,7 @@ impl ChunkedState {
                         buf.put_u8(byte);
                         *trailers_buf = Some(buf);
                     }
-                    Some(ref mut trailers_buf) => {
+                    Some(trailers_buf) => {
                         put_u8!(trailers_buf, byte, h1_max_header_size);
                     }
                 }

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -591,7 +591,7 @@ cfg_server! {
             cx: &mut Context<'_>,
         ) -> Poll<Option<Result<(Self::PollItem, Self::PollBody), Self::PollError>>> {
             let mut this = self.as_mut();
-            let ret = if let Some(ref mut fut) = this.in_flight.as_mut().as_pin_mut() {
+            let ret = if let Some(fut) = &mut this.in_flight.as_mut().as_pin_mut() {
                 let resp = ready!(fut.as_mut().poll(cx)?);
                 let (parts, body) = resp.into_parts();
                 let head = MessageHead {
@@ -741,8 +741,8 @@ cfg_client! {
         }
 
         fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ()>> {
-            match self.callback {
-                Some(ref mut cb) => match cb.poll_canceled(cx) {
+            match &mut self.callback {
+                Some(cb) => match cb.poll_canceled(cx) {
                     Poll::Ready(()) => {
                         trace!("callback receiver has dropped");
                         Poll::Ready(Err(()))

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -132,7 +132,7 @@ impl Encoder {
         let len = msg.remaining();
         debug_assert!(len > 0, "encode() called with empty buf");
 
-        let kind = match self.kind {
+        let kind = match &mut self.kind {
             Kind::Chunked(_) => {
                 trace!("encoding chunked {}B", len);
                 let buf = ChunkSize::new(len)
@@ -140,7 +140,7 @@ impl Encoder {
                     .chain(b"\r\n" as &'static [u8]);
                 BufKind::Chunked(buf)
             }
-            Kind::Length(ref mut remaining) => {
+            Kind::Length(remaining) => {
                 trace!("sized write, len = {}", len);
                 if len as u64 > *remaining {
                     let limit = *remaining as usize;
@@ -285,45 +285,45 @@ where
 {
     #[inline]
     fn remaining(&self) -> usize {
-        match self.kind {
-            BufKind::Exact(ref b) => b.remaining(),
-            BufKind::Limited(ref b) => b.remaining(),
-            BufKind::Chunked(ref b) => b.remaining(),
-            BufKind::ChunkedEnd(ref b) => b.remaining(),
-            BufKind::Trailers(ref b) => b.remaining(),
+        match &self.kind {
+            BufKind::Exact(b) => b.remaining(),
+            BufKind::Limited(b) => b.remaining(),
+            BufKind::Chunked(b) => b.remaining(),
+            BufKind::ChunkedEnd(b) => b.remaining(),
+            BufKind::Trailers(b) => b.remaining(),
         }
     }
 
     #[inline]
     fn chunk(&self) -> &[u8] {
-        match self.kind {
-            BufKind::Exact(ref b) => b.chunk(),
-            BufKind::Limited(ref b) => b.chunk(),
-            BufKind::Chunked(ref b) => b.chunk(),
-            BufKind::ChunkedEnd(ref b) => b.chunk(),
-            BufKind::Trailers(ref b) => b.chunk(),
+        match &self.kind {
+            BufKind::Exact(b) => b.chunk(),
+            BufKind::Limited(b) => b.chunk(),
+            BufKind::Chunked(b) => b.chunk(),
+            BufKind::ChunkedEnd(b) => b.chunk(),
+            BufKind::Trailers(b) => b.chunk(),
         }
     }
 
     #[inline]
     fn advance(&mut self, cnt: usize) {
-        match self.kind {
-            BufKind::Exact(ref mut b) => b.advance(cnt),
-            BufKind::Limited(ref mut b) => b.advance(cnt),
-            BufKind::Chunked(ref mut b) => b.advance(cnt),
-            BufKind::ChunkedEnd(ref mut b) => b.advance(cnt),
-            BufKind::Trailers(ref mut b) => b.advance(cnt),
+        match &mut self.kind {
+            BufKind::Exact(b) => b.advance(cnt),
+            BufKind::Limited(b) => b.advance(cnt),
+            BufKind::Chunked(b) => b.advance(cnt),
+            BufKind::ChunkedEnd(b) => b.advance(cnt),
+            BufKind::Trailers(b) => b.advance(cnt),
         }
     }
 
     #[inline]
     fn chunks_vectored<'t>(&'t self, dst: &mut [IoSlice<'t>]) -> usize {
-        match self.kind {
-            BufKind::Exact(ref b) => b.chunks_vectored(dst),
-            BufKind::Limited(ref b) => b.chunks_vectored(dst),
-            BufKind::Chunked(ref b) => b.chunks_vectored(dst),
-            BufKind::ChunkedEnd(ref b) => b.chunks_vectored(dst),
-            BufKind::Trailers(ref b) => b.chunks_vectored(dst),
+        match &self.kind {
+            BufKind::Exact(b) => b.chunks_vectored(dst),
+            BufKind::Limited(b) => b.chunks_vectored(dst),
+            BufKind::Chunked(b) => b.chunks_vectored(dst),
+            BufKind::ChunkedEnd(b) => b.chunks_vectored(dst),
+            BufKind::Trailers(b) => b.chunks_vectored(dst),
         }
     }
 }

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -394,15 +394,15 @@ impl ReadStrategy {
     }
 
     fn record(&mut self, bytes_read: usize) {
-        match *self {
+        match self {
             ReadStrategy::Adaptive {
-                ref mut decrease_now,
-                ref mut next,
+                decrease_now,
+                next,
                 max,
                 ..
             } => {
                 if bytes_read >= *next {
-                    *next = cmp::min(incr_power_of_two(*next), max);
+                    *next = cmp::min(incr_power_of_two(*next), *max);
                     *decrease_now = false;
                 } else {
                     let decr_to = prev_power_of_two(*next);

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -328,12 +328,12 @@ impl Http1Transaction for Server {
                 _ => (),
             }
 
-            if let Some(ref mut header_case_map) = header_case_map {
+            if let Some(header_case_map) = &mut header_case_map {
                 header_case_map.append(&name, slice.slice(header.name.0..header.name.1));
             }
 
             #[cfg(feature = "ffi")]
-            if let Some(ref mut header_order) = header_order {
+            if let Some(header_order) = &mut header_order {
                 header_order.append(&name);
             }
 
@@ -618,9 +618,9 @@ impl Server {
             fn write_header_name(&mut self, dst: &mut Vec<u8>, name: &HeaderName) {
                 let Self {
                     map,
-                    ref mut current,
+                    current,
                     title_case_headers,
-                } = *self;
+                } = self;
                 if current.as_ref().map_or(true, |(last, _)| last != name) {
                     *current = None;
                 }
@@ -629,7 +629,7 @@ impl Server {
 
                 if let Some(orig_name) = values.next() {
                     extend(dst, orig_name);
-                } else if title_case_headers {
+                } else if *title_case_headers {
                     title_case(dst, name.as_str().as_bytes());
                 } else {
                     extend(dst, name.as_str().as_bytes());
@@ -883,8 +883,8 @@ impl Server {
                             .filter_map(|s| HeaderName::from_bytes(s.trim().as_bytes()).ok())
                             .collect();
 
-                        match allowed_trailer_fields {
-                            Some(ref mut fields) => {
+                        match &mut allowed_trailer_fields {
+                            Some(fields) => {
                                 fields.extend(names);
                             }
                             None => {
@@ -1130,12 +1130,12 @@ impl Http1Transaction for Client {
                     }
                 }
 
-                if let Some(ref mut header_case_map) = header_case_map {
+                if let Some(header_case_map) = &mut header_case_map {
                     header_case_map.append(&name, slice.slice(header.name.0..header.name.1));
                 }
 
                 #[cfg(feature = "ffi")]
-                if let Some(ref mut header_order) = header_order {
+                if let Some(header_order) = &mut header_order {
                     header_order.append(&name);
                 }
 

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -285,35 +285,35 @@ enum SendBuf<B> {
 impl<B: Buf> Buf for SendBuf<B> {
     #[inline]
     fn remaining(&self) -> usize {
-        match *self {
-            Self::Buf(ref b) => b.remaining(),
-            Self::Cursor(ref c) => Buf::remaining(c),
+        match self {
+            Self::Buf(b) => b.remaining(),
+            Self::Cursor(c) => Buf::remaining(c),
             Self::None => 0,
         }
     }
 
     #[inline]
     fn chunk(&self) -> &[u8] {
-        match *self {
-            Self::Buf(ref b) => b.chunk(),
-            Self::Cursor(ref c) => c.chunk(),
+        match self {
+            Self::Buf(b) => b.chunk(),
+            Self::Cursor(c) => c.chunk(),
             Self::None => &[],
         }
     }
 
     #[inline]
     fn advance(&mut self, cnt: usize) {
-        match *self {
-            Self::Buf(ref mut b) => b.advance(cnt),
-            Self::Cursor(ref mut c) => c.advance(cnt),
+        match self {
+            Self::Buf(b) => b.advance(cnt),
+            Self::Cursor(c) => c.advance(cnt),
             Self::None => {}
         }
     }
 
     fn chunks_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
-        match *self {
-            Self::Buf(ref b) => b.chunks_vectored(dst),
-            Self::Cursor(ref c) => c.chunks_vectored(dst),
+        match self {
+            Self::Buf(b) => b.chunks_vectored(dst),
+            Self::Cursor(c) => c.chunks_vectored(dst),
             Self::None => 0,
         }
     }

--- a/src/proto/h2/ping.rs
+++ b/src/proto/h2/ping.rs
@@ -191,7 +191,7 @@ impl Config {
 
 impl Recorder {
     pub(crate) fn record_data(&self, len: usize) {
-        let shared = if let Some(ref shared) = self.shared {
+        let shared = if let Some(shared) = &self.shared {
             shared
         } else {
             return;
@@ -204,7 +204,7 @@ impl Recorder {
         // are we ready to send another bdp ping?
         // if not, we don't need to record bytes either
 
-        if let Some(ref next_bdp_at) = locked.next_bdp_at {
+        if let Some(next_bdp_at) = &locked.next_bdp_at {
             if locked.timer.now() < *next_bdp_at {
                 return;
             } else {
@@ -212,7 +212,7 @@ impl Recorder {
             }
         }
 
-        if let Some(ref mut bytes) = locked.bytes {
+        if let Some(bytes) = &mut locked.bytes {
             *bytes += len;
         } else {
             // no need to send bdp ping if bdp is disabled
@@ -225,7 +225,7 @@ impl Recorder {
     }
 
     pub(crate) fn record_non_data(&self) {
-        let shared = if let Some(ref shared) = self.shared {
+        let shared = if let Some(shared) = &self.shared {
             shared
         } else {
             return;
@@ -248,7 +248,7 @@ impl Recorder {
     }
 
     pub(super) fn ensure_not_timed_out(&self) -> crate::Result<()> {
-        if let Some(ref shared) = self.shared {
+        if let Some(shared) = &self.shared {
             let locked = shared.lock().panic_if_poisoned();
             if locked.is_keep_alive_timed_out {
                 return Err(KeepAliveTimedOut.crate_error());
@@ -268,7 +268,7 @@ impl Ponger {
         let now = locked.timer.now(); // hoping this is fine to move within the lock
         let is_idle = self.is_idle();
 
-        if let Some(ref mut ka) = self.keep_alive {
+        if let Some(ka) = &mut self.keep_alive {
             ka.maybe_schedule(is_idle, &locked);
             ka.maybe_ping(cx, is_idle, &mut locked);
         }
@@ -287,13 +287,13 @@ impl Ponger {
                 let rtt = now - start;
                 trace!("recv pong");
 
-                if let Some(ref mut ka) = self.keep_alive {
+                if let Some(ka) = &mut self.keep_alive {
                     locked.update_last_read_at();
                     ka.maybe_schedule(is_idle, &locked);
                     ka.maybe_ping(cx, is_idle, &mut locked);
                 }
 
-                if let Some(ref mut bdp) = self.bdp {
+                if let Some(bdp) = &mut self.bdp {
                     let bytes = locked.bytes.expect("bdp enabled implies bytes");
                     locked.bytes = Some(0); // reset
                     trace!("received BDP ack; bytes = {}, rtt = {:?}", bytes, rtt);
@@ -309,7 +309,7 @@ impl Ponger {
                 debug!("pong error: {}", _e);
             }
             Poll::Pending => {
-                if let Some(ref mut ka) = self.keep_alive {
+                if let Some(ka) = &mut self.keep_alive {
                     if let Err(KeepAliveTimedOut) = ka.maybe_timeout(cx) {
                         self.keep_alive = None;
                         locked.is_keep_alive_timed_out = true;

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -184,11 +184,11 @@ where
 
     pub(crate) fn graceful_shutdown(&mut self) {
         trace!("graceful_shutdown");
-        match self.state {
+        match &mut self.state {
             State::Handshaking { .. } => {
                 self.close_pending = true;
             }
-            State::Serving(ref mut srv) => {
+            State::Serving(srv) => {
                 if srv.closing.is_none() {
                     srv.conn.graceful_shutdown();
                 }
@@ -210,11 +210,8 @@ where
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = &mut *self;
         loop {
-            let next = match me.state {
-                State::Handshaking {
-                    ref mut hs,
-                    ref ping_config,
-                } => {
+            let next = match &mut me.state {
+                State::Handshaking { hs, ping_config } => {
                     let mut conn = ready!(Pin::new(hs).poll(cx).map_err(crate::Error::new_h2))?;
                     let ping = if ping_config.is_enabled() {
                         let pp = conn.ping_pong().expect("conn.ping_pong");
@@ -229,7 +226,7 @@ where
                         date_header: me.date_header,
                     })
                 }
-                State::Serving(ref mut srv) => {
+                State::Serving(srv) => {
                     // graceful_shutdown was called before handshaking finished,
                     if me.close_pending && srv.closing.is_none() {
                         srv.conn.graceful_shutdown();
@@ -324,7 +321,7 @@ where
                     }
                     None => {
                         // no more incoming streams...
-                        if let Some((ref ping, _)) = self.ping {
+                        if let Some((ping, _)) = &self.ping {
                             ping.ensure_not_timed_out()?;
                         }
 
@@ -346,7 +343,7 @@ where
     }
 
     fn poll_ping(&mut self, cx: &mut Context<'_>) {
-        if let Some((_, ref mut estimator)) = self.ping {
+        if let Some((_, estimator)) = &mut self.ping {
             match estimator.poll(cx) {
                 Poll::Ready(ping::Ponged::SizeUpdate(wnd)) => {
                     self.conn.set_target_window_size(wnd);

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -226,16 +226,18 @@ impl Future for OnUpgrade {
     type Output = Result<Upgraded, crate::Error>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.rx {
-            Some(ref rx) => Pin::new(&mut *rx.lock().panic_if_poisoned())
-                .poll(cx)
-                .map(|res| match res {
-                    Ok(Ok(upgraded)) => Ok(upgraded),
-                    Ok(Err(err)) => Err(err),
-                    Err(_oneshot_canceled) => {
-                        Err(crate::Error::new_canceled().with(UpgradeExpected))
-                    }
-                }),
+        match &self.rx {
+            Some(rx) => {
+                Pin::new(&mut *rx.lock().panic_if_poisoned())
+                    .poll(cx)
+                    .map(|res| match res {
+                        Ok(Ok(upgraded)) => Ok(upgraded),
+                        Ok(Err(err)) => Err(err),
+                        Err(_oneshot_canceled) => {
+                            Err(crate::Error::new_canceled().with(UpgradeExpected))
+                        }
+                    })
+            }
             None => Poll::Ready(Err(crate::Error::new_user_no_upgrade())),
         }
     }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2351,7 +2351,7 @@ mod conn {
                     if let Poll::Ready(res) = fut2.as_mut().poll(cx) {
                         return Poll::Ready(res);
                     }
-                    if let Some(ref mut conn) = conn_opt {
+                    if let Some(conn) = &mut conn_opt {
                         match Pin::new(conn).poll(cx) {
                             Poll::Ready(_) => {
                                 conn_opt = None;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -3561,13 +3561,6 @@ impl Drop for Serve {
     fn drop(&mut self) {
         drop(self.shutdown_signal.take());
         drop(self.thread.take());
-        /*
-        let r = self.thread.take().unwrap().join();
-        if let Err(e) = &r {
-            println!("{:?}", e);
-        }
-        r.unwrap();
-        */
     }
 }
 

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -3563,7 +3563,7 @@ impl Drop for Serve {
         drop(self.thread.take());
         /*
         let r = self.thread.take().unwrap().join();
-        if let Err(ref e) = r {
+        if let Err(e) = &r {
             println!("{:?}", e);
         }
         r.unwrap();

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -235,7 +235,7 @@ macro_rules! __internal_headers_eq {
     (@val $name: expr, $val:expr) => ({
         let __val = Option::from($val);
         std::sync::Arc::new(move |__hdrs: &hyper::HeaderMap| {
-            if let Some(ref val) = __val {
+            if let Some(val) = &__val {
                 assert_eq!(__hdrs.get($name).expect(stringify!($name)), val.to_string().as_str(), stringify!($name));
             } else {
                 assert_eq!(__hdrs.get($name), None, stringify!($name));


### PR DESCRIPTION
**This PR aims to** 
- Remove `allow` for `ref_patterns` lint, that will now be caught by a `warn` on `restriction`
```
restriction = { level = "warn", priority = -2 }
```
- Move from the use of ref patterns to `&`

**References** 
- https://doc.rust-lang.org/reference/patterns.html?highlight=ref#binding-modes

progresses https://github.com/hyperium/hyper/issues/4071
