### PR TITLE
build(deps): remove unused `futures-channel` from `http1` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ full = [
 ]
 
 # HTTP versions
-http1 = ["dep:atomic-waker", "dep:futures-channel", "dep:futures-core", "dep:httparse", "dep:itoa"]
+http1 = ["dep:atomic-waker", "dep:futures-core", "dep:httparse", "dep:itoa"]
 http2 = ["dep:atomic-waker", "dep:futures-channel", "dep:futures-core", "dep:h2"]
 
 # Client/Server


### PR DESCRIPTION
Continue: https://github.com/hyperium/hyper/pull/4168

Remove unused `futures-channel` dependency of `http1` features post this PR: #4168 .

- [x] The description, docs, and comments (words meant for humans) are written by a human, not by an LLM. (https://seanmonstar.com/micro/20260729-i-want-your-own-words/)
