### PR TITLE
feat(deps): disable default-features for tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 bytes = "1.2"
 http = "1"
 http-body = "1"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", default-features = false, features = ["sync"] }
 
 # Optional
 


### PR DESCRIPTION
before:

```
> cargo tree --edges normal -e features 
hyper v1.11.0
├── tokio feature "default"
│   └── tokio v1.53.1
│       └── pin-project-lite feature "default"
│           └── pin-project-lite v0.2.17
└── tokio feature "sync"
    └── tokio v1.53.1 (*)
```

after:

```
> cargo tree --edges normal -e features 
hyper v1.11.0
└── tokio feature "sync"
    └── tokio v1.53.1
        └── pin-project-lite feature "default"
            └── pin-project-lite v0.2.17
```

Remove unnecessary features so that downstream users have the opportunity to tailor functionality