### PR TITLE
style: replace single-character lifetime names with descriptive names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,6 @@ panic = "allow"
 pattern_type_mismatch = "allow"
 redundant_closure_for_method_calls = "allow"
 redundant_else = "allow"
-single_char_lifetime_names = "allow"
 struct_excessive_bools = "allow" # TODO: bogus lint?
 trivially_copy_pass_by_ref = "allow"
 unnecessary_trailing_comma = "allow"

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -408,7 +408,7 @@ mod tests {
     }
 
     /// Helper to check if the future is ready after polling once.
-    struct PollOnce<'a, F>(&'a mut F);
+    struct PollOnce<'func, F>(&'func mut F);
 
     impl<F, T> Future for PollOnce<'_, F>
     where

--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -408,7 +408,7 @@ mod tests {
     }
 
     /// Helper to check if the future is ready after polling once.
-    struct PollOnce<'func, F>(&'func mut F);
+    struct PollOnce<'fut, F>(&'fut mut F);
 
     impl<F, T> Future for PollOnce<'_, F>
     where

--- a/src/common/buf.rs
+++ b/src/common/buf.rs
@@ -56,7 +56,7 @@ impl<T: Buf> Buf for BufList<T> {
     }
 
     #[inline]
-    fn chunks_vectored<'t>(&'t self, dst: &mut [IoSlice<'t>]) -> usize {
+    fn chunks_vectored<'data>(&'data self, dst: &mut [IoSlice<'data>]) -> usize {
         if dst.is_empty() {
             return 0;
         }

--- a/src/ext/informational.rs
+++ b/src/ext/informational.rs
@@ -66,7 +66,7 @@ where
 // being either a real reference, or moving the http::Response into the closure,
 // in a backwards-compatible change in the future.
 #[derive(Debug)]
-pub struct Response<'a>(&'a http::Response<()>);
+pub struct Response<'resp>(&'resp http::Response<()>);
 
 impl Response<'_> {
     #[inline]

--- a/src/ext/mod.rs
+++ b/src/ext/mod.rs
@@ -113,8 +113,8 @@ impl Protocol {
 }
 
 #[cfg(feature = "http2")]
-impl<'a> From<&'a str> for Protocol {
-    fn from(value: &'a str) -> Self {
+impl<'proto> From<&'proto str> for Protocol {
+    fn from(value: &'proto str) -> Self {
         Self {
             inner: h2::ext::Protocol::from(value),
         }
@@ -165,10 +165,10 @@ impl HeaderCaseMap {
     /// Returns a view of all spellings associated with that header name,
     /// in the order they were found.
     #[cfg(feature = "client")]
-    pub(crate) fn get_all<'a>(
-        &'a self,
+    pub(crate) fn get_all<'hdr>(
+        &'hdr self,
         name: &HeaderName,
-    ) -> impl Iterator<Item = impl AsRef<[u8]> + 'a> + 'a {
+    ) -> impl Iterator<Item = impl AsRef<[u8]> + 'hdr> + 'hdr {
         self.get_all_internal(name)
     }
 

--- a/src/ffi/task.rs
+++ b/src/ffi/task.rs
@@ -128,7 +128,7 @@ struct TaskFuture {
 /// its only purpose is to provide access to the waker. See `hyper_waker`.
 ///
 /// Corresponding Rust type: <https://doc.rust-lang.org/std/task/struct.Context.html>
-pub struct hyper_context<'a>(Context<'a>);
+pub struct hyper_context<'ctx>(Context<'ctx>);
 
 /// A waker that is saved and used to waken a pending task.
 ///
@@ -511,7 +511,7 @@ where
 // ===== impl hyper_context =====
 
 impl hyper_context<'_> {
-    pub(crate) fn wrap<'a, 'b>(cx: &'a mut Context<'b>) -> &'a mut hyper_context<'b> {
+    pub(crate) fn wrap<'borrow, 'ctx>(cx: &'borrow mut Context<'ctx>) -> &'borrow mut hyper_context<'ctx> {
         // A struct with only one field has the same layout as that field.
         unsafe { std::mem::transmute::<&mut Context<'_>, &mut hyper_context<'_>>(cx) }
     }

--- a/src/ffi/task.rs
+++ b/src/ffi/task.rs
@@ -511,7 +511,9 @@ where
 // ===== impl hyper_context =====
 
 impl hyper_context<'_> {
-    pub(crate) fn wrap<'borrow, 'ctx>(cx: &'borrow mut Context<'ctx>) -> &'borrow mut hyper_context<'ctx> {
+    pub(crate) fn wrap<'borrow, 'ctx>(
+        cx: &'borrow mut Context<'ctx>,
+    ) -> &'borrow mut hyper_context<'ctx> {
         // A struct with only one field has the same layout as that field.
         unsafe { std::mem::transmute::<&mut Context<'_>, &mut hyper_context<'_>>(cx) }
     }

--- a/src/proto/h1/decode.rs
+++ b/src/proto/h1/decode.rs
@@ -286,12 +286,12 @@ macro_rules! put_u8 {
     };
 }
 
-struct StepArgs<'a> {
-    chunk_size: &'a mut u64,
-    chunk_buf: &'a mut Option<Bytes>,
-    extensions_cnt: &'a mut u64,
-    trailers_buf: &'a mut Option<BytesMut>,
-    trailers_cnt: &'a mut usize,
+struct StepArgs<'args> {
+    chunk_size: &'args mut u64,
+    chunk_buf: &'args mut Option<Bytes>,
+    extensions_cnt: &'args mut u64,
+    trailers_buf: &'args mut Option<BytesMut>,
+    trailers_cnt: &'args mut usize,
     max_headers_cnt: usize,
     max_headers_bytes: usize,
 }

--- a/src/proto/h1/dispatch.rs
+++ b/src/proto/h1/dispatch.rs
@@ -509,10 +509,10 @@ where
 
 /// A drop guard to allow a mutable borrow of an Option while being able to
 /// set whether the `Option` should be cleared on drop.
-struct OptGuard<'a, T>(Pin<&'a mut Option<T>>, bool);
+struct OptGuard<'opt, T>(Pin<&'opt mut Option<T>>, bool);
 
-impl<'a, T> OptGuard<'a, T> {
-    fn new(pin: Pin<&'a mut Option<T>>) -> Self {
+impl<'opt, T> OptGuard<'opt, T> {
+    fn new(pin: Pin<&'opt mut Option<T>>) -> Self {
         OptGuard(pin, false)
     }
 

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -317,7 +317,7 @@ where
     }
 
     #[inline]
-    fn chunks_vectored<'t>(&'t self, dst: &mut [IoSlice<'t>]) -> usize {
+    fn chunks_vectored<'data>(&'data self, dst: &mut [IoSlice<'data>]) -> usize {
         match &self.kind {
             BufKind::Exact(b) => b.chunks_vectored(dst),
             BufKind::Limited(b) => b.chunks_vectored(dst),

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -637,7 +637,7 @@ impl<B: Buf> Buf for WriteBuf<B> {
     }
 
     #[inline]
-    fn chunks_vectored<'t>(&'t self, dst: &mut [IoSlice<'t>]) -> usize {
+    fn chunks_vectored<'data>(&'data self, dst: &mut [IoSlice<'data>]) -> usize {
         let n = self.headers.chunks_vectored(dst);
         self.queue.chunks_vectored(&mut dst[n..]) + n
     }

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -68,9 +68,9 @@ pub(crate) struct ParsedMessage<T> {
     wants_upgrade: bool,
 }
 
-pub(crate) struct ParseContext<'a> {
-    cached_headers: &'a mut Option<HeaderMap>,
-    req_method: &'a mut Option<Method>,
+pub(crate) struct ParseContext<'ctx> {
+    cached_headers: &'ctx mut Option<HeaderMap>,
+    req_method: &'ctx mut Option<Method>,
     h1_parser_config: ParserConfig,
     h1_max_headers: Option<usize>,
     preserve_header_case: bool,
@@ -78,16 +78,16 @@ pub(crate) struct ParseContext<'a> {
     preserve_header_order: bool,
     h09_responses: bool,
     #[cfg(feature = "client")]
-    on_informational: &'a mut Option<crate::ext::OnInformational>,
+    on_informational: &'ctx mut Option<crate::ext::OnInformational>,
 }
 
 /// Passed to `Http1Transaction::encode`.
-pub(crate) struct Encode<'a, T> {
-    head: &'a mut MessageHead<T>,
+pub(crate) struct Encode<'encode, T> {
+    head: &'encode mut MessageHead<T>,
     body: Option<BodyLength>,
     #[cfg(feature = "server")]
     keep_alive: bool,
-    req_method: &'a mut Option<Method>,
+    req_method: &'encode mut Option<Method>,
     title_case_headers: bool,
     #[cfg(feature = "server")]
     date_header: bool,

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1652,7 +1652,7 @@ fn write_headers_original_case(
 }
 
 #[cfg(feature = "client")]
-struct FastWrite<'a>(&'a mut Vec<u8>);
+struct FastWrite<'data>(&'data mut Vec<u8>);
 
 #[cfg(feature = "client")]
 impl fmt::Write for FastWrite<'_> {

--- a/src/proto/h2/mod.rs
+++ b/src/proto/h2/mod.rs
@@ -319,7 +319,7 @@ impl<B: Buf> Buf for SendBuf<B> {
         }
     }
 
-    fn chunks_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
+    fn chunks_vectored<'data>(&'data self, dst: &mut [IoSlice<'data>]) -> usize {
         match self {
             Self::Buf(b) => b.chunks_vectored(dst),
             Self::Cursor(c) => c.chunks_vectored(dst),

--- a/src/rt/io.rs
+++ b/src/rt/io.rs
@@ -164,8 +164,8 @@ pub trait Write {
 /// It is undefined behavior to de-initialize any bytes from the uninitialized
 /// region, since it is merely unknown whether this region is uninitialized or
 /// not, and if part of it turns out to be initialized, it must stay initialized.
-pub struct ReadBuf<'a> {
-    raw: &'a mut [MaybeUninit<u8>],
+pub struct ReadBuf<'data> {
+    raw: &'data mut [MaybeUninit<u8>],
     filled: usize,
     init: usize,
 }
@@ -227,8 +227,8 @@ pub struct ReadBuf<'a> {
 /// assert_eq!(read_buf.filled(), b"hello");
 /// ```
 #[derive(Debug)]
-pub struct ReadBufCursor<'a> {
-    buf: &'a mut ReadBuf<'a>,
+pub struct ReadBufCursor<'buf> {
+    buf: &'buf mut ReadBuf<'buf>,
 }
 
 impl<'data> ReadBuf<'data> {

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -3542,8 +3542,8 @@ impl Serve {
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 type BoxFuture = Pin<Box<dyn Future<Output = Result<Response<ReplyBody>, BoxError>> + Send>>;
 
-struct ReplyBuilder<'a> {
-    tx: &'a Mutex<spmc::Sender<Reply>>,
+struct ReplyBuilder<'mtx> {
+    tx: &'mtx Mutex<spmc::Sender<Reply>>,
 }
 
 impl ReplyBuilder<'_> {


### PR DESCRIPTION
Removes the `single_char_lifetime_names` allow lint from the strict clippy config and replaces all single-character lifetime names with descriptive names.

Part of #4071.