### PR TITLE
Ignore personal cargo configurations 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.cargo


### PR DESCRIPTION
Add `.cargo` to `.gitignore` to ignore  local Cargo configuration files such as: `.cargo/config.toml`.
