### PR TITLE
perf(http2): reserve minimal send capacity when piping request bodies

### DIFF
--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -216,12 +216,21 @@ where
                             continue;
                         }
 
-                        // Reserve exactly the chunk size so we never pin more
-                        // connection-level flow-control window than we are
-                        // about to consume. Stash the chunk in `self` so it
-                        // survives the upcoming `poll_capacity` wait even if
-                        // it returns `Poll::Pending`.
-                        me.body_tx.reserve_capacity(len);
+                        // Reserve a minimal claim on the connection-level
+                        // flow-control window rather than the whole chunk. The
+                        // chunk is already in hand, so this still cannot pin
+                        // capacity against a body that never produces data
+                        // (#4003), and h2 raises the request to the buffered
+                        // length inside `send_data`, so the demand eventually
+                        // signalled to the peer is unchanged. Claiming the full
+                        // length up front instead makes every in-flight stream a
+                        // heavyweight claimant while it waits, which is costly
+                        // once the streams on a connection collectively demand
+                        // more than the window the peer advertises. Stash the
+                        // chunk in `self` so it survives the upcoming
+                        // `poll_capacity` wait even if it returns
+                        // `Poll::Pending`.
+                        me.body_tx.reserve_capacity(1);
                         *me.buffered_data = Some(Peeked {
                             data: chunk,
                             is_eos,


### PR DESCRIPTION
[Copilot speaking]

## Motivation

#4061 fixed the #4003 deadlock by polling the request body *before* reserving send capacity, so that a stream can no longer pin connection-level flow-control window against a body that may never produce data. As part of that change, the reservation also grew from a single byte to the full length of the chunk about to be sent.

We associate that second part with a ~10% increase in CPU time per request and a ~12% drop in throughput in a custom load-test environment. The effect only appears under high connection contention — when the streams sharing a connection collectively demand more send capacity than the peer's advertised connection window, so every request has to queue for capacity. Below that threshold it is not measurable.

Claiming the full chunk length makes every in-flight stream a heavyweight claimant in the connection-window distribution for as long as it waits, rather than a stream that is satisfied by its first byte and moves on.

## Change

The body pipe now reserves a single byte of send capacity instead of the full chunk length.

The deadlock fix is unaffected. The reservation is still made only once the chunk is in hand, so it can never be pinned by a body that produces nothing. h2 raises the requested send capacity to the buffered length inside `send_data`, so the demand eventually signalled to the peer is unchanged — only the transient claim held while the stream waits for its first byte of capacity differs.

The reservation size is not observable on the wire, so there is nothing a new test could assert about it; the existing #4003 regression coverage continues to pass.
