### PR TITLE
feat(http1): add max_header_size limit for server and client

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -131,6 +131,7 @@ pub struct Builder {
     h1_title_case_headers: bool,
     h1_preserve_header_case: bool,
     h1_max_headers: Option<usize>,
+    h1_max_header_size: Option<usize>,
     #[cfg(feature = "ffi")]
     h1_preserve_header_order: bool,
     h1_read_buf_exact_size: Option<usize>,
@@ -352,6 +353,7 @@ impl Builder {
             h1_title_case_headers: false,
             h1_preserve_header_case: false,
             h1_max_headers: None,
+            h1_max_header_size: None,
             #[cfg(feature = "ffi")]
             h1_preserve_header_order: false,
             h1_max_buf_size: None,
@@ -500,6 +502,17 @@ impl Builder {
         self
     }
 
+    /// Set the maximum size of response headers (including the status line) in bytes.
+    ///
+    /// If the server sends headers exceeding this limit, the error "message head is too large"
+    /// is returned.
+    ///
+    /// Default is `None`.
+    pub fn max_header_size(&mut self, val: usize) -> &mut Self {
+        self.h1_max_header_size = Some(val);
+        self
+    }
+
     /// Set whether to support preserving original header order.
     ///
     /// Currently, this will record the order in which headers are received, and store this
@@ -586,6 +599,9 @@ impl Builder {
             }
             if let Some(max_headers) = opts.h1_max_headers {
                 conn.set_http1_max_headers(max_headers);
+            }
+            if let Some(max_header_size) = opts.h1_max_header_size {
+                conn.set_http1_max_header_size(max_header_size);
             }
             #[cfg(feature = "ffi")]
             if opts.h1_preserve_header_order {

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -58,6 +58,7 @@ where
                 method: None,
                 h1_parser_config: ParserConfig::default(),
                 h1_max_headers: None,
+                h1_max_header_size: None,
                 #[cfg(feature = "server")]
                 h1_header_read_timeout: None,
                 #[cfg(feature = "server")]
@@ -139,6 +140,10 @@ where
 
     pub(crate) fn set_http1_max_headers(&mut self, val: usize) {
         self.state.h1_max_headers = Some(val);
+    }
+
+    pub(crate) fn set_http1_max_header_size(&mut self, val: usize) {
+        self.state.h1_max_header_size = Some(val);
     }
 
     #[cfg(feature = "server")]
@@ -241,6 +246,7 @@ where
                 req_method: &mut self.state.method,
                 h1_parser_config: self.state.h1_parser_config.clone(),
                 h1_max_headers: self.state.h1_max_headers,
+                h1_max_header_size: self.state.h1_max_header_size,
                 preserve_header_case: self.state.preserve_header_case,
                 #[cfg(feature = "ffi")]
                 preserve_header_order: self.state.preserve_header_order,
@@ -309,7 +315,7 @@ where
                 self.try_keep_alive(cx);
             }
         } else if msg.expect_continue && msg.head.version.gt(&Version::HTTP_10) {
-            let h1_max_header_size = None; // TODO: remove this when we land h1_max_header_size support
+            let h1_max_header_size = self.state.h1_max_header_size;
             self.state.reading = Reading::Continue(Decoder::new(
                 msg.decode,
                 self.state.h1_max_headers,
@@ -317,7 +323,7 @@ where
             ));
             wants = wants.add(Wants::EXPECT);
         } else {
-            let h1_max_header_size = None; // TODO: remove this when we land h1_max_header_size support
+            let h1_max_header_size = self.state.h1_max_header_size;
             self.state.reading = Reading::Body(Decoder::new(
                 msg.decode,
                 self.state.h1_max_headers,
@@ -933,6 +939,7 @@ struct State {
     method: Option<Method>,
     h1_parser_config: ParserConfig,
     h1_max_headers: Option<usize>,
+    h1_max_header_size: Option<usize>,
     #[cfg(feature = "server")]
     h1_header_read_timeout: Option<Duration>,
     #[cfg(feature = "server")]

--- a/src/proto/h1/io.rs
+++ b/src/proto/h1/io.rs
@@ -188,6 +188,7 @@ where
                     req_method: parse_ctx.req_method,
                     h1_parser_config: parse_ctx.h1_parser_config.clone(),
                     h1_max_headers: parse_ctx.h1_max_headers,
+                    h1_max_header_size: parse_ctx.h1_max_header_size,
                     preserve_header_case: parse_ctx.preserve_header_case,
                     #[cfg(feature = "ffi")]
                     preserve_header_order: parse_ctx.preserve_header_order,
@@ -200,8 +201,14 @@ where
                 self.partial_len = None;
                 return Poll::Ready(Ok(msg));
             } else {
-                let max = self.read_buf_strategy.max();
                 let curr_len = self.read_buf.len();
+                if let Some(max_header_size) = parse_ctx.h1_max_header_size {
+                    if curr_len >= max_header_size {
+                        debug!("max_header_size ({}) reached, closing", max_header_size);
+                        return Poll::Ready(Err(crate::Error::new_too_large()));
+                    }
+                }
+                let max = self.read_buf_strategy.max();
                 if curr_len >= max {
                     debug!("max_buf_size ({}) reached, closing", max);
                     return Poll::Ready(Err(crate::Error::new_too_large()));
@@ -702,6 +709,7 @@ mod tests {
                 req_method: &mut None,
                 h1_parser_config: Default::default(),
                 h1_max_headers: None,
+                h1_max_header_size: None,
                 preserve_header_case: false,
                 #[cfg(feature = "ffi")]
                 preserve_header_order: false,

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -73,6 +73,7 @@ pub(crate) struct ParseContext<'ctx> {
     req_method: &'ctx mut Option<Method>,
     h1_parser_config: ParserConfig,
     h1_max_headers: Option<usize>,
+    h1_max_header_size: Option<usize>,
     preserve_header_case: bool,
     #[cfg(feature = "ffi")]
     preserve_header_order: bool,

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -2999,37 +2999,16 @@ mod tests {
     }
 
     #[test]
-    fn test_h1_max_header_size() {
+    #[cfg(feature = "server")]
+    fn test_h1_server_max_header_size() {
         let _ = pretty_env_logger::try_init();
 
         let req_str = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
         assert_eq!(req_str.len(), 37);
-        let resp_str = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
-        assert_eq!(resp_str.len(), 38);
 
         let parse_req = |max_header_size: Option<usize>| {
             let mut bytes = BytesMut::from(req_str);
             Server::parse(
-                &mut bytes,
-                ParseContext {
-                    cached_headers: &mut None,
-                    req_method: &mut None,
-                    h1_parser_config: Default::default(),
-                    h1_max_headers: None,
-                    h1_max_header_size: max_header_size,
-                    preserve_header_case: false,
-                    #[cfg(feature = "ffi")]
-                    preserve_header_order: false,
-                    h09_responses: false,
-                    #[cfg(feature = "client")]
-                    on_informational: &mut None,
-                },
-            )
-        };
-
-        let parse_resp = |max_header_size: Option<usize>| {
-            let mut bytes = BytesMut::from(resp_str);
-            Client::parse(
                 &mut bytes,
                 ParseContext {
                     cached_headers: &mut None,
@@ -3053,6 +3032,35 @@ mod tests {
         parse_req(Some(50)).unwrap().unwrap();
         assert!(matches!(parse_req(Some(36)), Err(Parse::TooLarge)));
         assert!(matches!(parse_req(Some(10)), Err(Parse::TooLarge)));
+    }
+
+    #[test]
+    #[cfg(feature = "client")]
+    fn test_h1_client_max_header_size() {
+        let _ = pretty_env_logger::try_init();
+
+        let resp_str = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+        assert_eq!(resp_str.len(), 38);
+
+        let parse_resp = |max_header_size: Option<usize>| {
+            let mut bytes = BytesMut::from(resp_str);
+            Client::parse(
+                &mut bytes,
+                ParseContext {
+                    cached_headers: &mut None,
+                    req_method: &mut None,
+                    h1_parser_config: Default::default(),
+                    h1_max_headers: None,
+                    h1_max_header_size: max_header_size,
+                    preserve_header_case: false,
+                    #[cfg(feature = "ffi")]
+                    preserve_header_order: false,
+                    h09_responses: false,
+                    #[cfg(feature = "client")]
+                    on_informational: &mut None,
+                },
+            )
+        };
 
         // Client checks
         parse_resp(None).unwrap().unwrap();

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -180,6 +180,11 @@ impl Http1Transaction for Server {
             ) {
                 Ok(httparse::Status::Complete(parsed_len)) => {
                     trace!("Request.parse Complete({})", parsed_len);
+                    if let Some(max_header_size) = ctx.h1_max_header_size {
+                        if parsed_len > max_header_size {
+                            return Err(Parse::TooLarge);
+                        }
+                    }
                     len = parsed_len;
                     let uri = req.path.expect("httparse completed");
                     if uri.len() > MAX_URI_LEN {
@@ -1052,6 +1057,11 @@ impl Http1Transaction for Client {
                 ) {
                     Ok(httparse::Status::Complete(len)) => {
                         trace!("Response.parse Complete({})", len);
+                        if let Some(max_header_size) = ctx.h1_max_header_size {
+                            if len > max_header_size {
+                                return Err(Parse::TooLarge);
+                            }
+                        }
                         let status = StatusCode::from_u16(res.code.expect("httparse completed"))?;
 
                         let reason = {
@@ -1692,6 +1702,7 @@ mod tests {
                 req_method: &mut method,
                 h1_parser_config: Default::default(),
                 h1_max_headers: None,
+                h1_max_header_size: None,
                 preserve_header_case: false,
                 #[cfg(feature = "ffi")]
                 preserve_header_order: false,
@@ -1720,6 +1731,7 @@ mod tests {
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
             h1_max_headers: None,
+            h1_max_header_size: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
             preserve_header_order: false,
@@ -1744,6 +1756,7 @@ mod tests {
             req_method: &mut None,
             h1_parser_config: Default::default(),
             h1_max_headers: None,
+            h1_max_header_size: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
             preserve_header_order: false,
@@ -1765,6 +1778,7 @@ mod tests {
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
             h1_max_headers: None,
+            h1_max_header_size: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
             preserve_header_order: false,
@@ -1788,6 +1802,7 @@ mod tests {
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
             h1_max_headers: None,
+            h1_max_header_size: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
             preserve_header_order: false,
@@ -1815,6 +1830,7 @@ mod tests {
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config,
             h1_max_headers: None,
+            h1_max_header_size: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
             preserve_header_order: false,
@@ -1839,6 +1855,7 @@ mod tests {
             req_method: &mut Some(crate::Method::GET),
             h1_parser_config: Default::default(),
             h1_max_headers: None,
+            h1_max_header_size: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
             preserve_header_order: false,
@@ -1867,6 +1884,7 @@ mod tests {
             req_method: &mut method,
             h1_parser_config,
             h1_max_headers: None,
+            h1_max_header_size: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
             preserve_header_order: false,
@@ -1894,6 +1912,7 @@ mod tests {
             req_method: &mut None,
             h1_parser_config: Default::default(),
             h1_max_headers: None,
+            h1_max_header_size: None,
             preserve_header_case: false,
             #[cfg(feature = "ffi")]
             preserve_header_order: false,
@@ -1914,6 +1933,7 @@ mod tests {
             req_method: &mut None,
             h1_parser_config: Default::default(),
             h1_max_headers: None,
+            h1_max_header_size: None,
             preserve_header_case: true,
             #[cfg(feature = "ffi")]
             preserve_header_order: false,
@@ -1953,6 +1973,7 @@ mod tests {
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
                     h1_max_headers: None,
+                    h1_max_header_size: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
                     preserve_header_order: false,
@@ -1974,6 +1995,7 @@ mod tests {
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
                     h1_max_headers: None,
+                    h1_max_header_size: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
                     preserve_header_order: false,
@@ -2214,6 +2236,7 @@ mod tests {
                     req_method: &mut Some(Method::GET),
                     h1_parser_config: Default::default(),
                     h1_max_headers: None,
+                    h1_max_header_size: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
                     preserve_header_order: false,
@@ -2235,6 +2258,7 @@ mod tests {
                     req_method: &mut Some(m),
                     h1_parser_config: Default::default(),
                     h1_max_headers: None,
+                    h1_max_header_size: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
                     preserve_header_order: false,
@@ -2256,6 +2280,7 @@ mod tests {
                     req_method: &mut Some(Method::GET),
                     h1_parser_config: Default::default(),
                     h1_max_headers: None,
+                    h1_max_header_size: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
                     preserve_header_order: false,
@@ -2826,6 +2851,7 @@ mod tests {
                 req_method: &mut Some(Method::GET),
                 h1_parser_config: Default::default(),
                 h1_max_headers: None,
+                h1_max_header_size: None,
                 preserve_header_case: false,
                 #[cfg(feature = "ffi")]
                 preserve_header_order: false,
@@ -2870,6 +2896,7 @@ mod tests {
                         req_method: &mut None,
                         h1_parser_config: Default::default(),
                         h1_max_headers: max_headers,
+                        h1_max_header_size: None,
                         preserve_header_case: false,
                         #[cfg(feature = "ffi")]
                         preserve_header_order: false,
@@ -2894,6 +2921,7 @@ mod tests {
                         req_method: &mut None,
                         h1_parser_config: Default::default(),
                         h1_max_headers: max_headers,
+                        h1_max_header_size: None,
                         preserve_header_case: false,
                         #[cfg(feature = "ffi")]
                         preserve_header_order: false,
@@ -2971,6 +2999,70 @@ mod tests {
     }
 
     #[test]
+    fn test_h1_max_header_size() {
+        let _ = pretty_env_logger::try_init();
+
+        let req_str = "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        assert_eq!(req_str.len(), 37);
+        let resp_str = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
+        assert_eq!(resp_str.len(), 38);
+
+        let parse_req = |max_header_size: Option<usize>| {
+            let mut bytes = BytesMut::from(req_str);
+            Server::parse(
+                &mut bytes,
+                ParseContext {
+                    cached_headers: &mut None,
+                    req_method: &mut None,
+                    h1_parser_config: Default::default(),
+                    h1_max_headers: None,
+                    h1_max_header_size: max_header_size,
+                    preserve_header_case: false,
+                    #[cfg(feature = "ffi")]
+                    preserve_header_order: false,
+                    h09_responses: false,
+                    #[cfg(feature = "client")]
+                    on_informational: &mut None,
+                },
+            )
+        };
+
+        let parse_resp = |max_header_size: Option<usize>| {
+            let mut bytes = BytesMut::from(resp_str);
+            Client::parse(
+                &mut bytes,
+                ParseContext {
+                    cached_headers: &mut None,
+                    req_method: &mut None,
+                    h1_parser_config: Default::default(),
+                    h1_max_headers: None,
+                    h1_max_header_size: max_header_size,
+                    preserve_header_case: false,
+                    #[cfg(feature = "ffi")]
+                    preserve_header_order: false,
+                    h09_responses: false,
+                    #[cfg(feature = "client")]
+                    on_informational: &mut None,
+                },
+            )
+        };
+
+        // Server checks
+        parse_req(None).unwrap().unwrap();
+        parse_req(Some(37)).unwrap().unwrap();
+        parse_req(Some(50)).unwrap().unwrap();
+        assert!(matches!(parse_req(Some(36)), Err(Parse::TooLarge)));
+        assert!(matches!(parse_req(Some(10)), Err(Parse::TooLarge)));
+
+        // Client checks
+        parse_resp(None).unwrap().unwrap();
+        parse_resp(Some(38)).unwrap().unwrap();
+        parse_resp(Some(50)).unwrap().unwrap();
+        assert!(matches!(parse_resp(Some(37)), Err(Parse::TooLarge)));
+        assert!(matches!(parse_resp(Some(10)), Err(Parse::TooLarge)));
+    }
+
+    #[test]
     fn test_is_complete_fast() {
         let s = b"GET / HTTP/1.1\r\na: b\r\n\r\n";
         for n in 0..s.len() {
@@ -3014,6 +3106,7 @@ mod tests {
                 req_method: &mut None,
                 h1_parser_config: Default::default(),
                 h1_max_headers: None,
+                h1_max_header_size: None,
                 preserve_header_case: false,
                 #[cfg(feature = "ffi")]
                 preserve_header_order: false,
@@ -3097,6 +3190,7 @@ mod tests {
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
                     h1_max_headers: None,
+                    h1_max_header_size: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
                     preserve_header_order: false,
@@ -3142,6 +3236,7 @@ mod tests {
                     req_method: &mut None,
                     h1_parser_config: Default::default(),
                     h1_max_headers: None,
+                    h1_max_header_size: None,
                     preserve_header_case: false,
                     #[cfg(feature = "ffi")]
                     preserve_header_order: false,

--- a/src/server/conn/http1.rs
+++ b/src/server/conn/http1.rs
@@ -77,6 +77,7 @@ pub struct Builder {
     h1_title_case_headers: bool,
     h1_preserve_header_case: bool,
     h1_max_headers: Option<usize>,
+    h1_max_header_size: Option<usize>,
     h1_header_read_timeout: Dur,
     h1_writev: Option<bool>,
     max_buf_size: Option<usize>,
@@ -247,6 +248,7 @@ impl Builder {
             h1_title_case_headers: false,
             h1_preserve_header_case: false,
             h1_max_headers: None,
+            h1_max_header_size: None,
             h1_header_read_timeout: Dur::Default(Some(Duration::from_secs(30))),
             h1_writev: None,
             max_buf_size: None,
@@ -337,6 +339,17 @@ impl Builder {
     /// Default is 100.
     pub fn max_headers(&mut self, val: usize) -> &mut Self {
         self.h1_max_headers = Some(val);
+        self
+    }
+
+    /// Set the maximum size of request headers (including the start line) in bytes.
+    ///
+    /// If the client sends headers exceeding this limit, the server responds to the
+    /// client with "431 Request Header Fields Too Large" and closes the connection.
+    ///
+    /// Default is `None` (unbounded, or bounded by `max_buf_size`).
+    pub fn max_header_size(&mut self, val: usize) -> &mut Self {
+        self.h1_max_header_size = Some(val);
         self
     }
 
@@ -474,6 +487,9 @@ impl Builder {
         }
         if let Some(max_headers) = self.h1_max_headers {
             conn.set_http1_max_headers(max_headers);
+        }
+        if let Some(max_header_size) = self.h1_max_header_size {
+            conn.set_http1_max_header_size(max_header_size);
         }
         if let Some(dur) = self
             .timer

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2288,7 +2288,8 @@ mod conn {
             let mut sock = server.accept().unwrap().0;
             let mut buf = [0; 1024];
             sock.read(&mut buf).unwrap();
-            sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n").unwrap();
+            sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .unwrap();
         });
 
         let tcp = tcp_connect(&addr).await.unwrap();

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -2248,6 +2248,70 @@ mod conn {
     }
 
     #[tokio::test]
+    async fn client_max_header_size_exceeded() {
+        let (server, addr) = setup_std_test_server();
+
+        thread::spawn(move || {
+            let mut sock = server.accept().unwrap().0;
+            let mut buf = [0; 1024];
+            sock.read(&mut buf).unwrap();
+            sock.write_all(b"HTTP/1.1 200 OK\r\nX-Long: ").unwrap();
+            sock.write_all(&[b'a'; 1000]).unwrap();
+            sock.write_all(b"\r\n\r\n").unwrap();
+        });
+
+        let tcp = tcp_connect(&addr).await.unwrap();
+
+        let (mut client, conn) = conn::http1::Builder::new()
+            .max_header_size(512)
+            .handshake(tcp)
+            .await
+            .unwrap();
+
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+
+        let req = Request::builder()
+            .uri("/a")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let err = client.send_request(req).await.unwrap_err();
+        assert!(err.is_parse_too_large());
+    }
+
+    #[tokio::test]
+    async fn client_max_header_size_accepted() {
+        let (server, addr) = setup_std_test_server();
+
+        thread::spawn(move || {
+            let mut sock = server.accept().unwrap().0;
+            let mut buf = [0; 1024];
+            sock.read(&mut buf).unwrap();
+            sock.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n").unwrap();
+        });
+
+        let tcp = tcp_connect(&addr).await.unwrap();
+
+        let (mut client, conn) = conn::http1::Builder::new()
+            .max_header_size(512)
+            .handshake(tcp)
+            .await
+            .unwrap();
+
+        tokio::spawn(async move {
+            let _ = conn.await;
+        });
+
+        let req = Request::builder()
+            .uri("/a")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        let res = client.send_request(req).await.expect("send_request");
+        assert_eq!(res.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
     async fn client_on_informational_ext() {
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2786,6 +2786,90 @@ async fn max_buf_size_split_header_boundary() {
 
 #[cfg(feature = "http1")]
 #[tokio::test]
+async fn max_header_size_exceeded() {
+    let (listener, addr) = setup_tcp_listener();
+
+    const MAX_HEADER: usize = 512;
+
+    thread::spawn(move || {
+        let mut tcp = connect(&addr);
+        tcp.write_all(b"GET / HTTP/1.1\r\nHost: x\r\nX-Long: ").expect("write 1");
+        tcp.write_all(&[b'a'; 1000]).expect("write 2");
+        tcp.write_all(b"\r\n\r\n").expect("write 3");
+        let mut buf = [0; 256];
+        tcp.read(&mut buf).expect("read 1");
+
+        let expected = "HTTP/1.1 431 ";
+        assert_eq!(s(&buf[..expected.len()]), expected);
+    });
+
+    let (socket, _) = listener.accept().await.unwrap();
+    let socket = TokioIo::new(socket);
+    http1::Builder::new()
+        .max_header_size(MAX_HEADER)
+        .serve_connection(socket, HelloWorld)
+        .await
+        .expect_err("should TooLarge error");
+}
+
+#[cfg(feature = "http1")]
+#[tokio::test]
+async fn max_header_size_accepted() {
+    let (listener, addr) = setup_tcp_listener();
+
+    const MAX_HEADER: usize = 512;
+
+    thread::spawn(move || {
+        let mut tcp = connect(&addr);
+        tcp.write_all(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n").expect("write");
+        let mut buf = String::new();
+        tcp.read_to_string(&mut buf).expect("read");
+
+        let expected = "HTTP/1.1 200 ";
+        assert_eq!(&buf[..expected.len()], expected);
+    });
+
+    let (socket, _) = listener.accept().await.unwrap();
+    let socket = TokioIo::new(socket);
+    http1::Builder::new()
+        .max_header_size(MAX_HEADER)
+        .serve_connection(socket, HelloWorld)
+        .await
+        .expect("should succeed");
+}
+
+#[cfg(feature = "http1")]
+#[tokio::test]
+async fn max_header_size_with_large_max_buf_size() {
+    let (listener, addr) = setup_tcp_listener();
+
+    const MAX_HEADER: usize = 512;
+    const MAX_BUF: usize = 64 * 1024;
+
+    thread::spawn(move || {
+        let mut tcp = connect(&addr);
+        tcp.write_all(b"GET / HTTP/1.1\r\nHost: x\r\nX-Long: ").expect("write 1");
+        tcp.write_all(&[b'a'; 1000]).expect("write 2");
+        tcp.write_all(b"\r\n\r\n").expect("write 3");
+        let mut buf = [0; 256];
+        tcp.read(&mut buf).expect("read 1");
+
+        let expected = "HTTP/1.1 431 ";
+        assert_eq!(s(&buf[..expected.len()]), expected);
+    });
+
+    let (socket, _) = listener.accept().await.unwrap();
+    let socket = TokioIo::new(socket);
+    http1::Builder::new()
+        .max_buf_size(MAX_BUF)
+        .max_header_size(MAX_HEADER)
+        .serve_connection(socket, HelloWorld)
+        .await
+        .expect_err("should TooLarge error even with large max_buf_size");
+}
+
+#[cfg(feature = "http1")]
+#[tokio::test]
 async fn graceful_shutdown_before_first_request_no_block() {
     let (listener, addr) = setup_tcp_listener();
 

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2793,7 +2793,8 @@ async fn max_header_size_exceeded() {
 
     thread::spawn(move || {
         let mut tcp = connect(&addr);
-        tcp.write_all(b"GET / HTTP/1.1\r\nHost: x\r\nX-Long: ").expect("write 1");
+        tcp.write_all(b"GET / HTTP/1.1\r\nHost: x\r\nX-Long: ")
+            .expect("write 1");
         tcp.write_all(&[b'a'; 1000]).expect("write 2");
         tcp.write_all(b"\r\n\r\n").expect("write 3");
         let mut buf = [0; 256];
@@ -2821,7 +2822,8 @@ async fn max_header_size_accepted() {
 
     thread::spawn(move || {
         let mut tcp = connect(&addr);
-        tcp.write_all(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n").expect("write");
+        tcp.write_all(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n")
+            .expect("write");
         let mut buf = String::new();
         tcp.read_to_string(&mut buf).expect("read");
 
@@ -2848,7 +2850,8 @@ async fn max_header_size_with_large_max_buf_size() {
 
     thread::spawn(move || {
         let mut tcp = connect(&addr);
-        tcp.write_all(b"GET / HTTP/1.1\r\nHost: x\r\nX-Long: ").expect("write 1");
+        tcp.write_all(b"GET / HTTP/1.1\r\nHost: x\r\nX-Long: ")
+            .expect("write 1");
         tcp.write_all(&[b'a'; 1000]).expect("write 2");
         tcp.write_all(b"\r\n\r\n").expect("write 3");
         let mut buf = [0; 256];


### PR DESCRIPTION
## Motivation
Resolves #3832.

Currently, HTTP/1 header size limits can only be indirectly bounded using `max_buf_size`. However, setting `max_buf_size` also restricts the maximum single read buffer for streaming request or response bodies. Furthermore, there was an existing TODO in `proto/h1/conn.rs` noting that `h1_max_header_size` should be wired up to the chunked decoder for trailers.

This PR adds explicit `max_header_size(bytes)` configuration options to both `server::conn::http1::Builder` and `client::conn::http1::Builder`.

## Solution & Architecture
- **Server Builder (`server::conn::http1::Builder`)**:
  - Exposes `pub fn max_header_size(&mut self, val: usize) -> &mut Self`.
  - Configures the maximum total size of HTTP/1 request headers (request line + headers) in bytes.
  - When exceeded, the server responds with `431 Request Header Fields Too Large` (RFC 6585 §5) and closes the connection.
- **Client Builder (`client::conn::http1::Builder`)**:
  - Exposes `pub fn max_header_size(&mut self, val: usize) -> &mut Self`.
  - Configures the maximum total size of HTTP/1 response headers (status line + headers) in bytes.
  - When exceeded, the client returns an error where `error.is_parse_too_large() == true`.
- **Early Enforcement**:
  - Enforced in `io::Buffered::parse_headers` as bytes are read, preventing buffering unbounded amounts of header data.
  - Enforced in `Server::parse` / `Client::parse` against `parsed_len` to protect scenarios where a single read buffer already contains subsequent data.
- **Chunked Trailers**:
  - Replaced the pre-existing `// TODO: remove this when we land h1_max_header_size support` placeholder in `proto::h1::conn.rs` (`decode::Decoder::new`) with the configured `h1_max_header_size`.

## Verification
- Unit test in `src/proto/h1/role.rs`:
  - `test_h1_max_header_size`: Tests exact boundary conditions on both server and client parsers.
- Integration tests in `tests/server.rs`:
  - `max_header_size_exceeded`: Verifies server returns `431 Request Header Fields Too Large` when request header size exceeds limit.
  - `max_header_size_accepted`: Verifies server accepts requests when within limit.
  - `max_header_size_with_large_max_buf_size`: Verifies `max_header_size` enforcement is decoupled from and strictly enforced even when `max_buf_size` is large.
- Integration tests in `tests/client.rs`:
  - `client_max_header_size_exceeded`: Verifies client errors with `is_parse_too_large() == true`.
  - `client_max_header_size_accepted`: Verifies client successfully receives responses within limit.
- All test suites passing (`cargo test --lib --features full`, `cargo test --test server --features full`, `cargo test --test client --features full`).
