### PR TITLE
fix(http1): reject forbidden trailer fields

### DIFF
--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -635,7 +635,6 @@ impl ChunkedState {
     }
 }
 
-// TODO: disallow Transfer-Encoding, Content-Length, Trailer, etc in trailers ??
 fn decode_trailers(buf: &mut BytesMut, count: usize) -> Result<HeaderMap, io::Error> {
     let mut trailers = HeaderMap::new();
     let mut headers = vec![httparse::EMPTY_HEADER; count];
@@ -653,6 +652,16 @@ fn decode_trailers(buf: &mut BytesMut, count: usize) -> Result<HeaderMap, io::Er
                         ));
                     }
                 };
+
+                if name == http::header::CONTENT_LENGTH
+                    || name == http::header::TRANSFER_ENCODING
+                    || name == http::header::TRAILER
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("Forbidden trailer field: {:?}", &header),
+                    ));
+                }
 
                 let value = match HeaderValue::from_bytes(header.value) {
                     Ok(value) => value,
@@ -1162,6 +1171,15 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(values, ["first", "second"]);
+    }
+
+    #[test]
+    fn test_decode_trailers_rejects_forbidden_fields() {
+        for name in ["Content-Length", "Transfer-Encoding", "Trailer"] {
+            let mut buf = BytesMut::from(format!("{name}: value\r\n\r\n").as_bytes());
+            let err = decode_trailers(&mut buf, 1).expect_err("forbidden trailer field");
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        }
     }
 
     #[tokio::test]

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -619,7 +619,7 @@ test! {
             5\r\n\
             hello\r\n\
             0\r\n\
-            Trailer: value\r\n\
+            chunky-trailer: value\r\n\
             \r\n\
             ",
 
@@ -650,7 +650,7 @@ test! {
             5\r\n\
             hello\r\n\
             0\r\n\
-            Trailer: value\r\n\
+            chunky-trailer: value\r\n\
             another-trainer: another-value\r\n\
             \r\n\
             ",
@@ -833,9 +833,6 @@ test! {
             chunky-trailer4: header data4\r\n\
             chunky-trailer5: header data5\r\n\
             sneaky-trailer: not in trailer header\r\n\
-            transfer-encoding: chunked\r\n\
-            content-length: 5\r\n\
-            trailer: foo\r\n\
             \r\n\
             ",
 
@@ -860,9 +857,6 @@ test! {
                 "chunky-trailer4" => "header data4",
                 "chunky-trailer5" => "header data5",
                 "sneaky-trailer" => "not in trailer header",
-                "transfer-encoding" => "chunked",
-                "content-length" => "5",
-                "trailer" => "foo",
             },
 }
 


### PR DESCRIPTION
During a static audit of the HTTP/1 chunked-body decoding path, I found that decode_trailers() accepted every syntactically valid trailer field and inserted it directly into the trailer HeaderMap.

Specifically, a chunked request or response could include Content-Length, Transfer-Encoding, or Trailer in its trailer block. The previous implementation exposed these fields tothe application layer even though they must not be accepted as trailer fields b ecause they control or describe message framing.

The fix validates each trailer field name before inserting it into the HeaderMap. Content-Length, Transfer-Encoding, and Trailer now cause decoding to fail with `io::ErrorKind::InvalidInput`.

A regression test was added to verify that all three fields are rejected.