### PR TITLE
refactor: drop redundant `continue` and remove needless_continue allow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,6 @@ missing_fields_in_debug = "allow" # TODO: use finish_non_exhaustive
 missing_panics_doc = "allow" # TODO: might be false
 multiple_inherent_impl = "allow"
 multiple_unsafe_ops_per_block = "allow"
-needless_continue = "allow"
 needless_pass_by_value = "allow"
 panic = "allow"
 pattern_type_mismatch = "allow"

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -430,7 +430,6 @@ where
                             );
                         } else {
                             trace!("discarding unknown frame");
-                            continue;
                         }
                     } else {
                         *clear_body = true;

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -772,7 +772,6 @@ where
                         }
                     }
                     self.poll_pipe(f, cx);
-                    continue;
                 }
 
                 Poll::Ready(None) => {

--- a/src/proto/h2/upgrade.rs
+++ b/src/proto/h2/upgrade.rs
@@ -236,9 +236,7 @@ impl Read for H2Upgraded {
             self.buf = loop {
                 match ready!(self.recv_stream.poll_data(cx)) {
                     None => return Poll::Ready(Ok(())),
-                    Some(Ok(buf)) if buf.is_empty() && !self.recv_stream.is_end_stream() => {
-                        continue
-                    }
+                    Some(Ok(buf)) if buf.is_empty() && !self.recv_stream.is_end_stream() => {}
                     Some(Ok(buf)) => {
                         self.ping.record_data(buf.len());
                         break buf;


### PR DESCRIPTION
Drops three needless `continue` expressions caught by clippy::needless_continue and removes the lint's allow entry from the project lint allowlist, advancing issue #4071.

Changes:
- src/proto/h1/dispatch.rs: end of `else` branch in dispatch loop
- src/proto/h2/upgrade.rs: empty-buffer arm in poll_read loop
- src/proto/h2/client.rs: end of `Poll::Ready(Some(...))` arm in dispatch loop
- Cargo.toml: drop `needless_continue = "allow"`

Verification:
- `cargo clippy --features full -- -W clippy::needless_continue` is clean
- `cargo build --features full` succeeds
- `cargo test --features full --lib` passes (115 passed, 0 failed)

Generated with Claude Code; I have read and reviewed every change.