### PR TITLE
fix(ext): remove broken `OriginalHeaderOrder` doctest

### DIFF
--- a/src/ext/mod.rs
+++ b/src/ext/mod.rs
@@ -257,41 +257,6 @@ impl OriginalHeaderOrder {
     // here.
     /// This returns an iterator that provides header names and indexes
     /// in the original order received.
-    ///
-    /// # Examples
-    /// ```no_run
-    /// use hyper::ext::OriginalHeaderOrder;
-    /// use hyper::header::{HeaderName, HeaderValue, HeaderMap};
-    ///
-    /// let mut h_order = OriginalHeaderOrder::default();
-    /// let mut h_map = Headermap::new();
-    ///
-    /// let name1 = b"Set-CookiE";
-    /// let value1 = b"a=b";
-    /// h_map.append(name1);
-    /// h_order.append(name1);
-    ///
-    /// let name2 = b"Content-Encoding";
-    /// let value2 = b"gzip";
-    /// h_map.append(name2, value2);
-    /// h_order.append(name2);
-    ///
-    /// let name3 = b"SET-COOKIE";
-    /// let value3 = b"c=d";
-    /// h_map.append(name3, value3);
-    /// h_order.append(name3)
-    ///
-    /// let mut iter = h_order.get_in_order()
-    ///
-    /// let (name, idx) = iter.next();
-    /// assert_eq!(b"a=b", h_map.get_all(name).nth(idx).unwrap());
-    ///
-    /// let (name, idx) = iter.next();
-    /// assert_eq!(b"gzip", h_map.get_all(name).nth(idx).unwrap());
-    ///
-    /// let (name, idx) = iter.next();
-    /// assert_eq!(b"c=d", h_map.get_all(name).nth(idx).unwrap());
-    /// ```
     pub(crate) fn get_in_order(&self) -> impl Iterator<Item = &(HeaderName, usize)> {
         self.entry_order.iter()
     }


### PR DESCRIPTION
i stumbled across this while investigating a solution to #3914.

in #2798, a documentation test was introduced that appears to have been broken
since its inception. after spending some time figuring out how to run this
documentation test, i found the following errors:

```
; RUSTDOCFLAGS='--cfg hyper_unstable_ffi' RUSTFLAGS='--cfg hyper_unstable_ffi' cargo test --doc --features client,server,http1,http2,ffi get_in_order
   Compiling hyper v1.11.1 (/hyper)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.39s
   Doc-tests hyper

running 1 test
test src/ext/mod.rs - ext::OriginalHeaderOrder::get_in_order (line 262) - compile ... FAILED

failures:

---- src/ext/mod.rs - ext::OriginalHeaderOrder::get_in_order (line 262) stdout ----
error: expected item, found keyword `let`
   --> src/ext/mod.rs:266:1
    |
266 | let mut h_order = OriginalHeaderOrder::default();
    | ^^^ `let` cannot be used for global variables
    |
    = help: consider using `static` and a `Mutex` instead of `let mut`
    = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>

error: aborting due to 1 previous error

Couldn't compile the test.

failures:
    src/ext/mod.rs - ext::OriginalHeaderOrder::get_in_order (line 262)
```

after wrapping the code in the example in a `fn main() {}` block:

```
; RUSTDOCFLAGS='--cfg hyper_unstable_ffi' RUSTFLAGS='--cfg hyper_unstable_ffi' cargo test --doc --features client,server,http1,http2,ffi get_in_order
   Compiling hyper v1.11.1 (/hyper)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.37s
   Doc-tests hyper

running 1 test
test src/ext/mod.rs - ext::OriginalHeaderOrder::get_in_order (line 262) - compile ... FAILED

failures:

---- src/ext/mod.rs - ext::OriginalHeaderOrder::get_in_order (line 262) stdout ----
error: expected `;`, found keyword `let`
   --> src/ext/mod.rs:284:22
    |
284 | h_order.append(name3)
    |                      ^ help: add `;` here
285 |
286 | let mut iter = h_order.get_in_order()
    | --- unexpected token

error: expected `;`, found keyword `let`
   --> src/ext/mod.rs:286:38
    |
286 | let mut iter = h_order.get_in_order()
    |                                      ^ help: add `;` here
287 |
288 | let (name, idx) = iter.next();
    | --- unexpected token

error[E0603]: struct `OriginalHeaderOrder` is private
   --> src/ext/mod.rs:264:17
    |
264 | use hyper::ext::OriginalHeaderOrder;
    |                 ^^^^^^^^^^^^^^^^^^^ private struct
    |
note: the struct `OriginalHeaderOrder` is defined here
   --> src/ext/mod.rs:204:1
    |
204 | pub(crate) struct OriginalHeaderOrder {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0433]: cannot find type `Headermap` in this scope
   --> src/ext/mod.rs:269:17
    |
269 | let mut h_map = Headermap::new();
    |                 ^^^^^^^^^ use of undeclared type `Headermap`
    |
help: a struct with a similar name exists
    |
269 - let mut h_map = Headermap::new();
269 + let mut h_map = HeaderMap::new();
    |

error: aborting due to 4 previous errors

Some errors have detailed explanations: E0433, E0603.
For more information about an error, try `rustc --explain E0433`.
Couldn't compile the test.

failures:
    src/ext/mod.rs - ext::OriginalHeaderOrder::get_in_order (line 262)
```

after addressing these errors, i observed:

```
error[E0277]: the trait bound `&[u8; 10]: IntoHeaderName` is not satisfied
    --> src/ext/mod.rs:273:14
     |
 273 | h_map.append(name1);
     |       ------ ^^^^^ the trait `IntoHeaderName` is not implemented for `&[u8; 10]`
     |       |
     |       required by a bound introduced by this call
     |
help: the following other types implement trait `IntoHeaderName`
    --> /.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/http-1.3.1/src/header/map.rs:3690:5
     |
3690 |     impl IntoHeaderName for HeaderName {}
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `HeaderName`
...
3712 |     impl<'a> IntoHeaderName for &'a HeaderName {}
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'a HeaderName`
...
3734 |     impl IntoHeaderName for &'static str {}
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'static str`
note: required by a bound in `HeaderMap::<T>::append`
    --> /.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/http-1.3.1/src/header/map.rs:1373:12
     |
1371 |     pub fn append<K>(&mut self, key: K, value: T) -> bool
     |            ------ required by a bound in this associated function
1372 |     where
1373 |         K: IntoHeaderName,
     |            ^^^^^^^^^^^^^^ required by this bound in `HeaderMap::<T>::append`

error[E0061]: this method takes 2 arguments but 1 argument was supplied
    --> src/ext/mod.rs:273:7
     |
 273 | h_map.append(name1);
     |       ^^^^^^------- argument #2 of type `HeaderValue` is missing
     |
note: method defined here
    --> /.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/http-1.3.1/src/header/map.rs:1371:12
     |
1371 |     pub fn append<K>(&mut self, key: K, value: T) -> bool
     |            ^^^^^^
help: provide the argument
     |
 273 | h_map.append(name1, /* HeaderValue */);
     |                   +++++++++++++++++++
```

because these errors point to missing arguments and incorrect types, this
commit removes this example altogether. i'm not convinced it was ever run.

Signed-off-by: katelyn martin <git@katelyn.world>
