### PR TITLE
fix(http1): close client after completed response

### DIFF
--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -1096,6 +1096,9 @@ impl State {
             (&Reading::Closed, &Writing::KeepAlive) | (&Reading::KeepAlive, &Writing::Closed) => {
                 self.close();
             }
+            (&Reading::KeepAlive, &Writing::Body(_)) if T::is_client() => {
+                self.close();
+            }
             _ => (),
         }
     }
@@ -1264,6 +1267,37 @@ mod tests {
             !remains_reusable_after_get(&["keep-alive", "close"]),
             "a `close` in any Connection header line must disable keep-alive"
         );
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn client_closes_after_response_while_request_body_is_pending() {
+        let io = Compat(tokio_test::io::Builder::new().build());
+        let mut conn = Conn::<_, Bytes, crate::proto::h1::ClientTransaction>::new(io);
+        conn.state.reading = Reading::KeepAlive;
+        conn.state.writing = Writing::Body(Encoder::chunked());
+
+        conn.state
+            .try_keep_alive::<crate::proto::h1::ClientTransaction>();
+
+        assert!(conn.state.is_read_closed());
+        assert!(conn.state.is_write_closed());
+    }
+
+    #[cfg(feature = "server")]
+    #[test]
+    fn server_keeps_streaming_body_after_request_is_read() {
+        let io = Compat(tokio_test::io::Builder::new().build());
+        let mut conn = Conn::<_, Bytes, crate::proto::h1::ServerTransaction>::new(io);
+        conn.state.reading = Reading::KeepAlive;
+        conn.state.writing = Writing::Body(Encoder::chunked());
+
+        conn.state
+            .try_keep_alive::<crate::proto::h1::ServerTransaction>();
+
+        assert!(!conn.state.is_read_closed());
+        assert!(!conn.state.is_write_closed());
+        assert!(matches!(conn.state.writing, Writing::Body(_)));
     }
 
     use super::*;


### PR DESCRIPTION
Closes #4176

## Motivation

When an HTTP/1 client receives a complete response while its request body is
still being written, the connection can remain parked in
`(Reading::KeepAlive, Writing::Body)`. The response has completed, but the
connection is neither reusable nor closed, so pooled clients can leak sockets.

## Solution

Close this terminal client state in `State::try_keep_alive`. The transition is
guarded with `T::is_client()` because the same state shape is valid while a
server is still streaming its response. Regression tests cover both roles:
clients close and servers retain the streaming body.

The close-vs-drain choice follows the issue's terminal-outcome contract: a
client that has already received a complete response cannot safely reuse the
connection while its request body is unfinished. I am happy to adjust this to
a drain policy if maintainers prefer that semantics.

## Tests

- `cargo test --features full --lib` (117 passed, 6 ignored)
- deterministic client reproducer: unchanged `master` fails; this commit
  closes the connection
- server streaming harness: delayed response chunks remain intact
- `rustfmt --check --edition 2021 src/proto/h1/conn.rs`
- `git diff --check`

AI assistance was used for code navigation and test drafting. The patch,
reproduction, and verification were reviewed by the author and an independent
non-author agent. Full cross-platform CI remains to be run by GitHub.
