### PR TITLE
chore(lib): cleanup old commented code

### DIFF
--- a/src/body/incoming.rs
+++ b/src/body/incoming.rs
@@ -491,8 +491,6 @@ mod tests {
             body_expected_size,
         );
 
-        //assert_eq!(body_size, mem::size_of::<Option<Incoming>>(), "Option<Incoming>");
-
         assert_eq!(
             mem::size_of::<Sender>(),
             mem::size_of::<usize>() * 5,

--- a/src/common/io/rewind.rs
+++ b/src/common/io/rewind.rs
@@ -46,10 +46,6 @@ impl<T> Rewind<T> {
     pub(crate) fn into_inner(self) -> (T, Bytes) {
         (self.inner, self.pre.unwrap_or_default())
     }
-
-    // pub(crate) fn get_mut(&mut self) -> &mut T {
-    //     &mut self.inner
-    // }
 }
 
 impl<T> Read for Rewind<T>

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -657,19 +657,6 @@ mod tests {
 
     use tokio_test::io::Builder as Mock;
 
-    // #[cfg(feature = "nightly")]
-    // use test::Bencher;
-
-    /*
-    impl<T: Read> MemRead for AsyncIo<T> {
-        fn read_mem(&mut self, len: usize) -> Poll<Bytes, io::Error> {
-            let mut v = vec![0; len];
-            let n = try_nb!(self.read(v.as_mut_slice()));
-            Ok(Async::Ready(BytesMut::from(&v[..n]).freeze()))
-        }
-    }
-    */
-
     #[tokio::test]
     #[ignore]
     async fn iobuf_write_empty_slice() {

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -405,7 +405,6 @@ mod tests {
             _: &mut Context<'_>,
             buf: &[u8],
         ) -> Poll<io::Result<usize>> {
-            // panic!("poll_write shouldn't be called");
             Poll::Ready(Ok(buf.len()))
         }
 


### PR DESCRIPTION
Cleaning up some old commented code that hasn't been touched for awhile (>2 years old according to git blame).