### PR TITLE
Fix documentation typo

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -109,7 +109,7 @@ Responsibilities:
 
 - Adhere to the [Code of Conduct][coc]
 - Try to offer advice when the `@hyperium/advisors` team is tagged for input.
-  (This is not a frequent occurence, so the time commitment should generally be
+  (This is not a frequent occurrence, so the time commitment should generally be
   low.)
 
 How to become:


### PR DESCRIPTION
Small documentation typo noticed in the governance doc:

- `docs/GOVERNANCE.md`: "This is not a frequent occurence" -> "This is not a frequent occurrence"

Documentation only; no code changes.
