### PR TITLE
feat(server): add HTTP/2 handshake timeout

### DIFF
--- a/src/common/time.rs
+++ b/src/common/time.rs
@@ -16,7 +16,7 @@ pub(crate) enum Time {
     Empty,
 }
 
-#[cfg(all(feature = "server", feature = "http1"))]
+#[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum Dur {
     Default(Option<Duration>),
@@ -66,7 +66,7 @@ impl Time {
         }
     }
 
-    #[cfg(all(feature = "server", feature = "http1"))]
+    #[cfg(all(feature = "server", any(feature = "http1", feature = "http2")))]
     pub(crate) fn check(&self, dur: Dur, name: &'static str) -> Option<Duration> {
         match dur {
             Dur::Default(Some(dur)) => match self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,6 +64,9 @@ pub(super) enum Kind {
     /// User took too long to send headers.
     #[cfg(all(feature = "http1", feature = "server"))]
     HeaderTimeout,
+    /// Client took too long to send the HTTP/2 connection preface.
+    #[cfg(all(feature = "http2", feature = "server"))]
+    Http2HandshakeTimeout,
     /// Error while reading a body from connection.
     #[cfg(all(
         any(feature = "client", feature = "server"),
@@ -311,10 +314,16 @@ impl Error {
     ///
     /// For HTTP/1 servers, this includes the header read timeout (see
     /// [`header_read_timeout`](crate::server::conn::http1::Builder::header_read_timeout)).
+    /// For HTTP/2 servers, it includes the handshake timeout (see
+    /// [`handshake_timeout`](crate::server::conn::http2::Builder::handshake_timeout)).
     /// It also covers any timeout set via a user-provided timer.
     pub fn is_timeout(&self) -> bool {
         #[cfg(all(feature = "http1", feature = "server"))]
         if matches!(self.inner.kind, Kind::HeaderTimeout) {
+            return true;
+        }
+        #[cfg(all(feature = "http2", feature = "server"))]
+        if matches!(self.inner.kind, Kind::Http2HandshakeTimeout) {
             return true;
         }
         self.find_source::<TimedOut>().is_some()
@@ -437,6 +446,11 @@ impl Error {
         Error::new(Kind::HeaderTimeout)
     }
 
+    #[cfg(all(feature = "http2", feature = "server"))]
+    pub(super) fn new_h2_handshake_timeout() -> Error {
+        Error::new(Kind::Http2HandshakeTimeout)
+    }
+
     #[cfg(feature = "http1")]
     #[cfg(feature = "server")]
     pub(super) fn new_user_unsupported_status_code() -> Error {
@@ -540,6 +554,8 @@ impl Error {
             Kind::Canceled => "operation was canceled",
             #[cfg(all(feature = "http1", feature = "server"))]
             Kind::HeaderTimeout => "read header from client timeout",
+            #[cfg(all(feature = "http2", feature = "server"))]
+            Kind::Http2HandshakeTimeout => "read HTTP/2 handshake from client timeout",
             #[cfg(all(
                 any(feature = "client", feature = "server"),
                 any(feature = "http1", feature = "http2")

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -15,7 +15,7 @@ use super::{ping, PipeToSendStream, SendBuf};
 use crate::body::{Body, Incoming as IncomingBody};
 use crate::common::date;
 use crate::common::io::Compat;
-use crate::common::time::Time;
+use crate::common::time::{Dur, Time};
 use crate::ext::Protocol;
 use crate::headers;
 use crate::proto::h2::ping::Recorder;
@@ -52,7 +52,7 @@ pub(crate) struct Config {
     pub(crate) max_local_error_reset_streams: Option<usize>,
     pub(crate) keep_alive_interval: Option<Duration>,
     pub(crate) keep_alive_timeout: Duration,
-    pub(crate) handshake_timeout: Option<Duration>,
+    pub(crate) handshake_timeout: Dur,
     pub(crate) max_send_buffer_size: usize,
     pub(crate) header_table_size: Option<u32>,
     pub(crate) max_header_list_size: u32,
@@ -73,7 +73,7 @@ impl Default for Config {
             header_table_size: None,
             keep_alive_interval: None,
             keep_alive_timeout: Duration::from_secs(20),
-            handshake_timeout: None,
+            handshake_timeout: Dur::Default(Some(Duration::from_secs(30))),
             max_send_buffer_size: DEFAULT_MAX_SEND_BUF_SIZE,
             max_header_list_size: DEFAULT_SETTINGS_MAX_HEADER_LIST_SIZE,
             date_header: true,
@@ -177,8 +177,8 @@ where
             keep_alive_while_idle: true,
         };
 
-        let handshake_timeout = config
-            .handshake_timeout
+        let handshake_timeout = timer
+            .check(config.handshake_timeout, "handshake_timeout")
             .map(|duration| timer.sleep(duration));
 
         Server {

--- a/src/proto/h2/server.rs
+++ b/src/proto/h2/server.rs
@@ -21,7 +21,7 @@ use crate::headers;
 use crate::proto::h2::ping::Recorder;
 use crate::proto::Dispatched;
 use crate::rt::bounds::{Http2ServerConnExec, Http2UpgradedExec};
-use crate::rt::{Read, Write};
+use crate::rt::{Read, Sleep, Write};
 use crate::service::HttpService;
 
 use crate::upgrade::{OnUpgrade, Pending, Upgraded};
@@ -52,6 +52,7 @@ pub(crate) struct Config {
     pub(crate) max_local_error_reset_streams: Option<usize>,
     pub(crate) keep_alive_interval: Option<Duration>,
     pub(crate) keep_alive_timeout: Duration,
+    pub(crate) handshake_timeout: Option<Duration>,
     pub(crate) max_send_buffer_size: usize,
     pub(crate) header_table_size: Option<u32>,
     pub(crate) max_header_list_size: u32,
@@ -72,6 +73,7 @@ impl Default for Config {
             header_table_size: None,
             keep_alive_interval: None,
             keep_alive_timeout: Duration::from_secs(20),
+            handshake_timeout: None,
             max_send_buffer_size: DEFAULT_MAX_SEND_BUF_SIZE,
             max_header_list_size: DEFAULT_SETTINGS_MAX_HEADER_LIST_SIZE,
             date_header: true,
@@ -103,6 +105,12 @@ where
     Handshaking {
         ping_config: ping::Config,
         hs: Handshake<Compat<T>, SendBuf<B::Data>>,
+        /// Bounds how long the client may take to send its connection preface.
+        /// Nothing else does: keep-alive pings only begin once the handshake
+        /// has completed, so without this a peer that connects and stays
+        /// silent holds the connection, and any graceful shutdown waiting on
+        /// it, forever.
+        timeout: Option<Pin<Box<dyn Sleep>>>,
     },
     Serving(Serving<T, B>),
 }
@@ -169,12 +177,17 @@ where
             keep_alive_while_idle: true,
         };
 
+        let handshake_timeout = config
+            .handshake_timeout
+            .map(|duration| timer.sleep(duration));
+
         Server {
             exec,
             timer,
             state: State::Handshaking {
                 ping_config,
                 hs: handshake,
+                timeout: handshake_timeout,
             },
             service,
             date_header: config.date_header,
@@ -211,7 +224,17 @@ where
         let me = &mut *self;
         loop {
             let next = match &mut me.state {
-                State::Handshaking { hs, ping_config } => {
+                State::Handshaking {
+                    hs,
+                    ping_config,
+                    timeout,
+                } => {
+                    if let Some(timeout) = timeout.as_mut() {
+                        if Pin::new(timeout).poll(cx).is_ready() {
+                            debug!("timed out waiting for HTTP/2 client handshake");
+                            return Poll::Ready(Err(crate::Error::new_h2_handshake_timeout()));
+                        }
+                    }
                     let mut conn = ready!(Pin::new(hs).poll(cx).map_err(crate::Error::new_h2))?;
                     let ping = if ping_config.is_enabled() {
                         let pp = conn.ping_pong().expect("conn.ping_pong");

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -16,6 +16,7 @@ use crate::body::{Body, Incoming as IncomingBody};
 use crate::proto;
 use crate::rt::bounds::Http2ServerConnExec;
 use crate::service::HttpService;
+use crate::common::time::Dur;
 use crate::{common::time::Time, rt::Timer};
 
 pin_project! {
@@ -253,9 +254,9 @@ impl<E> Builder<E> {
     /// Requires a [`Timer`](crate::rt::Timer) set by [`Builder::timer`] to take
     /// effect.
     ///
-    /// Default is no timeout.
+    /// Default is 30 seconds.
     pub fn handshake_timeout(&mut self, timeout: impl Into<Option<Duration>>) -> &mut Self {
-        self.h2_builder.handshake_timeout = timeout.into();
+        self.h2_builder.handshake_timeout = Dur::Configured(timeout.into());
         self
     }
 

--- a/src/server/conn/http2.rs
+++ b/src/server/conn/http2.rs
@@ -239,6 +239,26 @@ impl<E> Builder<E> {
         self
     }
 
+    /// Set a timeout for the client to send its connection preface.
+    ///
+    /// A client that opens a connection and then sends nothing otherwise holds
+    /// it open indefinitely: the keep-alive ping above cannot help, because
+    /// pings only begin once the handshake has completed. If the preface has
+    /// not arrived within this timeout, the connection is closed with an error
+    /// for which [`Error::is_timeout`](crate::Error::is_timeout) is true.
+    ///
+    /// This is the HTTP/2 counterpart of
+    /// [`http1::Builder::header_read_timeout`](crate::server::conn::http1::Builder::header_read_timeout).
+    ///
+    /// Requires a [`Timer`](crate::rt::Timer) set by [`Builder::timer`] to take
+    /// effect.
+    ///
+    /// Default is no timeout.
+    pub fn handshake_timeout(&mut self, timeout: impl Into<Option<Duration>>) -> &mut Self {
+        self.h2_builder.handshake_timeout = timeout.into();
+        self
+    }
+
     /// Set the maximum write buffer size for each HTTP/2 stream.
     ///
     /// Default is currently ~400KB, but may change.

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2048,6 +2048,66 @@ async fn h2_connect() {
 }
 
 #[tokio::test]
+async fn http2_handshake_timeout() {
+    let (listener, addr) = setup_tcp_listener();
+
+    // A client that opens the connection and then never sends the preface.
+    // The server writes its own SETTINGS straight away, so read and discard
+    // until it gives up on us and closes the connection.
+    thread::spawn(move || {
+        let mut tcp = connect(&addr);
+        let mut buf = [0u8; 256];
+        while let Ok(n) = tcp.read(&mut buf) {
+            if n == 0 {
+                break;
+            }
+        }
+    });
+
+    let (socket, _) = listener.accept().await.unwrap();
+    let socket = TokioIo::new(socket);
+    let conn = http2::Builder::new(TokioExecutor)
+        .timer(TokioTimer)
+        .handshake_timeout(Duration::from_secs(1))
+        .serve_connection(socket, unreachable_service());
+    assert!(conn.await.unwrap_err().is_timeout());
+}
+
+#[tokio::test]
+async fn http2_handshake_timeout_does_not_apply_once_connected() {
+    let (listener, addr) = setup_tcp_listener();
+
+    tokio::spawn(async move {
+        let (socket, _) = listener.accept().await.expect("accept");
+        let socket = TokioIo::new(socket);
+
+        http2::Builder::new(TokioExecutor)
+            .timer(TokioTimer)
+            .handshake_timeout(Duration::from_secs(1))
+            .serve_connection(socket, HelloWorld)
+            .await
+            .expect("serve_connection");
+    });
+
+    let tcp = TokioIo::new(connect_async(addr).await);
+    let (mut client, conn) = hyper::client::conn::http2::Builder::new(TokioExecutor)
+        .handshake(tcp)
+        .await
+        .expect("http handshake");
+
+    tokio::spawn(async move {
+        conn.await.expect("client conn");
+    });
+
+    // Idle well past the handshake timeout. It bounds the wait for the preface
+    // only, so a connection that has already spoken is unaffected.
+    TokioTimer.sleep(Duration::from_secs(3)).await;
+
+    let req = http::Request::new(Empty::<Bytes>::new());
+    client.send_request(req).await.expect("client.send_request");
+}
+
+#[tokio::test]
 async fn h2_connect_multiplex() {
     use futures_util::stream::FuturesUnordered;
     use futures_util::StreamExt;


### PR DESCRIPTION
## Problem

An HTTP/2 server has no bound on how long it will wait for a client's
connection preface. A peer that completes the TCP connect and then sends
nothing holds the connection open indefinitely, sitting in h2's
`ReadingPreface` state.

HTTP/2 keepalive cannot reach it. Keepalive pings only begin once the handshake
has completed, so a connection that never handshakes is never pinged and never
reaped.

HTTP/1 already guards against exactly this shape of peer, and does so by
default: `http1::Builder::header_read_timeout` defaults to 30 seconds.

https://github.com/hyperium/hyper/blob/37c9d0c7e018d3c218f1fc0e472207ff05ef3772/src/server/conn/http1.rs#L250

`http2::Builder` has no counterpart. Its only time based options are
`keep_alive_interval` and `keep_alive_timeout`, both of which apply after the
handshake. The h2 handshake future is polled with nothing bounding it:

https://github.com/hyperium/hyper/blob/37c9d0c7e018d3c218f1fc0e472207ff05ef3772/src/proto/h2/server.rs#L215

Two consequences. Server resources can be pinned indefinitely by an
unauthenticated peer that sends zero bytes, which HTTP/1 servers are protected
from by default. And a graceful shutdown never finishes, because it waits for
every connection to be done, so a server built to drain before exiting does not
exit.

## Change

Adds `http2::Builder::handshake_timeout`, the HTTP/2 counterpart of
`http1::Builder::header_read_timeout`, defaulting to 30 seconds to match it. If
the preface has not arrived in time the connection is closed with an error for
which `Error::is_timeout()` returns true, again matching HTTP/1.

The implementation needed no new machinery. `Server::new` already receives a
`Time` for the keep-alive ping channel, so the sleep is armed alongside the
handshake future and polled with it. The value is carried as `Dur`, so the
existing semantics are preserved: a default with no timer installed warns and
disables itself, an explicitly configured value with no timer panics.

Defaulting is what makes this reachable in practice. Servers usually do not
build hyper's `http2::Builder` themselves, they get it through a stack of
crates, and exposing a new setter all the way up takes coordinated releases of
several of them. A default arrives with a version bump.

## Tests

Two, in `tests/server.rs`:

* `http2_handshake_timeout`, a client that connects and never sends its
  preface, asserting the connection errors and `is_timeout()` is true.
* `http2_handshake_timeout_does_not_apply_once_connected`, a client that
  completes the handshake and then idles for three times the timeout, asserting
  it is still served. This is the one that matters: the bound applies to the
  preface only.

Both were checked to fail when the change is reverted rather than assumed to
cover it.

## Notes

The default is the part most worth discussing. It is a behaviour change on a
stable line: connections that previously lived forever now end. I think the
symmetry argument is strong, since hyper already made this exact tradeoff for
HTTP/1 and has shipped that default for years, but it is easy to change this to
opt in only by dropping the second commit.

One wart to flag: `Time::check` warns per connection when a default is set with
no timer installed, so timer-less HTTP/2 servers would see new log output.
HTTP/1 servers already have this.

I also have a smaller, more targeted change that bounds only the wait during a
graceful shutdown, which addresses the shutdown half of this without changing
behaviour for servers that are not shutting down. The two are independent and I
am happy to pursue either, or both.
