### PR TITLE
refactor(http1): resolve collapsible_match lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ as_conversions = "allow" # TODO: tricky
 cast_possible_truncation = "allow" # TODO: consider
 cast_precision_loss = "allow" # TODO: consider
 checked_conversions = "allow"
-collapsible_match = "allow"
 else_if_without_else = "allow"
 enum_glob_use = "allow"
 float_arithmetic = "allow"

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -676,11 +676,9 @@ where
                 Version::HTTP_10 => self.state.disable_keep_alive(),
                 // If response is version 1.1 and keep-alive is wanted, add
                 // Connection: keep-alive header when not present
-                Version::HTTP_11 => {
-                    if self.state.wants_keep_alive() {
-                        head.headers
-                            .insert(CONNECTION, HeaderValue::from_static("keep-alive"));
-                    }
+                Version::HTTP_11 if self.state.wants_keep_alive() => {
+                    head.headers
+                        .insert(CONNECTION, HeaderValue::from_static("keep-alive"));
                 }
                 _ => (),
             }


### PR DESCRIPTION
Part of #4071

## Changes
- Remove `collapsible_match` from `Cargo.toml`
- Collapse the nested `if` in `src/proto/h1/conn.rs` into a match guard

Behavior is unchanged:  
When http version is 1.1 and `wants_keep_alive()` is false, it falls through to `_ => ()`.