### PR TITLE
chore(ci): update to cargo-check-external-types 0.5.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -298,12 +298,12 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-10-18 # Compatible version for cargo-check-external-types
+          toolchain: nightly-2026-03-20 # Compatible version for cargo-check-external-types
 
       - name: Install cargo-check-external-types
         uses: taiki-e/cache-cargo-install-action@v2
         with:
-          tool: cargo-check-external-types@0.4.0
+          tool: cargo-check-external-types@0.5.0
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
Updates to `cargo-check-external-types` 0.5.0.

https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.5.0

- [x] The description, docs, and comments (words meant for humans) are written by a human, not by an LLM. (https://seanmonstar.com/micro/20260729-i-want-your-own-words/)
