### PR TITLE
feat(http2): expose h2 data_frame_budget on the client conn builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ atomic-waker = { version = "1.1.2", optional = true }
 futures-channel = { version = "0.3", optional = true }
 futures-core = { version = "0.3.31", optional = true }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
-h2 = { version = "0.4.14", optional = true }
+h2 = { version = "0.4.18", optional = true }
 http-body-util = { version = "0.1", optional = true }
 httparse = { version = "1.9", optional = true }
 httpdate = { version = "1.0", optional = true }

--- a/src/client/conn/http2.rs
+++ b/src/client/conn/http2.rs
@@ -392,6 +392,21 @@ where
         self
     }
 
+    /// Sets a connection-level budget for limiting memory overhead from
+    /// received small DATA frames.
+    ///
+    /// See the documentation of [`h2::client::Builder::data_frame_budget`] for more
+    /// details.
+    ///
+    /// The default value is determined by the `h2` crate. As of v0.4.18, it is
+    /// 25,600 bytes.
+    ///
+    /// [`h2::client::Builder::data_frame_budget`]: https://docs.rs/h2/client/struct.Builder.html#method.data_frame_budget
+    pub fn data_frame_budget(&mut self, budget: usize) -> &mut Self {
+        self.h2_builder.data_frame_budget = Some(budget);
+        self
+    }
+
     /// Sets the max size of received header frames.
     ///
     /// Default is currently 16KB, but can change.

--- a/src/proto/h2/client.rs
+++ b/src/proto/h2/client.rs
@@ -78,6 +78,7 @@ pub(crate) struct Config {
     pub(crate) header_table_size: Option<u32>,
     pub(crate) max_concurrent_streams: Option<u32>,
     pub(crate) reset_stream_duration: Option<Duration>,
+    pub(crate) data_frame_budget: Option<usize>,
 }
 
 impl Default for Config {
@@ -99,6 +100,7 @@ impl Default for Config {
             header_table_size: None,
             max_concurrent_streams: None,
             reset_stream_duration: None,
+            data_frame_budget: None,
         }
     }
 }
@@ -130,6 +132,9 @@ fn new_builder(config: &Config) -> Builder {
     }
     if let Some(dur) = config.reset_stream_duration {
         builder.reset_stream_duration(dur);
+    }
+    if let Some(budget) = config.data_frame_budget {
+        builder.data_frame_budget(budget);
     }
     builder
 }


### PR DESCRIPTION

h2 0.4.16 added a client-side guard against floods of small DATA frames (connection closed with
`GOAWAY ENHANCE_YOUR_CALM` / `too_many_data_frames`), and h2 0.4.18 added the tuning knob for it:
`client::Builder::data_frame_budget`. hyper's `client::conn::http2::Builder` doesn't expose it, so
callers whose peers legitimately send many small frames have no mitigation. Real-world case: gRPC
server-streaming APIs that emit one small message per frame — e.g. Zcash's lightwalletd streams
one ~600-byte block per DATA frame, and a 10,000-item range trips the default budget partway
through, deterministically, on released hyper 1.11.0 + h2 0.4.18 (minimal tonic-only reproducer
attached to, and full context in, zcash/lightwalletd#593:
https://github.com/zcash/lightwalletd/issues/593).

This PR adds `Builder::data_frame_budget` following the exact pass-through pattern of
`max_concurrent_reset_streams` / `reset_stream_duration`, and bumps the h2 floor to 0.4.18 (the
release that introduced the method). Verified: `cargo test --features full` all green; and with
this passthrough plumbed further up through tonic, the reproducer's failing range completes when
the budget is raised, and fails immediately when the budget is set artificially low — the setting
demonstrably reaches h2 in both directions.

A sibling tonic PR exposing this on `Endpoint` is filed as a draft blocked on this one.
