### PR TITLE
docs: expand crate-level cancel safety section with HTTP/1 vs HTTP/2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,10 +33,23 @@
 //! # Cancel safety
 //!
 //! Futures returned by hyper are cancel safe: dropping a future before it
-//! completes is the supported way to cancel the operation. See the
-//! documentation on individual futures — for example `SendRequest::send_request`
-//! in `client::conn::http1` and `client::conn::http2` — for the protocol-
-//! specific behavior on cancellation.
+//! completes is the supported way to cancel the operation. The protocol in
+//! use changes what that cancellation actually does on the wire:
+//!
+//! - **HTTP/1** has no in-protocol way to abort a single request without
+//!   affecting the shared connection, so dropping an in-flight request future
+//!   closes the underlying TCP connection. Any subsequent call on the same
+//!   `SendRequest` returns a `canceled` error; the connection cannot be
+//!   reused.
+//! - **HTTP/2** resets the single stream with `RST_STREAM` (`CANCEL` error
+//!   code) and notifies the peer immediately rather than continuing to
+//!   deliver a response body that would be discarded. The shared connection
+//!   stays usable for other in-flight and future requests.
+//!
+//! See the documentation on individual futures — for example
+//! `SendRequest::send_request` in `client::conn::http1` and the equivalent
+//! in `client::conn::http2` — for the protocol-specific behavior on
+//! cancellation.
 //!
 //! # Optional Features
 //!


### PR DESCRIPTION
Closes #4054.

The crate-level `# Cancel safety` section in `src/lib.rs` already pointed
readers at the per-future docs, but didn't itself answer the question
that an `unstable_`-doc reader actually has when they land on the crate
root: *"what happens on the wire when I drop this?"*

This change fills in the two-line stub with the protocol-specific
behavior, mirroring what `SendRequest::send_request` already says
downstream:

- HTTP/1: dropping an in-flight request closes the underlying TCP
  connection (no in-protocol per-request abort), and any subsequent
  call on the same `SendRequest` returns `Error::new_canceled()`.
- HTTP/2: dropping resets the single stream with `RST_STREAM`
  (`CANCEL` error code); the shared connection stays usable for other
  in-flight and future requests.

The "see individual futures" pointer at the bottom is preserved so
the existing per-future `Cancel safety` docblocks remain the source of
truth for edge cases (e.g. the bidi client future or specific request
body streams).

Verified with `cargo doc --no-deps` — no new warnings introduced.

Disclosed: this contribution was prepared with the help of Claude (a
large language model). The human in the loop reviewed the diff against
the per-future `Cancel safety` paragraphs in
`src/client/conn/http1.rs` and `src/client/conn/http2.rs` and verified
the summary is faithful and not a paraphrase of anything external.