### PR TITLE
feat: make H2Upgraded public for HTTP/2 upgrade downcasting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,11 @@ pub mod ffi;
 
 cfg_proto! {
     mod headers;
-    mod proto;
+    #[cfg_attr(docsrs, doc(cfg(all(
+        any(feature = "http1", feature = "http2"),
+        any(feature = "client", feature = "server"),
+    ))))]
+    pub mod proto;
 }
 
 cfg_feature! {

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -14,7 +14,8 @@ use pin_project_lite::pin_project;
 use crate::body::Body;
 
 pub(crate) mod ping;
-pub(crate) mod upgrade;
+/// HTTP/2 connection upgrade handling.
+pub mod upgrade;
 
 cfg_client! {
     pub(crate) mod client;
@@ -285,6 +286,7 @@ impl<B: Buf> SendStreamExt for SendStream<SendBuf<B>> {
 }
 
 #[repr(usize)]
+#[derive(Debug)]
 enum SendBuf<B> {
     Buf(B),
     Cursor(Cursor<Box<[u8]>>),

--- a/src/proto/h2/upgrade.rs
+++ b/src/proto/h2/upgrade.rs
@@ -45,13 +45,41 @@ pub(super) fn pair<B>(
     )
 }
 
-pub(super) struct H2Upgraded {
+/// The I/O object returned by an HTTP/2 upgrade.
+///
+/// After downgrading an [`Upgraded`](crate::upgrade::Upgraded) connection that
+/// was established over HTTP/2, this type can be used as a [`Read`]/[`Write`]
+/// stream for the upgraded protocol.
+///
+/// ```no_run
+/// # use hyper::upgrade::Upgraded;
+/// use hyper::proto::h2::upgrade::H2Upgraded;
+/// # use hyper::rt::Read;
+///
+/// # fn run(upgraded: Upgraded) {
+/// if let Ok(parts) = upgraded.downcast::<H2Upgraded>() {
+///     let io = parts.io;
+///     // use `io` as Read/Write for the HTTP/2 upgraded stream
+/// #   let _ = io;
+/// }
+/// # }
+/// ```
+pub struct H2Upgraded {
     ping: Recorder,
     send_stream: UpgradedSendStreamBridge,
     recv_stream: RecvStream,
     buf: Bytes,
 }
 
+impl std::fmt::Debug for H2Upgraded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("H2Upgraded")
+            .field("buf", &self.buf)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug)]
 struct UpgradedSendStreamBridge {
     tx: mpsc::Sender<Cursor<Box<[u8]>>>,
     error_rx: oneshot::Receiver<crate::Error>,
@@ -64,6 +92,9 @@ impl Drop for UpgradedSendStreamBridge {
     }
 }
 
+/// Shared state for tracking close notification across the upgraded
+/// send and receive halves.
+#[derive(Debug)]
 struct UpgradedCloseNotify {
     closed: AtomicBool,
     task: AtomicWaker,
@@ -98,7 +129,9 @@ impl UpgradedCloseNotify {
 }
 
 pin_project! {
+    /// Task that drives an HTTP/2 upgraded send stream to completion.
     #[must_use = "futures do nothing unless polled"]
+    #[derive(Debug)]
     pub struct UpgradedSendStreamTask<B> {
         #[pin]
         h2_tx: SendStream<SendBuf<B>>,

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -13,8 +13,9 @@ cfg_feature! {
     pub(crate) use self::h1::ServerTransaction;
 }
 
+/// HTTP/2 protocol implementation.
 #[cfg(feature = "http2")]
-pub(crate) mod h2;
+pub mod h2;
 
 /// An Incoming Message head. Includes request/status line, and headers.
 #[cfg(feature = "http1")]


### PR DESCRIPTION
Fixes hyperium/hyper#3987 — Users currently cannot downcast upgraded HTTP/2 connections to access the underlying IO. H2Upgraded was hidden behind pub(crate) modules and pub(super) visibility. This change makes H2Upgraded public with documentation and Debug impl, and makes the module path public.