### PR TITLE
fix(http2): bound the graceful shutdown wait during handshake

### DIFF
--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -16,7 +16,7 @@ pub(crate) enum Time {
     Empty,
 }
 
-#[cfg(all(feature = "server", feature = "http1"))]
+#[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum Dur {
     Default(Option<Duration>),
@@ -66,7 +66,7 @@ impl Time {
         }
     }
 
-    #[cfg(all(feature = "server", feature = "http1"))]
+    #[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
     pub(crate) fn check(&self, dur: Dur, name: &'static str) -> Option<Duration> {
         match dur {
             Dur::Default(Some(dur)) => match self {

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -15,7 +15,7 @@ use super::{ping, PipeToSendStream, SendBuf};
 use crate::body::{Body, Incoming as IncomingBody};
 use crate::common::date;
 use crate::common::io::Compat;
-use crate::common::time::Time;
+use crate::common::time::{Dur, Time};
 use crate::ext::Protocol;
 use crate::headers;
 use crate::proto::h2::ping::Recorder;
@@ -52,7 +52,7 @@ const DEFAULT_MAX_LOCAL_ERROR_RESET_STREAMS: usize = 1024;
 //
 // This only has to cover a handshake whose bytes have already arrived, which
 // takes microseconds, so it is deliberately short.
-const HANDSHAKE_SHUTDOWN_GRACE: Duration = Duration::from_secs(1);
+const DEFAULT_HANDSHAKE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Debug)]
 pub(crate) struct Config {
@@ -66,6 +66,7 @@ pub(crate) struct Config {
     pub(crate) max_local_error_reset_streams: Option<usize>,
     pub(crate) keep_alive_interval: Option<Duration>,
     pub(crate) keep_alive_timeout: Duration,
+    pub(crate) handshake_shutdown_timeout: Dur,
     pub(crate) max_send_buffer_size: usize,
     pub(crate) header_table_size: Option<u32>,
     pub(crate) max_header_list_size: u32,
@@ -86,6 +87,9 @@ impl Default for Config {
             header_table_size: None,
             keep_alive_interval: None,
             keep_alive_timeout: Duration::from_secs(20),
+            handshake_shutdown_timeout: Dur::Default(Some(
+                DEFAULT_HANDSHAKE_SHUTDOWN_TIMEOUT,
+            )),
             max_send_buffer_size: DEFAULT_MAX_SEND_BUF_SIZE,
             max_header_list_size: DEFAULT_SETTINGS_MAX_HEADER_LIST_SIZE,
             date_header: true,
@@ -104,12 +108,21 @@ pin_project! {
         service: S,
         state: State<T, B>,
         date_header: bool,
-        close_pending: bool,
-        // Bounds `close_pending`. `None` while a shutdown is pending means
-        // there was no timer to build a deadline with, and the connection is
-        // closed at the next poll instead.
-        handshake_deadline: Option<Pin<Box<dyn Sleep>>>
+        handshake_shutdown_timeout: Dur,
+        // `None` until a graceful shutdown arrives while still handshaking.
+        shutdown: Option<HandshakeShutdown>
     }
+}
+
+/// What a graceful shutdown that arrived mid-handshake should do about it.
+enum HandshakeShutdown {
+    /// Close once this elapses, if the handshake has not finished by then.
+    Deadline(Pin<Box<dyn Sleep>>),
+    /// Nothing to build a deadline from, so no grace is granted and the
+    /// connection closes at the next poll.
+    Immediate,
+    /// Bounding is switched off; wait for the handshake however long it takes.
+    Unbounded,
 }
 
 //#[expect(clippy::large_enum_variant, reason = "the whole future is boxed")]
@@ -196,8 +209,8 @@ where
             },
             service,
             date_header: config.date_header,
-            close_pending: false,
-            handshake_deadline: None,
+            handshake_shutdown_timeout: config.handshake_shutdown_timeout,
+            shutdown: None,
         }
     }
 
@@ -205,15 +218,21 @@ where
         trace!("graceful_shutdown");
         match &mut self.state {
             State::Handshaking { .. } => {
-                if !self.close_pending {
-                    self.close_pending = true;
-                    // Without a timer there is no way to bound the wait, so
-                    // none is granted: the next poll closes the connection,
-                    // which is what hyper did before 1.10.
-                    if let Time::Timer(_) = self.timer {
-                        self.handshake_deadline =
-                            Some(self.timer.sleep(HANDSHAKE_SHUTDOWN_GRACE));
-                    }
+                if self.shutdown.is_none() {
+                    self.shutdown = Some(match self.handshake_shutdown_timeout {
+                        // Explicitly switched off by the user.
+                        Dur::Configured(None) | Dur::Default(None) => {
+                            HandshakeShutdown::Unbounded
+                        }
+                        dur => match self.timer.check(dur, "handshake_shutdown_timeout") {
+                            Some(dur) => HandshakeShutdown::Deadline(self.timer.sleep(dur)),
+                            // Only reachable for the default, since `check`
+                            // panics on a configured value with no timer. With
+                            // no way to bound the wait, none is granted, which
+                            // is what hyper did before 1.10.
+                            None => HandshakeShutdown::Immediate,
+                        },
+                    });
                 }
             }
             State::Serving(srv) => {
@@ -240,21 +259,18 @@ where
         loop {
             let next = match &mut me.state {
                 State::Handshaking { hs, ping_config } => {
-                    if me.close_pending {
-                        match me.handshake_deadline.as_mut() {
-                            None => {
-                                trace!("graceful shutdown during handshake, no timer set");
+                    match me.shutdown.as_mut() {
+                        Some(HandshakeShutdown::Immediate) => {
+                            trace!("graceful shutdown during handshake, no timer set");
+                            return Poll::Ready(Ok(Dispatched::Shutdown));
+                        }
+                        Some(HandshakeShutdown::Deadline(deadline)) => {
+                            if Pin::new(deadline).poll(cx).is_ready() {
+                                debug!("graceful shutdown timed out waiting for the handshake");
                                 return Poll::Ready(Ok(Dispatched::Shutdown));
                             }
-                            Some(deadline) => {
-                                if Pin::new(deadline).poll(cx).is_ready() {
-                                    debug!(
-                                        "graceful shutdown timed out waiting for the handshake"
-                                    );
-                                    return Poll::Ready(Ok(Dispatched::Shutdown));
-                                }
-                            }
                         }
+                        Some(HandshakeShutdown::Unbounded) | None => (),
                     }
                     let mut conn = ready!(Pin::new(hs).poll(cx).map_err(crate::Error::new_h2))?;
                     let ping = if ping_config.is_enabled() {
@@ -272,7 +288,7 @@ where
                 }
                 State::Serving(srv) => {
                     // graceful_shutdown was called before handshaking finished,
-                    if me.close_pending && srv.closing.is_none() {
+                    if me.shutdown.is_some() && srv.closing.is_none() {
                         srv.conn.graceful_shutdown();
                     }
                     ready!(srv.poll_server(cx, &mut me.service, &mut me.exec))?;

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -21,7 +21,7 @@ use crate::headers;
 use crate::proto::h2::ping::Recorder;
 use crate::proto::Dispatched;
 use crate::rt::bounds::{Http2ServerConnExec, Http2UpgradedExec};
-use crate::rt::{Read, Write};
+use crate::rt::{Read, Sleep, Write};
 use crate::service::HttpService;
 
 use crate::upgrade::{OnUpgrade, Pending, Upgraded};
@@ -39,6 +39,20 @@ const DEFAULT_MAX_FRAME_SIZE: u32 = 1024 * 16; // 16kb
 const DEFAULT_MAX_SEND_BUF_SIZE: usize = 1024 * 400; // 400kb
 const DEFAULT_SETTINGS_MAX_HEADER_LIST_SIZE: u32 = 1024 * 16; // 16kb
 const DEFAULT_MAX_LOCAL_ERROR_RESET_STREAMS: usize = 1024;
+
+// How long the handshake is given to finish once a graceful shutdown has been
+// requested.
+//
+// A client may coalesce its connection preface with real requests, so a
+// shutdown arriving mid-handshake has to let the handshake finish where it
+// can: that is what allows those requests to be answered, or at least
+// accounted for in a GOAWAY. Waiting for it unconditionally is what cannot be
+// done, because a peer that connects and then says nothing leaves the
+// handshake pending forever and takes the shutdown down with it.
+//
+// This only has to cover a handshake whose bytes have already arrived, which
+// takes microseconds, so it is deliberately short.
+const HANDSHAKE_SHUTDOWN_GRACE: Duration = Duration::from_secs(1);
 
 #[derive(Clone, Debug)]
 pub(crate) struct Config {
@@ -90,7 +104,11 @@ pin_project! {
         service: S,
         state: State<T, B>,
         date_header: bool,
-        close_pending: bool
+        close_pending: bool,
+        // Bounds `close_pending`. `None` while a shutdown is pending means
+        // there was no timer to build a deadline with, and the connection is
+        // closed at the next poll instead.
+        handshake_deadline: Option<Pin<Box<dyn Sleep>>>
     }
 }
 
@@ -179,6 +197,7 @@ where
             service,
             date_header: config.date_header,
             close_pending: false,
+            handshake_deadline: None,
         }
     }
 
@@ -186,7 +205,16 @@ where
         trace!("graceful_shutdown");
         match &mut self.state {
             State::Handshaking { .. } => {
-                self.close_pending = true;
+                if !self.close_pending {
+                    self.close_pending = true;
+                    // Without a timer there is no way to bound the wait, so
+                    // none is granted: the next poll closes the connection,
+                    // which is what hyper did before 1.10.
+                    if let Time::Timer(_) = self.timer {
+                        self.handshake_deadline =
+                            Some(self.timer.sleep(HANDSHAKE_SHUTDOWN_GRACE));
+                    }
+                }
             }
             State::Serving(srv) => {
                 if srv.closing.is_none() {
@@ -212,6 +240,22 @@ where
         loop {
             let next = match &mut me.state {
                 State::Handshaking { hs, ping_config } => {
+                    if me.close_pending {
+                        match me.handshake_deadline.as_mut() {
+                            None => {
+                                trace!("graceful shutdown during handshake, no timer set");
+                                return Poll::Ready(Ok(Dispatched::Shutdown));
+                            }
+                            Some(deadline) => {
+                                if Pin::new(deadline).poll(cx).is_ready() {
+                                    debug!(
+                                        "graceful shutdown timed out waiting for the handshake"
+                                    );
+                                    return Poll::Ready(Ok(Dispatched::Shutdown));
+                                }
+                            }
+                        }
+                    }
                     let mut conn = ready!(Pin::new(hs).poll(cx).map_err(crate::Error::new_h2))?;
                     let ping = if ping_config.is_enabled() {
                         let pp = conn.ping_pong().expect("conn.ping_pong");

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -16,6 +16,7 @@ use crate::body::{Body, Incoming as IncomingBody};
 use crate::proto;
 use crate::rt::bounds::Http2ServerConnExec;
 use crate::service::HttpService;
+use crate::common::time::Dur;
 use crate::{common::time::Time, rt::Timer};
 
 pin_project! {
@@ -236,6 +237,31 @@ impl<E> Builder<E> {
     /// Default is 20 seconds.
     pub fn keep_alive_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.h2_builder.keep_alive_timeout = timeout;
+        self
+    }
+
+    /// Set how long a graceful shutdown will wait for an in-progress handshake
+    /// to finish.
+    ///
+    /// A shutdown requested while a connection is still handshaking is applied
+    /// once that handshake completes, so that requests a client coalesced with
+    /// its connection preface are still answered, or at least accounted for in
+    /// a GOAWAY. A handshake that never completes would otherwise hold the
+    /// shutdown open forever, which this bounds.
+    ///
+    /// Passing `None` restores that unbounded wait.
+    ///
+    /// Requires a [`Timer`](crate::rt::Timer) set by [`Builder::timer`]. If one
+    /// is configured without a timer, this panics. Without a timer the default
+    /// cannot be applied either, and such connections are closed at once
+    /// rather than waited on.
+    ///
+    /// Default is 1 second.
+    pub fn handshake_shutdown_timeout(
+        &mut self,
+        timeout: impl Into<Option<Duration>>,
+    ) -> &mut Self {
+        self.h2_builder.handshake_shutdown_timeout = Dur::Configured(timeout.into());
         self
     }
 

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2884,6 +2884,63 @@ async fn http2_graceful_shutdown_during_handshake_lets_it_finish() {
     assert_eq!(buf[3], 0x04, "expected SETTINGS, got {:?}", &buf[..n]);
 }
 
+#[tokio::test]
+async fn http2_handshake_shutdown_timeout_configurable() {
+    let (listener, addr) = setup_tcp_listener();
+
+    tokio::spawn(async move {
+        let socket = listener.accept().await.unwrap().0;
+        let socket = TokioIo::new(socket);
+
+        let future = http2::Builder::new(TokioExecutor)
+            .timer(TokioTimer)
+            .handshake_shutdown_timeout(Duration::from_millis(100))
+            .serve_connection(socket, HelloWorld);
+        pin!(future);
+        future.as_mut().graceful_shutdown();
+
+        future.await.unwrap();
+    });
+
+    // Same silent client as above, but the connection should be given up on
+    // well inside the one second default.
+    let mut stream = TkTcpStream::connect(addr).await.unwrap();
+
+    let mut buf = vec![];
+    tokio::time::timeout(Duration::from_millis(750), stream.read_to_end(&mut buf))
+        .await
+        .expect("should have closed inside the configured timeout")
+        .expect("error reading");
+}
+
+#[tokio::test]
+async fn http2_handshake_shutdown_timeout_can_be_disabled() {
+    let (listener, addr) = setup_tcp_listener();
+
+    tokio::spawn(async move {
+        let socket = listener.accept().await.unwrap().0;
+        let socket = TokioIo::new(socket);
+
+        let future = http2::Builder::new(TokioExecutor)
+            .timer(TokioTimer)
+            .handshake_shutdown_timeout(None)
+            .serve_connection(socket, HelloWorld);
+        pin!(future);
+        future.as_mut().graceful_shutdown();
+
+        future.await.unwrap();
+    });
+
+    // Opting out restores the unbounded wait, so this silent client keeps the
+    // shutdown open and nothing is closed.
+    let mut stream = TkTcpStream::connect(addr).await.unwrap();
+
+    let mut buf = vec![];
+    tokio::time::timeout(Duration::from_secs(2), stream.read_to_end(&mut buf))
+        .await
+        .expect_err("connection should still be waiting on the handshake");
+}
+
 #[test]
 fn streaming_body() {
     use futures_util::StreamExt;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2810,6 +2810,80 @@ async fn graceful_shutdown_before_first_request_no_block() {
         .expect("error receiving response");
 }
 
+#[tokio::test]
+async fn http2_graceful_shutdown_before_handshake_no_block() {
+    let (listener, addr) = setup_tcp_listener();
+
+    tokio::spawn(async move {
+        let socket = listener.accept().await.unwrap().0;
+        let socket = TokioIo::new(socket);
+
+        let future = http2::Builder::new(TokioExecutor)
+            .timer(TokioTimer)
+            .serve_connection(socket, HelloWorld);
+        pin!(future);
+        // Shutdown requested before the handshake has been polled at all.
+        future.as_mut().graceful_shutdown();
+
+        future.await.unwrap();
+    });
+
+    // This client never sends its preface, so the handshake it is holding open
+    // can never complete. The shutdown must finish regardless, which we see as
+    // the socket being closed.
+    let mut stream = TkTcpStream::connect(addr).await.unwrap();
+
+    let mut buf = vec![];
+    tokio::time::timeout(Duration::from_secs(10), stream.read_to_end(&mut buf))
+        .await
+        .expect("timed out waiting for graceful shutdown")
+        .expect("error reading");
+}
+
+#[tokio::test]
+async fn http2_graceful_shutdown_during_handshake_lets_it_finish() {
+    let (listener, addr) = setup_tcp_listener();
+
+    tokio::spawn(async move {
+        let socket = listener.accept().await.unwrap().0;
+        let socket = TokioIo::new(socket);
+
+        let future = http2::Builder::new(TokioExecutor)
+            .timer(TokioTimer)
+            .serve_connection(socket, HelloWorld);
+        pin!(future);
+        // Again before the first poll, but this time the peer does speak.
+        future.as_mut().graceful_shutdown();
+
+        let _ = future.await;
+    });
+
+    let mut stream = TkTcpStream::connect(addr).await.unwrap();
+    // The preface and an empty SETTINGS frame, so the handshake can complete
+    // from bytes that have already arrived.
+    stream
+        .write_all(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")
+        .await
+        .unwrap();
+    stream
+        .write_all(&[0, 0, 0, 4, 0, 0, 0, 0, 0])
+        .await
+        .unwrap();
+
+    // A shutdown that dropped the connection outright would close without a
+    // word, taking any requests coalesced with the preface down with it, which
+    // is what hyper#3729 fixed. Letting the handshake finish means the server
+    // speaks first, starting with its own SETTINGS.
+    let mut buf = [0u8; 64];
+    let n = tokio::time::timeout(Duration::from_secs(10), stream.read(&mut buf))
+        .await
+        .expect("timed out waiting for the server")
+        .expect("error reading");
+    assert!(n > 0, "server closed without completing the handshake");
+    // Frame header is a 3 byte length then the type; 0x04 is SETTINGS.
+    assert_eq!(buf[3], 0x04, "expected SETTINGS, got {:?}", &buf[..n]);
+}
+
 #[test]
 fn streaming_body() {
     use futures_util::StreamExt;


### PR DESCRIPTION
## Problem

A graceful shutdown that arrives while an HTTP/2 connection is still
handshaking is recorded and replayed once the handshake completes:

https://github.com/hyperium/hyper/blob/37c9d0c7e018d3c218f1fc0e472207ff05ef3772/src/proto/h2/server.rs#L189

That deferral is correct and was added deliberately in #3729. A client may
coalesce its connection preface with real request frames, and dropping the
connection outright would take those requests with it, leaving the client with
no idea whether they had been processed.

The problem is that the deferral is unbounded. If the handshake never
completes, the intent is never delivered and the shutdown waits on that
connection forever. Nothing else bounds it either, because the keep-alive ping
only starts once the handshake is done and so cannot reach a connection parked
in `ReadingPreface`. A server that drains before exiting therefore never exits.

This is not only reachable by a misbehaving peer. A client holding a pool of
lazily dialled connections produces it as a matter of course: the pool dials
its endpoints, the kernel completes those TCP handshakes, and every connection
the pool does not immediately route a request onto is left parked before it
sends a preface. When traffic goes quiet those connections just sit there, and
the next deploy of the server hangs on them. That is how we hit this, with
several hundred such connections against a single server.

## Change

Keeps the deferral and gives it a deadline. If the handshake finishes first,
the full graceful path runs exactly as it does today and #3729's guarantee is
untouched. If it does not, the connection is closed.

The default is 1 second, which only has to cover a handshake whose bytes have
already arrived and so is generous by orders of magnitude. It is configurable
via `http2::Builder::handshake_shutdown_timeout`, and passing `None` restores
the current unbounded wait.

Servers with no timer installed cannot be given a deadline, and are closed at
once instead, which is what hyper did before 1.10. Waiting forever did not seem
like a better answer for them.

The default matters for reach: servers usually get hyper's `http2::Builder`
through a stack of other crates rather than building it themselves, so a
setter alone would not reach most of the code affected by this, while a default
arrives with a version bump.

## Tests

Two in `tests/server.rs`, mirroring the existing
`graceful_shutdown_before_first_request_no_block` for HTTP/1:

* `http2_graceful_shutdown_before_handshake_no_block`, a client that never
  sends its preface, asserting the shutdown still completes.
* `http2_graceful_shutdown_during_handshake_lets_it_finish`, a client that
  writes the preface and an empty SETTINGS frame, asserting the server answers
  with SETTINGS of its own rather than closing on it. This guards #3729: a
  shutdown that dropped the connection outright would fail it.

Plus two covering the option itself, one for a configured value and one for
`None`.

Each was checked to fail for the right reason rather than assumed to cover
anything. Reverting the source change fails the first by timing out. Changing
it to close outright, which is what a naive revert of #3729 would do, fails the
second with a connection reset, which is the symptom #3729 was filed about.

## Notes

The 1 second default is the obvious thing to argue about, and I do not feel
strongly about the value. What I would like to keep is the property that the
shutdown path terminates without the caller having to opt in, since the servers
most affected are the ones several crates away from this builder.

I also have a broader change that adds a general handshake timeout, the HTTP/2
counterpart of `http1::Builder::header_read_timeout`. It subsumes this one but
changes behaviour for every connection rather than only during shutdown, so I
have kept them separate. They are independent and I am happy to pursue either,
or both.
