### PR TITLE
docs: fix typo responsibile -> responsible

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-hyper (and related projects in hyperium) take security seriously, and greatly appreciate responsibile disclosure.
+hyper (and related projects in hyperium) take security seriously, and greatly appreciate responsible disclosure.
 
 ## Report a security issue
 


### PR DESCRIPTION
Corrects the misspelling `responsibile` -> `responsible` in `SECURITY.md`.

Documentation only, no behaviour change.